### PR TITLE
Add trap mechanism to handle term signals. Fixes #28

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ If you think this is a project you could use in the future, please :star2: this 
 <td align="center"><a href="https://github.com/UbadahJ"><img src="https://avatars1.githubusercontent.com/u/26687928?s=460&u=ae1d3ae5fad6e4cfa71809f8ce4a99429321dcaf&v=4" width="100px;" alt=""/><br /><sub><b>LordChadiwala</b></sub></a></td>
 <td align="center"><a href="https://github.com/LuizDoPc"><img src="https://avatars0.githubusercontent.com/u/20651653?s=460&u=d673e5357da83e446311831efe107e695d3ef875&v=4" width="100px;" alt=""/><br /><sub><b>Luiz Soares</b></sub></a></td>
 <td align="center"><a href="https://github.com/sudiptog81"><img src="https://avatars0.githubusercontent.com/u/11232940?s=460&u=07b4989ae4c43e43f35730d7f8d59631f5ed933c&v=4" width="100px;" alt=""/><br /><sub><b>Sudipto Ghosh</b></sub></a></td>
+<td align="center"><a href="https://github.com/Fabricio20"><img src="https://avatars1.githubusercontent.com/u/7545720?s=400&v=4" width="100px;" alt=""/><br /><sub><b>Fabricio20</b></sub></a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ If you think this is a project you could use in the future, please :star2: this 
 <td align="center"><a href="https://github.com/arnxv0"><img src="https://avatars2.githubusercontent.com/u/57629464?s=460&u=5f0cca1aed9fabb38bea74df73ed99dfcfec2f26&v=4" width="100px;" alt=""/><br /><sub><b>Arnav Dewan</b></sub></a></td>
 <td align="center"><a href="https://github.com/NkxxkN"><img src="https://avatars1.githubusercontent.com/u/5072452?s=460&u=eda6b25b674d20e3389bf19a0619d6e4c1e46670&v=4" width="100px;" alt=""/><br /><sub><b>NkxxkN</b></sub></a></td>
   </tr>
+  <tr>
+<td align="center"><a href="https://github.com/UbadahJ"><img src="https://avatars1.githubusercontent.com/u/26687928?s=460&u=ae1d3ae5fad6e4cfa71809f8ce4a99429321dcaf&v=4" width="100px;" alt=""/><br /><sub><b>LordChadiwala</b></sub></a></td>
+  </tr>
 </table>
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ If you think this is a project you could use in the future, please :star2: this 
   <tr>
 <td align="center"><a href="https://github.com/UbadahJ"><img src="https://avatars1.githubusercontent.com/u/26687928?s=460&u=ae1d3ae5fad6e4cfa71809f8ce4a99429321dcaf&v=4" width="100px;" alt=""/><br /><sub><b>LordChadiwala</b></sub></a></td>
 <td align="center"><a href="https://github.com/LuizDoPc"><img src="https://avatars0.githubusercontent.com/u/20651653?s=460&u=d673e5357da83e446311831efe107e695d3ef875&v=4" width="100px;" alt=""/><br /><sub><b>Luiz Soares</b></sub></a></td>
+<td align="center"><a href="https://github.com/sudiptog81"><img src="https://avatars0.githubusercontent.com/u/11232940?s=460&u=07b4989ae4c43e43f35730d7f8d59631f5ed933c&v=4" width="100px;" alt=""/><br /><sub><b>Sudipto Ghosh</b></sub></a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -77,12 +77,9 @@ We also believe in the principle of least vendor lockin. Your having full contro
      treated as the same user).
 
 ### Documentation
