### PR TITLE
Fix typo in method name

### DIFF
--- a/src/main/java/io/supertokens/emailpassword/EmailPassword.java
+++ b/src/main/java/io/supertokens/emailpassword/EmailPassword.java
@@ -182,7 +182,7 @@ public class EmailPassword {
         }
     }
 
-    public static User getUserUsingUsingId(Main main, String userId) throws StorageQueryException {
+    public static User getUserUsingId(Main main, String userId) throws StorageQueryException {
         UserInfo info = StorageLayer.getEmailPasswordStorage(main).getUserInfoUsingId(userId);
         if (info == null) {
             return null;
@@ -190,7 +190,7 @@ public class EmailPassword {
         return new User(info.id, info.email);
     }
 
-    public static User getUserUsingUsingEmail(Main main, String email) throws StorageQueryException {
+    public static User getUserUsingEmail(Main main, String email) throws StorageQueryException {
         UserInfo info = StorageLayer.getEmailPasswordStorage(main).getUserInfoUsingEmail(email);
         if (info == null) {
             return null;

--- a/src/main/java/io/supertokens/webserver/api/emailpassword/UserAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/emailpassword/UserAPI.java
@@ -63,10 +63,10 @@ public class UserAPI extends WebserverAPI {
         try {
             User user = null;
             if (userId != null) {
-                user = EmailPassword.getUserUsingUsingId(main, userId);
+                user = EmailPassword.getUserUsingId(main, userId);
             } else {
                 String normalisedEmail = Utils.normaliseEmail(email);
-                user = EmailPassword.getUserUsingUsingEmail(main, normalisedEmail);
+                user = EmailPassword.getUserUsingEmail(main, normalisedEmail);
             }
 
             if (user == null) {


### PR DESCRIPTION
Replace getUserUsingUsingId() to getUserUsingId() and getUserUsingUsingEmail() to getUserUsingEmail()

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to SuperTokens here: https://github.com/supertokens/supertokens-core/blob/master/CONTRIBUTING.md

Happy contributing!

-->

## Link to a github issue if relevant

No issue

## Motivation

Was going through the code, then I notice typo

### Have you read the [Contributing Guidelines on pull requests](https://github.com/supertokens/supertokens-core/blob/master/CONTRIBUTING.md#pull-request)?

yes

## Test Plan

I only change the method name. And after that, I was able to create build successfully, So that's how I test it.
Test cases are no longer required, as it is a typo issue.

## Documentation changes

(If this PR adds or changes functionality, please take some time to point to the relevant documentation that we should update -  https://supertokens.io/docs/community/getting-started/installation)
