### PR TITLE
refactor: closes ResultSet to avoid Memory Leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adding the `userId` to the reponse of `recipe/user/password/reset`
 - Adds support for providing base path for all APIs: https://github.com/supertokens/supertokens-node/issues/252
 - Add workflow to verify if pr title follows conventional commits
+- Closed ResultSet instances to avoid Memory Leaks
 ### New config param:
 
 - `base_path` - default is `""` (No base path)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adding the `userId` to the reponse of `recipe/user/password/reset`
 - Adds support for providing base path for all APIs: https://github.com/supertokens/supertokens-node/issues/252
 - Add workflow to verify if pr title follows conventional commits
-- Closed ResultSet instances to avoid Memory Leaks
+- Fixed ResultSet instances to avoid Memory Leaks
 ### New config param:
 
 - `base_path` - default is `""` (No base path)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Changes
+
+- Fixed ResultSet instances to avoid Memory Leaks
 
 ## [3.9.0] - 2022-01-31
 ### Changes
@@ -14,7 +17,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adding the `userId` to the reponse of `recipe/user/password/reset`
 - Adds support for providing base path for all APIs: https://github.com/supertokens/supertokens-node/issues/252
 - Add workflow to verify if pr title follows conventional commits
-- Fixed ResultSet instances to avoid Memory Leaks
+
 ### New config param:
 
 - `base_path` - default is `""` (No base path)

--- a/src/main/java/io/supertokens/inmemorydb/queries/EmailPasswordQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/EmailPasswordQueries.java
@@ -109,16 +109,17 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
-            ResultSet result = pst.executeQuery();
-            List<PasswordResetTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordResetTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -132,16 +133,17 @@ public class EmailPasswordQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
-            ResultSet result = pst.executeQuery();
-            List<PasswordResetTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordResetTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordResetTokenInfo[] finalResult = new PasswordResetTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -152,9 +154,10 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, token);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordResetTokenInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -288,9 +291,10 @@ public class EmailPasswordQueries {
                     // i+1 cause this starts with 1 and not 0
                     pst.setString(i + 1, ids.get(i));
                 }
-                ResultSet result = pst.executeQuery();
-                while (result.next()) {
-                    finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                try (ResultSet result = pst.executeQuery()) {
+                    while (result.next()) {
+                        finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                    }
                 }
             }
         }
@@ -306,9 +310,10 @@ public class EmailPasswordQueries {
                 + Config.getConfig(start).getEmailPasswordUsersTable() + " WHERE user_id = ?";
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, id);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -320,9 +325,10 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -337,16 +343,17 @@ public class EmailPasswordQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setInt(1, limit);
-            ResultSet result = pst.executeQuery();
-            List<UserInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<UserInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                UserInfo[] finalResult = new UserInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            UserInfo[] finalResult = new UserInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -364,16 +371,17 @@ public class EmailPasswordQueries {
             pst.setLong(2, timeJoined);
             pst.setString(3, userId);
             pst.setInt(4, limit);
-            ResultSet result = pst.executeQuery();
-            List<UserInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<UserInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                UserInfo[] finalResult = new UserInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            UserInfo[] finalResult = new UserInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -382,11 +390,12 @@ public class EmailPasswordQueries {
         String QUERY = "SELECT COUNT(*) as total FROM " + Config.getConfig(start).getEmailPasswordUsersTable();
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getLong("total");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getLong("total");
+                }
+                return 0;
             }
-            return 0;
         }
     }
 

--- a/src/main/java/io/supertokens/inmemorydb/queries/EmailVerificationQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/EmailVerificationQueries.java
@@ -105,9 +105,10 @@ public class EmailVerificationQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, token);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return EmailVerificationQueries.EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -139,16 +140,17 @@ public class EmailVerificationQueries {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
             pst.setString(2, email);
-            ResultSet result = pst.executeQuery();
-            List<EmailVerificationTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(EmailVerificationQueries.EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<EmailVerificationTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -161,16 +163,17 @@ public class EmailVerificationQueries {
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
             pst.setString(2, email);
-            ResultSet result = pst.executeQuery();
-            List<EmailVerificationTokenInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(EmailVerificationQueries.EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<EmailVerificationTokenInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(EmailVerificationTokenInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+                EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            EmailVerificationTokenInfo[] finalResult = new EmailVerificationTokenInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -183,9 +186,9 @@ public class EmailVerificationQueries {
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
             pst.setString(2, email);
-            ResultSet result = pst.executeQuery();
-
-            return result.next();
+            try (ResultSet result = pst.executeQuery()) {
+                return result.next();
+            }
         }
     }
 

--- a/src/main/java/io/supertokens/inmemorydb/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/GeneralQueries.java
@@ -267,9 +267,10 @@ public class GeneralQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, key);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -285,9 +286,10 @@ public class GeneralQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, key);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return KeyValueInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -327,11 +329,12 @@ public class GeneralQueries {
 
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY.toString())) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getLong("total");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getLong("total");
+                }
+                return 0;
             }
