### PR TITLE
writes errors to stderr from container

### DIFF
--- a/src/main/java/io/supertokens/output/Logging.java
+++ b/src/main/java/io/supertokens/output/Logging.java
@@ -186,6 +186,9 @@ public class Logging extends ResourceDistributor.SingletonResource {
         ConsoleAppender<ILoggingEvent> logConsoleAppender = new ConsoleAppender<>();
         logConsoleAppender.setEncoder(ple);
         logConsoleAppender.setContext(lc);
+        if (name.startsWith("io.supertokens.Error")) {
+            logConsoleAppender.setTarget("System.err");
+        }
         logConsoleAppender.start();
 
         Logger logger = (Logger) LoggerFactory.getLogger(name);

--- a/src/test/java/io/supertokens/test/LoggingTest.java
+++ b/src/test/java/io/supertokens/test/LoggingTest.java
@@ -171,7 +171,7 @@ public class LoggingTest {
     }
 
     @Test
-    public void testStandardOutLoggingWithNullStr() throws Exception {
+    public void testStdoutStderrWithNullStr() throws Exception {
         String[] args = { "../" };
         ByteArrayOutputStream stdOutput = new ByteArrayOutputStream();
         ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
@@ -192,7 +192,7 @@ public class LoggingTest {
             Logging.error(process.getProcess(), "errTest-sdvjovnoasid", false);
 
             assertTrue(fileContainsString(stdOutput, "outTest-dfkn3knsakn"));
-            assertTrue(fileContainsString(stdOutput, "errTest-sdvjovnoasid"));
+            assertTrue(fileContainsString(errorOutput, "errTest-sdvjovnoasid"));
 
         } finally {
             process.kill();
@@ -204,7 +204,7 @@ public class LoggingTest {
     }
 
     @Test
-    public void testStandardOutLoggingWithNull() throws Exception {
+    public void testStdoutStderrWithNull() throws Exception {
         String[] args = { "../" };
         ByteArrayOutputStream stdOutput = new ByteArrayOutputStream();
         ByteArrayOutputStream errorOutput = new ByteArrayOutputStream();
@@ -225,7 +225,7 @@ public class LoggingTest {
             Logging.error(process.getProcess(), "errTest-sdvjovnoasid", false);
 
             assertTrue(fileContainsString(stdOutput, "outTest-dfkn3knsakn"));
-            assertTrue(fileContainsString(stdOutput, "errTest-sdvjovnoasid"));
+            assertTrue(fileContainsString(errorOutput, "errTest-sdvjovnoasid"));
 
         } finally {
             process.kill();


### PR DESCRIPTION
## Summary of change
When running in a container without `$ERROR_LOG_PATH` specified, this change will now print errors to `stderr` (instead of being merged into `stdout`

## Related issues
- https://github.com/supertokens/supertokens-core/issues/5

## Test Plan
1. `docker run -p 3567:3567 supertokens 2> >(while read line; do echo -e "\e[01;31m$line\e[0m" >&2; done)`
2. `curl 'http://localhost:3567/users/count?includeRecipeIds=thirdparty,random'`
3. Confirm error is colored red

![image](https://user-images.githubusercontent.com/603829/150576562-62945d38-9ac2-41d6-9af7-8bb7133fadb7.png)

## Documentation changes
None

## Checklist for important updates
- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [X] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [X] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
None