### PR TITLE
Test optimisation to reuse storage layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+- Fixes memory leak during testing.
 
 ## [3.10.0] - 2022-02-23
 

--- a/cli/src/main/java/io/supertokens/cli/Main.java
+++ b/cli/src/main/java/io/supertokens/cli/Main.java
@@ -41,7 +41,7 @@ public class Main {
     public static int exitCode = 0;
 
     private static Thread shutdownHook;
-    private static Thread mainThread = Thread.currentThread();;
+    private static Thread mainThread = Thread.currentThread();
     private static boolean doNotWaitInShutdownHook = false;
 
     public static void main(String[] args) {

--- a/cli/src/main/java/io/supertokens/cli/Main.java
+++ b/cli/src/main/java/io/supertokens/cli/Main.java
@@ -41,7 +41,7 @@ public class Main {
     public static int exitCode = 0;
 
     private static Thread shutdownHook;
-    private static Thread mainThread;
+    private static Thread mainThread = Thread.currentThread();;
     private static boolean doNotWaitInShutdownHook = false;
 
     public static void main(String[] args) {
@@ -72,7 +72,6 @@ public class Main {
     // args: true [--path <path location>] --> via installer is true
     // args: false <installation path> <command> <...command args>
     private static void start(String[] args) {
-        mainThread = Thread.currentThread();
         boolean viaInstaller = Boolean.parseBoolean(args[0]);
         String installationDir;
         String command;

--- a/cli/src/main/java/io/supertokens/cli/Main.java
+++ b/cli/src/main/java/io/supertokens/cli/Main.java
@@ -41,7 +41,7 @@ public class Main {
     public static int exitCode = 0;
 
     private static Thread shutdownHook;
-    private static Thread mainThread = Thread.currentThread();
+    private static Thread mainThread;
     private static boolean doNotWaitInShutdownHook = false;
 
     public static void main(String[] args) {
@@ -72,6 +72,7 @@ public class Main {
     // args: true [--path <path location>] --> via installer is true
     // args: false <installation path> <command> <...command args>
     private static void start(String[] args) {
+        mainThread = Thread.currentThread();
         boolean viaInstaller = Boolean.parseBoolean(args[0]);
         String installationDir;
         String command;

--- a/src/main/java/io/supertokens/output/CustomLayout.java
+++ b/src/main/java/io/supertokens/output/CustomLayout.java
@@ -27,11 +27,11 @@ import java.util.Date;
 
 class CustomLayout extends LayoutBase<ILoggingEvent> {
 
-    private final Main main;
+    private String processID;
 
-    CustomLayout(Main main) {
+    CustomLayout(String processID) {
         super();
-        this.main = main;
+        this.processID = processID;
     }
 
     @Override
@@ -46,7 +46,7 @@ class CustomLayout extends LayoutBase<ILoggingEvent> {
         sbuf.append(" | ");
 
         sbuf.append("pid: ");
-        sbuf.append(main.getProcessId());
+        sbuf.append(this.processID);
         sbuf.append(" | ");
 
         sbuf.append("[");

--- a/src/main/java/io/supertokens/output/LayoutWrappingEncoder.java
+++ b/src/main/java/io/supertokens/output/LayoutWrappingEncoder.java
@@ -27,8 +27,8 @@ class LayoutWrappingEncoder extends EncoderBase<ILoggingEvent> {
 
     private Layout<ILoggingEvent> layout;
 
-    LayoutWrappingEncoder(Main main) {
-        layout = new CustomLayout(main);
+    LayoutWrappingEncoder(String processID) {
+        layout = new CustomLayout(processID);
     }
 
     @Override

--- a/src/main/java/io/supertokens/output/Logging.java
+++ b/src/main/java/io/supertokens/output/Logging.java
@@ -162,7 +162,7 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logger createLoggerForFile(Main main, String file, String name) {
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(main);
+        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(main.getProcessId());
         ple.setContext(lc);
         ple.start();
         FileAppender<ILoggingEvent> fileAppender = new FileAppender<>();
@@ -180,7 +180,7 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logger createLoggerForConsole(Main main, String name) {
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(main);
+        LayoutWrappingEncoder ple = new LayoutWrappingEncoder(main.getProcessId());
         ple.setContext(lc);
         ple.start();
         ConsoleAppender<ILoggingEvent> logConsoleAppender = new ConsoleAppender<>();

--- a/src/main/java/io/supertokens/output/Logging.java
+++ b/src/main/java/io/supertokens/output/Logging.java
@@ -38,13 +38,11 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logging(Main main) {
         this.infoLogger = Config.getConfig(main).getInfoLogPath(main).equals("null")
-                ? createLoggerForConsole(main, "io.supertokens.Info." + main.getProcessId())
-                : createLoggerForFile(main, Config.getConfig(main).getInfoLogPath(main),
-                        "io.supertokens.Info." + main.getProcessId());
+                ? createLoggerForConsole(main, "io.supertokens.Info")
+                : createLoggerForFile(main, Config.getConfig(main).getInfoLogPath(main), "io.supertokens.Info");
         this.errorLogger = Config.getConfig(main).getErrorLogPath(main).equals("null")
-                ? createLoggerForConsole(main, "io.supertokens.Error." + main.getProcessId())
-                : createLoggerForFile(main, Config.getConfig(main).getErrorLogPath(main),
-                        "io.supertokens.Error." + main.getProcessId());
+                ? createLoggerForConsole(main, "io.supertokens.Error")
+                : createLoggerForFile(main, Config.getConfig(main).getErrorLogPath(main), "io.supertokens.Error");
         Storage storage = StorageLayer.getStorage(main);
         if (storage != null) {
             storage.initFileLogging(Config.getConfig(main).getInfoLogPath(main),

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -31,6 +31,7 @@ import io.supertokens.pluginInterface.jwt.JWTRecipeStorage;
 import io.supertokens.pluginInterface.passwordless.sqlStorage.PasswordlessSQLStorage;
 import io.supertokens.pluginInterface.session.SessionStorage;
 import io.supertokens.pluginInterface.thirdparty.sqlStorage.ThirdPartySQLStorage;
+import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -43,45 +44,76 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
 
     private static final String RESOURCE_KEY = "io.supertokens.storageLayer.StorageLayer";
     private final Storage storage;
+    private static Storage static_ref_to_storage = null;
 
     private StorageLayer(Main main, String pluginFolderPath, String configFilePath) throws MalformedURLException {
         Logging.info(main, "Loading storage layer.");
-        File loc = new File(pluginFolderPath);
-        Storage storageLayerTemp = null;
+        if (static_ref_to_storage != null && Main.isTesting) {
+            // we reuse the storage layer during testing so that we do not waste
+            // time reconnecting to the db.
+            this.storage = StorageLayer.static_ref_to_storage;
+        } else {
+            File loc = new File(pluginFolderPath);
+            Storage storageLayerTemp = null;
 
-        File[] flist = loc.listFiles(file -> file.getPath().toLowerCase().endsWith(".jar"));
+            File[] flist = loc.listFiles(file -> file.getPath().toLowerCase().endsWith(".jar"));
 
-        if (flist != null) {
-            URL[] urls = new URL[flist.length];
-            for (int i = 0; i < flist.length; i++) {
-                urls[i] = flist[i].toURI().toURL();
-            }
-            URLClassLoader ucl = new URLClassLoader(urls);
+            if (flist != null) {
+                URL[] urls = new URL[flist.length];
+                for (int i = 0; i < flist.length; i++) {
+                    urls[i] = flist[i].toURI().toURL();
+                }
+                URLClassLoader ucl = new URLClassLoader(urls);
 
-            ServiceLoader<Storage> sl = ServiceLoader.load(Storage.class, ucl);
-            Iterator<Storage> it = sl.iterator();
-            while (it.hasNext()) {
-                Storage plugin = it.next();
-                if (storageLayerTemp == null) {
-                    storageLayerTemp = plugin;
-                } else {
-                    throw new QuitProgramException(
-                            "Multiple database plugins found. Please make sure that just one plugin is in the /plugin"
-                                    + " " + "folder of the installation. Alternatively, please redownload and install "
-                                    + "SuperTokens" + ".");
+                ServiceLoader<Storage> sl = ServiceLoader.load(Storage.class, ucl);
+                Iterator<Storage> it = sl.iterator();
+                while (it.hasNext()) {
+                    Storage plugin = it.next();
+                    if (storageLayerTemp == null) {
+                        storageLayerTemp = plugin;
+                    } else {
+                        throw new QuitProgramException(
+                                "Multiple database plugins found. Please make sure that just one plugin is in the /plugin"
+                                        + " "
+                                        + "folder of the installation. Alternatively, please redownload and install "
+                                        + "SuperTokens" + ".");
+                    }
                 }
             }
-        }
 
-        if (storageLayerTemp != null && !main.isForceInMemoryDB()
-                && (storageLayerTemp.canBeUsed(configFilePath) || CLIOptions.get(main).isForceNoInMemoryDB())) {
-            this.storage = storageLayerTemp;
-        } else {
-            Logging.info(main, "Using in memory storage.");
-            this.storage = new Start(main);
+            if (storageLayerTemp != null && !main.isForceInMemoryDB()
+                    && (storageLayerTemp.canBeUsed(configFilePath) || CLIOptions.get(main).isForceNoInMemoryDB())) {
+                this.storage = storageLayerTemp;
+            } else {
+                Logging.info(main, "Using in memory storage.");
+                this.storage = new Start(main);
+            }
         }
         this.storage.constructor(main.getProcessId(), Main.makeConsolePrintSilent);
         this.storage.loadConfig(configFilePath);
+        if (Main.isTesting) {
+            // we save the storage layer for testing purposes so that
+            // next time, we can just reuse this.
+            // StorageLayer.static_ref_to_storage is set to null by the testing framework in case
+            // something in the config or CLI args change.
+            StorageLayer.static_ref_to_storage = this.storage;
+        }
+    }
+
+    public static void close(Main main) {
+        if (getInstance(main) == null) {
+            return;
+        }
+        getInstance(main).storage.close();
+        StorageLayer.static_ref_to_storage = null;
+    }
+
+    @TestOnly
+    public static void close() {
+        if (StorageLayer.static_ref_to_storage != null) {
+            StorageLayer.static_ref_to_storage.close();
+        }
+        StorageLayer.static_ref_to_storage = null;
     }
 
     public static StorageLayer getInstance(Main main) {

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -34,6 +34,7 @@ import io.supertokens.pluginInterface.thirdparty.sqlStorage.ThirdPartySQLStorage
 import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -45,6 +46,7 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
     private static final String RESOURCE_KEY = "io.supertokens.storageLayer.StorageLayer";
     private final Storage storage;
     private static Storage static_ref_to_storage = null;
+    private static URLClassLoader ucl = null;
 
     private StorageLayer(Main main, String pluginFolderPath, String configFilePath) throws MalformedURLException {
         Logging.info(main, "Loading storage layer.");
@@ -63,7 +65,13 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
                 for (int i = 0; i < flist.length; i++) {
                     urls[i] = flist[i].toURI().toURL();
                 }
-                URLClassLoader ucl = new URLClassLoader(urls);
+                if (StorageLayer.ucl == null) {
+                    // we have this as a static variable because
+                    // in prod, this is loaded just once anyway.
+                    // During testing, we just want to load the jars
+                    // once too cause the JARs don't change across tests either.
+                    StorageLayer.ucl = new URLClassLoader(urls);
+                }
 
                 ServiceLoader<Storage> sl = ServiceLoader.load(Storage.class, ucl);
                 Iterator<Storage> it = sl.iterator();

--- a/src/test/java/io/supertokens/test/APIKeysTest.java
+++ b/src/test/java/io/supertokens/test/APIKeysTest.java
@@ -68,7 +68,6 @@ public class APIKeysTest {
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
-
     }
 
     // * - don't set API key and check that config.getAPIKeys() returns null

--- a/src/test/java/io/supertokens/test/AuthRecipeTest.java
+++ b/src/test/java/io/supertokens/test/AuthRecipeTest.java
@@ -456,7 +456,7 @@ public class AuthRecipeTest {
         // we create multiple users in parallel...
         List<AuthRecipeUserInfo> usersCreated = new ArrayList<>();
 
-        ExecutorService es = Executors.newCachedThreadPool();
+        ExecutorService es = Executors.newFixedThreadPool(500);
         for (int i = 0; i < numberOfUsers; i++) {
             if (Math.random() > 0.5) {
                 while (true) {

--- a/src/test/java/io/supertokens/test/InMemoryDBTest.java
+++ b/src/test/java/io/supertokens/test/InMemoryDBTest.java
@@ -81,7 +81,7 @@ public class InMemoryDBTest {
         process.startProcess();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 
-        ExecutorService es = Executors.newCachedThreadPool();
+        ExecutorService es = Executors.newFixedThreadPool(500);
 
         AtomicBoolean pass = new AtomicBoolean(true);
 

--- a/src/test/java/io/supertokens/test/LoggingTest.java
+++ b/src/test/java/io/supertokens/test/LoggingTest.java
@@ -153,10 +153,8 @@ public class LoggingTest {
 
         assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STARTED));
 
-        Logger comInfoLog = (Logger) LoggerFactory
-                .getLogger("io.supertokens.Info." + process.getProcess().getProcessId());
-        Logger comErrorLog = (Logger) LoggerFactory
-                .getLogger("io.supertokens.Error." + process.getProcess().getProcessId());
+        Logger comInfoLog = (Logger) LoggerFactory.getLogger("io.supertokens.Info");
+        Logger comErrorLog = (Logger) LoggerFactory.getLogger("io.supertokens.Error");
 
         java.util.logging.Logger webLogger = java.util.logging.Logger.getLogger("org.apache");
 

--- a/src/test/java/io/supertokens/test/StorageTest.java
+++ b/src/test/java/io/supertokens/test/StorageTest.java
@@ -250,7 +250,8 @@ public class StorageTest {
                 t2.join();
 
                 assertEquals(endValueOfCon1.get(), endValueOfCon2.get());
-                if (Version.getVersion(process.getProcess()).getPluginName().equals("postgresql")) {
+                if (Version.getVersion(process.getProcess()).getPluginName().equals("postgresql")
+                        || Version.getVersion(process.getProcess()).getPluginName().equals("sql")) {
                     // Becasue FOR UPDATE does not wait in Postgresql. Instead if throws an error.
                     assert (numberOfIterations.get() == 1 || numberOfIterations.get() == 0);
                 } else {

--- a/src/test/java/io/supertokens/test/Utils.java
+++ b/src/test/java/io/supertokens/test/Utils.java
@@ -131,6 +131,7 @@ public abstract class Utils extends Mockito {
         } catch (Exception e) {
             e.printStackTrace();
         }
+        System.gc();
     }
 
     static void commentConfigValue(String key) throws IOException {

--- a/src/test/java/io/supertokens/test/Utils.java
+++ b/src/test/java/io/supertokens/test/Utils.java
@@ -19,6 +19,7 @@ package io.supertokens.test;
 import com.google.gson.JsonObject;
 import io.supertokens.Main;
 import io.supertokens.pluginInterface.PluginInterfaceTesting;
+import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.webserver.WebserverAPI;
@@ -30,6 +31,8 @@ import org.mockito.Mockito;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
 
 public abstract class Utils extends Mockito {
 
@@ -99,6 +102,17 @@ public abstract class Utils extends Mockito {
         String installDir = "../";
         try {
 
+            // if the default config is not the same as the current config, we must reset the storage layer
+            File ogConfig = new File("../temp/config.yaml");
+            File currentConfig = new File("../config.yaml");
+            if (currentConfig.isFile()) {
+                byte[] ogConfigContent = Files.readAllBytes(ogConfig.toPath());
+                byte[] currentConfigContent = Files.readAllBytes(currentConfig.toPath());
+                if (!Arrays.equals(ogConfigContent, currentConfigContent)) {
+                    StorageLayer.close();
+                }
+            }
+
             ProcessBuilder pb = new ProcessBuilder("cp", "temp/config.yaml", "./config.yaml");
             pb.directory(new File(installDir));
             Process process = pb.start();
@@ -120,6 +134,9 @@ public abstract class Utils extends Mockito {
     }
 
     static void commentConfigValue(String key) throws IOException {
+        // we close the storage layer since there might be a change in the db related config.
+        StorageLayer.close();
+
         String oldStr = "((#\\s)?)" + key + "(:|((:\\s).+))\n";
         String newStr = "# " + key + ":";
 
@@ -139,6 +156,9 @@ public abstract class Utils extends Mockito {
     }
 
     public static void setValueInConfig(String key, String value) throws IOException {
+        // we close the storage layer since there might be a change in the db related config.
+        StorageLayer.close();
+
         String oldStr = "((#\\s)?)" + key + "(:|((:\\s).+))\n";
         String newStr = key + ": " + value + "\n";
         StringBuilder originalFileContent = new StringBuilder();

--- a/src/test/java/io/supertokens/test/session/AccessTokenTest.java
+++ b/src/test/java/io/supertokens/test/session/AccessTokenTest.java
@@ -337,7 +337,7 @@ public class AccessTokenTest {
 
         Thread.sleep(3500);
 
-        ExecutorService es = Executors.newCachedThreadPool();
+        ExecutorService es = Executors.newFixedThreadPool(1000);
 
         AtomicBoolean hasNullPointerException = new AtomicBoolean(false);
 


### PR DESCRIPTION
## Summary of change
We do not destroy the storage layer between tests unless required. This speeds up each test run.

## Remaining TODOs for this PR
- [x] We are still getting issues of read timeout errors
- [x] If certain test fails, all tests after those fail too
- [x] Manually test if connection retries in case of initial connection failures still happen
- [x] LayoutWrappingEncoder memory leak issue

```
13 Mar 2022 03:47:04:312 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-5] thread | io.supertokens.storage.sql.HibernateLoggingAppender.doAppend(HibernateLoggingAppender.java:132) | HikariDataSource HikariDataSource (SuperTokens) has been closed.

13 Mar 2022 03:47:04:313 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-4] thread | io.supertokens.storage.sql.HibernateLoggingAppender.doAppend(HibernateLoggingAppender.java:132) | HikariDataSource HikariDataSource (SuperTokens) has been closed.

13 Mar 2022 03:47:04:315 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-3] thread | io.supertokens.storage.sql.HibernateLoggingAppender.doAppend(HibernateLoggingAppender.java:132) | HikariDataSource HikariDataSource (SuperTokens) has been closed.

13 Mar 2022 03:47:04:320 +0530 | WARN | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-1] thread | io.supertokens.storage.sql.HibernateLoggingAppender.doAppend(HibernateLoggingAppender.java:134) | SQL Error: 0, SQLState: null

13 Mar 2022 03:47:04:322 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-1] thread | io.supertokens.storage.sql.HibernateLoggingAppender.doAppend(HibernateLoggingAppender.java:132) | HikariDataSource HikariDataSource (SuperTokens) has been closed.

13 Mar 2022 03:47:04:399 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-3] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:42)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:111)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:138)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getConnectionForTransactionManagement(LogicalConnectionManagedImpl.java:276)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.begin(LogicalConnectionManagedImpl.java:284)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.begin(JdbcResourceLocalTransactionCoordinatorImpl.java:246)
	at org.hibernate.engine.transaction.internal.TransactionImpl.begin(TransactionImpl.java:83)
	at org.hibernate.internal.AbstractSharedSessionContract.beginTransaction(AbstractSharedSessionContract.java:503)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:275)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.EmailVerificationQueries.deleteExpiredEmailVerificationTokens(EmailVerificationQueries.java:75)
	at io.supertokens.storage.sql.Start.deleteExpiredEmailVerificationTokens(Start.java:705)
	at io.supertokens.cronjobs.deleteExpiredEmailVerificationTokens.DeleteExpiredEmailVerificationTokens.doTask(DeleteExpiredEmailVerificationTokens.java:49)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (SuperTokens) has been closed.
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:122)
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:38)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:108)
	... 19 more

13 Mar 2022 03:47:04:399 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-4] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:42)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:111)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:138)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getConnectionForTransactionManagement(LogicalConnectionManagedImpl.java:276)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.begin(LogicalConnectionManagedImpl.java:284)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.begin(JdbcResourceLocalTransactionCoordinatorImpl.java:246)
	at org.hibernate.engine.transaction.internal.TransactionImpl.begin(TransactionImpl.java:83)
	at org.hibernate.internal.AbstractSharedSessionContract.beginTransaction(AbstractSharedSessionContract.java:503)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:275)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.queries.PasswordlessQueries.getCodesBefore(PasswordlessQueries.java:395)
	at io.supertokens.storage.sql.Start.getCodesBefore(Start.java:1348)
	at io.supertokens.cronjobs.deleteExpiredPasswordlessDevices.DeleteExpiredPasswordlessDevices.doTask(DeleteExpiredPasswordlessDevices.java:61)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (SuperTokens) has been closed.
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:122)
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:38)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:108)
	... 19 more

13 Mar 2022 03:47:04:400 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-3] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: RemoveOldEmailVerificationTokens

13 Mar 2022 03:47:04:399 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-5] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:42)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:111)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:138)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getConnectionForTransactionManagement(LogicalConnectionManagedImpl.java:276)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.begin(LogicalConnectionManagedImpl.java:284)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.begin(JdbcResourceLocalTransactionCoordinatorImpl.java:246)
	at org.hibernate.engine.transaction.internal.TransactionImpl.begin(TransactionImpl.java:83)
	at org.hibernate.internal.AbstractSharedSessionContract.beginTransaction(AbstractSharedSessionContract.java:503)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:275)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.queries.GeneralQueries.getKeyValue(GeneralQueries.java:258)
	at io.supertokens.storage.sql.Start.getKeyValue(Start.java:422)
	at io.supertokens.cronjobs.telemetry.Telemetry.doTask(Telemetry.java:68)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (SuperTokens) has been closed.
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:122)
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:38)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:108)
	... 19 more

13 Mar 2022 03:47:04:400 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-4] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: DeleteExpiredPasswordlessDevices

13 Mar 2022 03:47:04:400 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-5] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: Telemetry

13 Mar 2022 03:47:04:400 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-1] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | org.hibernate.exception.GenericJDBCException: Unable to acquire JDBC Connection
	at org.hibernate.exception.internal.StandardSQLExceptionConverter.convert(StandardSQLExceptionConverter.java:42)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:113)
	at org.hibernate.engine.jdbc.spi.SqlExceptionHelper.convert(SqlExceptionHelper.java:99)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:111)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getPhysicalConnection(LogicalConnectionManagedImpl.java:138)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.getConnectionForTransactionManagement(LogicalConnectionManagedImpl.java:276)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.begin(LogicalConnectionManagedImpl.java:284)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.begin(JdbcResourceLocalTransactionCoordinatorImpl.java:246)
	at org.hibernate.engine.transaction.internal.TransactionImpl.begin(TransactionImpl.java:83)
	at org.hibernate.internal.AbstractSharedSessionContract.beginTransaction(AbstractSharedSessionContract.java:503)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:275)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.SessionQueries.removeAccessTokenSigningKeysBefore(SessionQueries.java:262)
	at io.supertokens.storage.sql.Start.removeAccessTokenSigningKeysBefore(Start.java:320)
	at io.supertokens.session.accessToken.AccessTokenSigningKey.cleanExpiredAccessTokenSigningKeys(AccessTokenSigningKey.java:145)
	at io.supertokens.cronjobs.deleteExpiredAccessTokenSigningKeys.DeleteExpiredAccessTokenSigningKeys.doTask(DeleteExpiredAccessTokenSigningKeys.java:46)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: java.sql.SQLException: HikariDataSource HikariDataSource (SuperTokens) has been closed.
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:96)
	at org.hibernate.engine.jdbc.connections.internal.DatasourceConnectionProviderImpl.getConnection(DatasourceConnectionProviderImpl.java:122)
	at org.hibernate.internal.NonContextualJdbcConnectionAccess.obtainConnection(NonContextualJdbcConnectionAccess.java:38)
	at org.hibernate.resource.jdbc.internal.LogicalConnectionManagedImpl.acquireConnectionIfNeeded(LogicalConnectionManagedImpl.java:108)
	... 20 more

13 Mar 2022 03:47:04:401 +0530 | ERROR | pid: 3c5fb9d8-3020-4d54-b7f1-7130165d623c | [pool-873-thread-1] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: DeleteExpiredAccessTokenSigningKeys

13 Mar 2022 03:47:43:588 +0530 | WARN | pid: 630f82f6-5c7c-4b05-8e0a-9f230737bc80 | [Thread-5405] thread | io.supertokens.storage.sql.HikariLoggingAppender.doAppend(HikariLoggingAppender.java:134) | SuperTokens - Connection org.postgresql.jdbc.PgConnection@7de0175c marked as broken because of SQLSTATE(08003), ErrorCode(0)

13 Mar 2022 03:47:43:595 +0530 | ERROR | pid: 630f82f6-5c7c-4b05-8e0a-9f230737bc80 | [Thread-5405] thread | io.supertokens.Main.start(Main.java:124) | org.hibernate.TransactionException: Unable to rollback against JDBC Connection
	at org.hibernate.resource.jdbc.internal.AbstractLogicalConnectionImplementor.rollback(AbstractLogicalConnectionImplementor.java:127)
	at org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.rollback(JdbcResourceLocalTransactionCoordinatorImpl.java:304)
	at org.hibernate.engine.transaction.internal.TransactionImpl.rollback(TransactionImpl.java:142)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:309)
	at io.supertokens.storage.sql.Start.startTransactionHelper(Start.java:259)
	at io.supertokens.storage.sql.Start.startTransaction(Start.java:198)
	at io.supertokens.storage.sql.Start.startTransaction(Start.java:188)
	at io.supertokens.jwt.JWTSigningKey.getOrCreateAndGetKeyForAlgorithm(JWTSigningKey.java:141)
	at io.supertokens.jwt.JWTSigningKey.init(JWTSigningKey.java:48)
	at io.supertokens.Main.init(Main.java:183)
	at io.supertokens.Main.start(Main.java:108)
	at io.supertokens.test.TestingProcessManager$1.run(TestingProcessManager.java:69)
Caused by: java.sql.SQLException: Connection is closed
	at com.zaxxer.hikari.pool.ProxyConnection$ClosedConnection.lambda$getClosedConnection$0(ProxyConnection.java:489)
	at com.sun.proxy.$Proxy24.rollback(Unknown Source)
	at com.zaxxer.hikari.pool.ProxyConnection.rollback(ProxyConnection.java:370)
	at com.zaxxer.hikari.pool.HikariProxyConnection.rollback(HikariProxyConnection.java)
	at org.hibernate.resource.jdbc.internal.AbstractLogicalConnectionImplementor.rollback(AbstractLogicalConnectionImplementor.java:121)
	... 11 more

13 Mar 2022 03:47:43:595 +0530 | ERROR | pid: 630f82f6-5c7c-4b05-8e0a-9f230737bc80 | [Thread-5405] thread | io.supertokens.Main.start(Main.java:124) | What caused the crash: Unable to rollback against JDBC Connection

13 Mar 2022 03:48:03:961 +0530 | ERROR | pid: 48187797-9fcf-4155-b32d-4f72c476e502 | [pool-876-thread-3] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "session_access_token_signing_keys" does not exist
  Position: 13
	at io.supertokens.storage.sql.Start.removeAccessTokenSigningKeysBefore(Start.java:322)
	at io.supertokens.session.accessToken.AccessTokenSigningKey.cleanExpiredAccessTokenSigningKeys(AccessTokenSigningKey.java:145)
	at io.supertokens.cronjobs.deleteExpiredAccessTokenSigningKeys.DeleteExpiredAccessTokenSigningKeys.doTask(DeleteExpiredAccessTokenSigningKeys.java:46)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "session_access_token_signing_keys" does not exist
  Position: 13
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:125)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:54)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$update$1(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.SessionQueries.removeAccessTokenSigningKeysBefore(SessionQueries.java:262)
	at io.supertokens.storage.sql.Start.removeAccessTokenSigningKeysBefore(Start.java:320)
	... 9 more

13 Mar 2022 03:48:03:962 +0530 | ERROR | pid: 48187797-9fcf-4155-b32d-4f72c476e502 | [pool-876-thread-3] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: DeleteExpiredAccessTokenSigningKeys

13 Mar 2022 03:48:03:961 +0530 | ERROR | pid: 48187797-9fcf-4155-b32d-4f72c476e502 | [pool-876-thread-5] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "key_value" does not exist
  Position: 36
	at io.supertokens.storage.sql.Start.getKeyValue(Start.java:424)
	at io.supertokens.cronjobs.telemetry.Telemetry.doTask(Telemetry.java:68)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "key_value" does not exist
  Position: 36
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:109)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:39)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$execute$0(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.queries.GeneralQueries.getKeyValue(GeneralQueries.java:258)
	at io.supertokens.storage.sql.Start.getKeyValue(Start.java:422)
	... 8 more

13 Mar 2022 03:48:03:962 +0530 | ERROR | pid: 48187797-9fcf-4155-b32d-4f72c476e502 | [pool-876-thread-5] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: Telemetry

13 Mar 2022 03:48:28:608 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [Thread-5415] thread | io.supertokens.session.refreshToken.RefreshTokenKey.<init>(RefreshTokenKey.java:48) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "key_value" does not exist
  Position: 36
	at io.supertokens.storage.sql.Start.getRefreshTokenSigningKey_Transaction(Start.java:332)
	at io.supertokens.session.refreshToken.RefreshTokenKey.lambda$maybeGenerateNewKeyAndUpdateInDb$0(RefreshTokenKey.java:86)
	at io.supertokens.storage.sql.Start.lambda$startTransactionHelper$0(Start.java:260)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.Start.startTransactionHelper(Start.java:259)
	at io.supertokens.storage.sql.Start.startTransaction(Start.java:198)
	at io.supertokens.storage.sql.Start.startTransaction(Start.java:188)
	at io.supertokens.session.refreshToken.RefreshTokenKey.maybeGenerateNewKeyAndUpdateInDb(RefreshTokenKey.java:84)
	at io.supertokens.session.refreshToken.RefreshTokenKey.getKey(RefreshTokenKey.java:70)
	at io.supertokens.session.refreshToken.RefreshTokenKey.<init>(RefreshTokenKey.java:46)
	at io.supertokens.session.refreshToken.RefreshTokenKey.init(RefreshTokenKey.java:57)
	at io.supertokens.Main.init(Main.java:182)
	at io.supertokens.Main.start(Main.java:108)
	at io.supertokens.test.TestingProcessManager$1.run(TestingProcessManager.java:69)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "key_value" does not exist
  Position: 36
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:109)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:39)
	at io.supertokens.storage.sql.queries.GeneralQueries.getKeyValue_Transaction(GeneralQueries.java:271)
	at io.supertokens.storage.sql.Start.getRefreshTokenSigningKey_Transaction(Start.java:330)
	... 13 more

13 Mar 2022 03:48:28:609 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [Thread-5415] thread | io.supertokens.session.refreshToken.RefreshTokenKey.<init>(RefreshTokenKey.java:48) | Error while fetching refresh token key

13 Mar 2022 03:48:28:653 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-1] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "session_info" does not exist
  Position: 13
	at io.supertokens.storage.sql.Start.deleteAllExpiredSessions(Start.java:415)
	at io.supertokens.cronjobs.deleteExpiredSessions.DeleteExpiredSessions.doTask(DeleteExpiredSessions.java:43)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "session_info" does not exist
  Position: 13
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:125)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:54)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$update$1(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.SessionQueries.deleteAllExpiredSessions(SessionQueries.java:182)
	at io.supertokens.storage.sql.Start.deleteAllExpiredSessions(Start.java:413)
	... 8 more

13 Mar 2022 03:48:28:653 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-1] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: RemoveOldSessions

13 Mar 2022 03:48:28:653 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-3] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "emailverification_tokens" does not exist
  Position: 13
	at io.supertokens.storage.sql.Start.deleteExpiredEmailVerificationTokens(Start.java:707)
	at io.supertokens.cronjobs.deleteExpiredEmailVerificationTokens.DeleteExpiredEmailVerificationTokens.doTask(DeleteExpiredEmailVerificationTokens.java:49)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "emailverification_tokens" does not exist
  Position: 13
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:125)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:54)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$update$1(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.EmailVerificationQueries.deleteExpiredEmailVerificationTokens(EmailVerificationQueries.java:75)
	at io.supertokens.storage.sql.Start.deleteExpiredEmailVerificationTokens(Start.java:705)
	... 8 more

13 Mar 2022 03:48:28:653 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-3] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: RemoveOldEmailVerificationTokens

13 Mar 2022 03:48:28:653 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-2] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "emailpassword_pswd_reset_tokens" does not exist
  Position: 13
	at io.supertokens.storage.sql.Start.deleteExpiredPasswordResetTokens(Start.java:872)
	at io.supertokens.cronjobs.deleteExpiredPasswordResetTokens.DeleteExpiredPasswordResetTokens.doTask(DeleteExpiredPasswordResetTokens.java:49)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "emailpassword_pswd_reset_tokens" does not exist
  Position: 13
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:125)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:54)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$update$1(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.EmailPasswordQueries.deleteExpiredPasswordResetTokens(EmailPasswordQueries.java:84)
	at io.supertokens.storage.sql.Start.deleteExpiredPasswordResetTokens(Start.java:870)
	... 8 more

13 Mar 2022 03:48:28:653 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-2] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: RemoveOldPasswordResetTokens

13 Mar 2022 03:48:28:654 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-5] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "key_value" does not exist
  Position: 36
	at io.supertokens.storage.sql.Start.getKeyValue(Start.java:424)
	at io.supertokens.cronjobs.telemetry.Telemetry.doTask(Telemetry.java:68)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "key_value" does not exist
  Position: 36
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:109)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:39)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$execute$0(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.queries.GeneralQueries.getKeyValue(GeneralQueries.java:258)
	at io.supertokens.storage.sql.Start.getKeyValue(Start.java:422)
	... 8 more

13 Mar 2022 03:48:28:654 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-5] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: Telemetry

13 Mar 2022 03:48:28:666 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-2] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | io.supertokens.pluginInterface.exceptions.StorageQueryException: org.postgresql.util.PSQLException: ERROR: relation "session_access_token_signing_keys" does not exist
  Position: 13
	at io.supertokens.storage.sql.Start.removeAccessTokenSigningKeysBefore(Start.java:322)
	at io.supertokens.session.accessToken.AccessTokenSigningKey.cleanExpiredAccessTokenSigningKeys(AccessTokenSigningKey.java:145)
	at io.supertokens.cronjobs.deleteExpiredAccessTokenSigningKeys.DeleteExpiredAccessTokenSigningKeys.doTask(DeleteExpiredAccessTokenSigningKeys.java:46)
	at io.supertokens.cronjobs.CronTask.run(CronTask.java:44)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Caused by: org.postgresql.util.PSQLException: ERROR: relation "session_access_token_signing_keys" does not exist
  Position: 13
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2510)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2245)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:311)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:447)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:368)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:159)
	at org.postgresql.jdbc.PgPreparedStatement.executeUpdate(PgPreparedStatement.java:125)
	at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeUpdate(ProxyPreparedStatement.java:61)
	at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeUpdate(HikariProxyPreparedStatement.java)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:54)
	at io.supertokens.storage.sql.QueryExecutorTemplate.lambda$update$1(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:304)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.update(QueryExecutorTemplate.java:47)
	at io.supertokens.storage.sql.queries.SessionQueries.removeAccessTokenSigningKeysBefore(SessionQueries.java:262)
	at io.supertokens.storage.sql.Start.removeAccessTokenSigningKeysBefore(Start.java:320)
	... 9 more

13 Mar 2022 03:48:28:666 +0530 | ERROR | pid: e161fc42-a19a-420b-bb40-d75dd8cd50cc | [pool-878-thread-2] thread | io.supertokens.cronjobs.CronTask.run(CronTask.java:47) | Cronjob threw an exception: DeleteExpiredAccessTokenSigningKeys

13 Mar 2022 03:49:09:156 +0530 | ERROR | pid: 71e8007c-349c-4091-995f-66b77b93a3ca | [Thread-5426] thread | io.supertokens.Main.start(Main.java:124) | java.lang.NullPointerException: Cannot invoke "org.hibernate.SessionFactory.openSession()" because "sessionFactory" is null
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:272)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.queries.GeneralQueries.doesTableExists(GeneralQueries.java:59)
	at io.supertokens.storage.sql.queries.GeneralQueries.createTablesIfNotExists(GeneralQueries.java:103)
	at io.supertokens.storage.sql.Start.initStorage(Start.java:179)
	at io.supertokens.Main.init(Main.java:178)
	at io.supertokens.Main.start(Main.java:108)
	at io.supertokens.test.TestingProcessManager$1.run(TestingProcessManager.java:69)

13 Mar 2022 03:49:09:156 +0530 | ERROR | pid: 71e8007c-349c-4091-995f-66b77b93a3ca | [Thread-5426] thread | io.supertokens.Main.start(Main.java:124) | What caused the crash: Cannot invoke "org.hibernate.SessionFactory.openSession()" because "sessionFactory" is null

13 Mar 2022 03:49:44:589 +0530 | ERROR | pid: 41c15c08-1ea0-4654-a32f-a194d00ea044 | [Thread-5432] thread | io.supertokens.Main.start(Main.java:124) | java.lang.NullPointerException: Cannot invoke "org.hibernate.SessionFactory.openSession()" because "sessionFactory" is null
	at io.supertokens.storage.sql.ConnectionPool.withConnectionForComplexTransaction(ConnectionPool.java:272)
	at io.supertokens.storage.sql.ConnectionPool.withConnection(ConnectionPool.java:218)
	at io.supertokens.storage.sql.QueryExecutorTemplate.execute(QueryExecutorTemplate.java:30)
	at io.supertokens.storage.sql.queries.GeneralQueries.doesTableExists(GeneralQueries.java:59)
	at io.supertokens.storage.sql.queries.GeneralQueries.createTablesIfNotExists(GeneralQueries.java:103)
	at io.supertokens.storage.sql.Start.initStorage(Start.java:179)
	at io.supertokens.Main.init(Main.java:178)
	at io.supertokens.Main.start(Main.java:108)
	at io.supertokens.test.TestingProcessManager$1.run(TestingProcessManager.java:69)

13 Mar 2022 03:49:44:589 +0530 | ERROR | pid: 41c15c08-1ea0-4654-a32f-a194d00ea044 | [Thread-5432] thread | io.supertokens.Main.start(Main.java:124) | What caused the crash: Cannot invoke "org.hibernate.SessionFactory.openSession()" because "sessionFactory" is null
```