-            return 0;
         }
     }
 
@@ -357,7 +360,6 @@ public class GeneralQueries {
                 RECIPE_ID_CONDITION.append(")");
             }
 
-            ResultSet result;
             if (timeJoined != null && userId != null) {
                 String recipeIdCondition = RECIPE_ID_CONDITION.toString();
                 if (!recipeIdCondition.equals("")) {
@@ -374,10 +376,11 @@ public class GeneralQueries {
                     pst.setLong(2, timeJoined);
                     pst.setString(3, userId);
                     pst.setInt(4, limit);
-                    result = pst.executeQuery();
-                    while (result.next()) {
-                        usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
-                                result.getString("recipe_id")));
+                    try (ResultSet result = pst.executeQuery()) {
+                        while (result.next()) {
+                            usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
+                                    result.getString("recipe_id")));
+                        }
                     }
                 }
             } else {
@@ -390,10 +393,11 @@ public class GeneralQueries {
                 try (Connection con = ConnectionPool.getConnection(start);
                         PreparedStatement pst = con.prepareStatement(QUERY)) {
                     pst.setInt(1, limit);
-                    result = pst.executeQuery();
-                    while (result.next()) {
-                        usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
-                                result.getString("recipe_id")));
+                    try (ResultSet result = pst.executeQuery()) {
+                        while (result.next()) {
+                            usersFromQuery.add(new UserInfoPaginationResultHolder(result.getString("user_id"),
+                                    result.getString("recipe_id")));
+                        }
                     }
                 }
             }

--- a/src/main/java/io/supertokens/inmemorydb/queries/JWTSigningQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/JWTSigningQueries.java
@@ -57,14 +57,15 @@ public class JWTSigningQueries {
                 + " ORDER BY created_at DESC;";
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            List<JWTSigningKeyInfo> keys = new ArrayList<>();
+            try (ResultSet result = pst.executeQuery()) {
+                List<JWTSigningKeyInfo> keys = new ArrayList<>();
 
-            while (result.next()) {
-                keys.add(JWTSigningKeyInfoRowMapper.getInstance().mapOrThrow(result));
+                while (result.next()) {
+                    keys.add(JWTSigningKeyInfoRowMapper.getInstance().mapOrThrow(result));
+                }
+
+                return keys;
             }
-
-            return keys;
         }
     }
 

--- a/src/main/java/io/supertokens/inmemorydb/queries/PasswordlessQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/PasswordlessQueries.java
@@ -112,9 +112,10 @@ public class PasswordlessQueries {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, deviceIdHash);
 
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -166,9 +167,10 @@ public class PasswordlessQueries {
         List<String> deviceIdHashes = new ArrayList<>();
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, phoneNumber);
-            ResultSet result = pst.executeQuery();
-            while (result.next()) {
-                deviceIdHashes.add(result.getString("device_id_hash"));
+            try (ResultSet result = pst.executeQuery()) {
+                while (result.next()) {
+                    deviceIdHashes.add(result.getString("device_id_hash"));
+                }
             }
         }
         deleteRowsByDeviceIdHashList_Transaction(con, Config.getConfig(start).getPasswordlessCodesTable(),
@@ -191,9 +193,10 @@ public class PasswordlessQueries {
         List<String> deviceIdHashes = new ArrayList<>();
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            while (result.next()) {
-                deviceIdHashes.add(result.getString("device_id_hash"));
+            try (ResultSet result = pst.executeQuery()) {
+                while (result.next()) {
+                    deviceIdHashes.add(result.getString("device_id_hash"));
+                }
             }
         }
         deleteRowsByDeviceIdHashList_Transaction(con, Config.getConfig(start).getPasswordlessCodesTable(),
@@ -247,16 +250,17 @@ public class PasswordlessQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, deviceIdHash);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessCode> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessCode> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -269,9 +273,10 @@ public class PasswordlessQueries {
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, linkCodeHash);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -402,10 +407,10 @@ public class PasswordlessQueries {
                     + Config.getConfig(start).getPasswordlessDevicesTable() + " WHERE device_id_hash = ?";
             try (PreparedStatement pst = con.prepareStatement(QUERY)) {
                 pst.setString(1, deviceIdHash);
-                ResultSet result = pst.executeQuery();
-
-                if (result.next()) {
-                    return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+                try (ResultSet result = pst.executeQuery()) {
+                    if (result.next()) {
+                        return PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result);
+                    }
                 }
             }
             return null;
@@ -420,16 +425,17 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessDevice> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessDevice> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -441,16 +447,17 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, phoneNumber);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessDevice> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessDevice> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessDeviceRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessDevice[] finalResult = new PasswordlessDevice[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -469,16 +476,17 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setLong(1, time);
-            ResultSet result = pst.executeQuery();
-            List<PasswordlessCode> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<PasswordlessCode> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(PasswordlessCodeRowMapper.getInstance().mapOrThrow(result));
+                }
+                PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            PasswordlessCode[] finalResult = new PasswordlessCode[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -489,9 +497,10 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, codeId);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return PasswordlessCodeRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -528,9 +537,10 @@ public class PasswordlessQueries {
                     // i+1 cause this starts with 1 and not 0
                     pst.setString(i + 1, ids.get(i));
                 }
-                ResultSet result = pst.executeQuery();
-                while (result.next()) {
-                    finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                try (ResultSet result = pst.executeQuery()) {
+                    while (result.next()) {
+                        finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                    }
                 }
             }
         }
@@ -555,9 +565,10 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, email);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -571,10 +582,10 @@ public class PasswordlessQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, phoneNumber);
-            ResultSet result = pst.executeQuery();
-
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;