-As of now, we only offer session management.
+The docs can be seen [on our website](https://supertokens.io/docs/community/getting-started/installation) along with an [implementation video](https://www.youtube.com/watch?v=kbC-QzxeZ4s&feature=emb_logo).
 
-The docs can be seen [here](https://supertokens.io/docs/community/getting-started/installation)
-
-A short [implementation video](https://www.youtube.com/watch?v=kbC-QzxeZ4s&feature=emb_logo)
-
+There is more information about SuperTokens on the [GitHub wiki section](https://github.com/supertokens/supertokens-core/wiki).
 
 ## Architecture
 Please find a writeup about this in the [wiki section](https://github.com/supertokens/supertokens-core/wiki/SuperTokens-Architecture)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ If you think this is a project you could use in the future, please :star2: this 
   </tr>
   <tr>
 <td align="center"><a href="https://github.com/UbadahJ"><img src="https://avatars1.githubusercontent.com/u/26687928?s=460&u=ae1d3ae5fad6e4cfa71809f8ce4a99429321dcaf&v=4" width="100px;" alt=""/><br /><sub><b>LordChadiwala</b></sub></a></td>
+<td align="center"><a href="https://github.com/LuizDoPc"><img src="https://avatars0.githubusercontent.com/u/20651653?s=460&u=d673e5357da83e446311831efe107e695d3ef875&v=4" width="100px;" alt=""/><br /><sub><b>Luiz Soares</b></sub></a></td>
   </tr>
 </table>
 

--- a/cli/src/main/java/io/supertokens/cli/commandHandler/install/InstallHandler.java
+++ b/cli/src/main/java/io/supertokens/cli/commandHandler/install/InstallHandler.java
@@ -142,11 +142,10 @@ public class InstallHandler extends CommandHandler {
         installationDir = Utils.normaliseDirectoryPath(new File(installationDir).getAbsolutePath());
         if (OperatingSystem.getOS() == OperatingSystem.OS.WINDOWS) {
             content += this.getResourceFileAsString("/install-windows.bat");
-            content = content.replace("$ST_INSTALL_LOC", installationDir);
         } else {
             content += this.getResourceFileAsString("/install-linux.sh");
-            content = content.replace("$ST_INSTALL_LOC", installationDir);
         }
+        content = content.replace("$ST_INSTALL_LOC", installationDir);
         File f = new File(location);
         if (!f.exists()) {
             boolean success = f.createNewFile();
@@ -171,9 +170,11 @@ public class InstallHandler extends CommandHandler {
      * @throws IOException if read fails for any reason
      */
     private String getResourceFileAsString(String fileName) throws IOException {
-        ClassLoader classLoader = ClassLoader.getSystemClassLoader();
-        try (InputStream is = classLoader.getResourceAsStream(fileName)) {
-            if (is == null) return null;
+        try (InputStream is = this.getClass().getResourceAsStream(fileName)) {
+            if (is == null) {
+                Logging.error("Failed to load resource named " + fileName);
+                return null;
+            }
             try (InputStreamReader isr = new InputStreamReader(is);
                  BufferedReader reader = new BufferedReader(isr)) {
                 return reader.lines().collect(Collectors.joining(System.lineSeparator()));

--- a/cli/src/main/resources/install-linux.sh
+++ b/cli/src/main/resources/install-linux.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+trap 'kill -TERM $PID' TERM INT
+
+ST_INSTALL_LOC=$ST_INSTALL_LOC
+
+"${ST_INSTALL_LOC}"jre/bin/java -classpath "${ST_INSTALL_LOC}cli/*" io.supertokens.cli.Main false "${ST_INSTALL_LOC}" $@ &
+PID=$!
+wait $PID
+if [ $? -eq 0 ] && [ "$#" -ne 0 ] && [ "$1" == update ]; then
+  "${ST_INSTALL_LOC}"/.update/supertokensExe update-complete --originalInstallDir="${ST_INSTALL_LOC}" &
+  PID=$!
+  wait $PID
+fi

--- a/cli/src/main/resources/install-linux.sh
+++ b/cli/src/main/resources/install-linux.sh
@@ -2,11 +2,12 @@
 
 ST_INSTALL_LOC=$ST_INSTALL_LOC
 
-if grep docker /proc/1/cgroup -qa; then
+if [ -f /proc/1/cgroup ] && grep docker /proc/1/cgroup -qa; then
   trap 'kill -TERM $PID' TERM INT
   "${ST_INSTALL_LOC}"jre/bin/java -classpath "${ST_INSTALL_LOC}cli/*" io.supertokens.cli.Main false "${ST_INSTALL_LOC}" $@ &
   PID=$!
   wait $PID
+  trap - TERM INT
 else
   "${ST_INSTALL_LOC}"jre/bin/java -classpath "${ST_INSTALL_LOC}cli/*" io.supertokens.cli.Main false "${ST_INSTALL_LOC}" $@
 fi

--- a/cli/src/main/resources/install-linux.sh
+++ b/cli/src/main/resources/install-linux.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-trap 'kill -TERM $PID' TERM INT
-
 ST_INSTALL_LOC=$ST_INSTALL_LOC
 
-"${ST_INSTALL_LOC}"jre/bin/java -classpath "${ST_INSTALL_LOC}cli/*" io.supertokens.cli.Main false "${ST_INSTALL_LOC}" $@ &
-PID=$!
-wait $PID
-if [ $? -eq 0 ] && [ "$#" -ne 0 ] && [ "$1" == update ]; then
-  "${ST_INSTALL_LOC}"/.update/supertokensExe update-complete --originalInstallDir="${ST_INSTALL_LOC}" &
+if grep docker /proc/1/cgroup -qa; then
+  trap 'kill -TERM $PID' TERM INT
+  "${ST_INSTALL_LOC}"jre/bin/java -classpath "${ST_INSTALL_LOC}cli/*" io.supertokens.cli.Main false "${ST_INSTALL_LOC}" $@ &
   PID=$!
   wait $PID
+else
+  "${ST_INSTALL_LOC}"jre/bin/java -classpath "${ST_INSTALL_LOC}cli/*" io.supertokens.cli.Main false "${ST_INSTALL_LOC}" $@
 fi

--- a/cli/src/main/resources/install-windows.bat
+++ b/cli/src/main/resources/install-windows.bat
@@ -1,0 +1,15 @@
+@echo off
+set st_install_loc=$ST_INSTALL_LOC
+"%st_install_loc%jre\bin"\java -classpath "%st_install_loc%cli\*" io.supertokens.cli.Main false "%st_install_loc%\" %*
+IF %errorlevel% NEQ 0 (
+echo exiting
+goto:eof
+)
+IF "%1" == "uninstall" (
+rmdir /S /Q "%st_install_loc%"
+del "%~f0"
+)
+IF "%1" == "update" (
+"%st_install_loc%.update"\supertokensExe.bat update-complete --originalInstallDir="%st_install_loc%\"
+)
+:eof


### PR DESCRIPTION
This commit adds a trap mechanism around the exec call to pass the signals received by bash to a child process.

Due to added complexity and for better legibility, I've opted to move the source for both scripts from java to a resource.

These changes are based on [sigterm propagation](http://veithen.io/2014/11/16/sigterm-propagation.html).

I was not able to test the changes in their full extent, due to compilation issues on this project, I did however successfully test the change by overriding via volume mounts in docker. Let me know if this breaks windows compatibility or doesn't work after a full build.