### PR TITLE
Add iss claim only if it is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.2] - 2021-11-15
-
-### Changes
-
-- JWT creation logic to add a `iss` claim only if none is provided
-
-## [3.6.1] - 2021-11-12
+## [3.6.1] - 2021-11-15
 
 ### Fixes
 
 - Issue with JWT expiry always being lower than expected
+
+### Changes
+
+- JWT creation logic to add a `iss` claim only if none is provided
 
 ## [3.6.0] - 2021-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.2] - 2021-11-15
+
+### Changes
+
+- JWT creation logic to add a `iss` claim only if none is provided
+
 ## [3.6.1] - 2021-11-12
 
 ### Fixes

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "3.6.1"
+version = "3.6.2"
 
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "3.6.2"
+version = "3.6.1"
 
 
 repositories {

--- a/src/main/java/io/supertokens/jwt/JWTSigningFunctions.java
+++ b/src/main/java/io/supertokens/jwt/JWTSigningFunctions.java
@@ -89,7 +89,7 @@ public class JWTSigningFunctions {
 
         // Add relevant claims to the payload, note we only add/override ones that we absolutely need to.
         Map<String, Object> jwtPayload = new Gson().fromJson(payload, HashMap.class);
-        jwtPayload.put("iss", jwksDomain);
+        jwtPayload.putIfAbsent("iss", jwksDomain);
         jwtPayload.put("exp", jwtExpiry);
         jwtPayload.put("iat", currentTimeInMillis / 1000); // JWT uses seconds from epoch not millis
 

--- a/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
+++ b/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
@@ -222,4 +222,33 @@ public class JWTCreateTest {
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
+
+    /**
+     * Test that final JWT uses custom iss claim instead of jwks domain
+     */
+    @Test
+    public void testThatDecodedJWTUsesCustomIssuer() throws Exception {
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String algorithm = "RS256";
+        JsonObject payload = new JsonObject();
+        payload.addProperty("iss", "http://customiss");
+
+        String jwksDomain = "http://localhost";
+        long validity = 3600;
+
+        String jwt = JWTSigningFunctions.createJWTToken(process.getProcess(), algorithm, payload, jwksDomain, validity);
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        String issuer = decodedJWT.getIssuer();
+
+        if (!issuer.equals("http://customiss")) {
+            throw new Exception("Decoded JWT does not contain 'iss' claim matching user defined value");
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }


### PR DESCRIPTION
## Summary of change
In the JWT recipe when creating a JWT the core would always add the apiDomain as the `iss` claim in the payload (overwriting any value that the user would send). This PR changes the logic to do that only if there is no value already provided for the `iss` claim.

## Related issues
NA

## Test Plan
- [x] Add a test to make sure that user defined `iss` values are used
- [x] Ensure existing tests pass

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
    - [ ] ~~If there are any db schema changes, mention those changes clearly~~
- [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
- [ ] ~~`pluginInterfaceSupported.json` file has been updated (if needed)~~
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [ ] ~~If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.~~
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [x] Update CHANGELOG and version