--- a/src/main/java/io/supertokens/inmemorydb/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/SessionQueries.java
@@ -79,9 +79,10 @@ public class SessionQueries {
                 + " WHERE session_handle = ?";
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, sessionHandle);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -105,11 +106,12 @@ public class SessionQueries {
 
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getInt("num");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getInt("num");
+                }
+                throw new SQLException("Should not have come here.");
             }
-            throw new SQLException("Should not have come here.");
         }
     }
 
@@ -153,16 +155,17 @@ public class SessionQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, userId);
-            ResultSet result = pst.executeQuery();
-            List<String> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(result.getString("session_handle"));
+            try (ResultSet result = pst.executeQuery()) {
+                List<String> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(result.getString("session_handle"));
+                }
+                String[] finalResult = new String[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            String[] finalResult = new String[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 
@@ -183,9 +186,10 @@ public class SessionQueries {
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, sessionHandle);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return SessionInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -245,16 +249,17 @@ public class SessionQueries {
         String QUERY = "SELECT * FROM " + accessTokenSigningKeysTableName;
 
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            List<KeyValueInfo> temp = new ArrayList<>();
-            while (result.next()) {
-                temp.add(AccessTokenSigningKeyRowMapper.getInstance().mapOrThrow(result));
+            try (ResultSet result = pst.executeQuery()) {
+                List<KeyValueInfo> temp = new ArrayList<>();
+                while (result.next()) {
+                    temp.add(AccessTokenSigningKeyRowMapper.getInstance().mapOrThrow(result));
+                }
+                KeyValueInfo[] finalResult = new KeyValueInfo[temp.size()];
+                for (int i = 0; i < temp.size(); i++) {
+                    finalResult[i] = temp.get(i);
+                }
+                return finalResult;
             }
-            KeyValueInfo[] finalResult = new KeyValueInfo[temp.size()];
-            for (int i = 0; i < temp.size(); i++) {
-                finalResult[i] = temp.get(i);
-            }
-            return finalResult;
         }
     }
 

--- a/src/main/java/io/supertokens/inmemorydb/queries/ThirdPartyQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/ThirdPartyQueries.java
@@ -146,9 +146,10 @@ public class ThirdPartyQueries {
                     // i+1 cause this starts with 1 and not 0
                     pst.setString(i + 1, ids.get(i));
                 }
-                ResultSet result = pst.executeQuery();
-                while (result.next()) {
-                    finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                try (ResultSet result = pst.executeQuery()) {
+                    while (result.next()) {
+                        finalResult.add(UserInfoRowMapper.getInstance().mapOrThrow(result));
+                    }
                 }
             }
         }
@@ -165,9 +166,10 @@ public class ThirdPartyQueries {
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, thirdPartyId);
             pst.setString(2, thirdPartyUserId);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -198,9 +200,10 @@ public class ThirdPartyQueries {
         try (PreparedStatement pst = con.prepareStatement(QUERY)) {
             pst.setString(1, thirdPartyId);
             pst.setString(2, thirdPartyUserId);
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return UserInfoRowMapper.getInstance().mapOrThrow(result);
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return UserInfoRowMapper.getInstance().mapOrThrow(result);
+                }
             }
         }
         return null;
@@ -268,11 +271,12 @@ public class ThirdPartyQueries {
         String QUERY = "SELECT COUNT(*) as total FROM " + Config.getConfig(start).getThirdPartyUsersTable();
         try (Connection con = ConnectionPool.getConnection(start);
                 PreparedStatement pst = con.prepareStatement(QUERY)) {
-            ResultSet result = pst.executeQuery();
-            if (result.next()) {
-                return result.getLong("total");
+            try (ResultSet result = pst.executeQuery()) {
+                if (result.next()) {
+                    return result.getLong("total");
+                }
+                return 0;
             }
-            return 0;
         }
     }
 


### PR DESCRIPTION
## Summary of change
Closes The ResultSet object by wrapping then in a try-with-resources block

## Related issues
- #361

## Test Plan
NA

## Documentation changes
NA

## Checklist for important updates
- [x] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
