### PR TITLE
fix: SuperTokens list ignoring base_path in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+- Fixes base_path config option not being observed when running `supertokens list`
+- Adds base_path normalization logic
+
 ## [3.12.1] - 2022-04-02
 
 ### Changes

--- a/src/main/java/io/supertokens/Main.java
+++ b/src/main/java/io/supertokens/Main.java
@@ -278,7 +278,7 @@ public class Main {
         boolean ignored = dotStarted.setWritable(true, false);
         this.startedFileName = fileName;
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(dotStarted))) { // overwrite mode
-            writer.write(ProcessHandle.current().pid() + "");
+            writer.write(ProcessHandle.current().pid() + "\n" + Config.getConfig(this).getBasePath());
         }
     }
 

--- a/src/main/java/io/supertokens/config/CoreConfig.java
+++ b/src/main/java/io/supertokens/config/CoreConfig.java
@@ -115,14 +115,14 @@ public class CoreConfig {
         if (base_path == null || base_path.equals("/") || base_path.isEmpty()) {
             return "";
         }
+        while (base_path.contains("//")) { // Catch corner case where there are multiple '/' together
+            base_path = base_path.replace("//", "/");
+        }
         if (!base_path.startsWith("/")) { // Add leading '/'
             base_path = "/" + base_path;
         }
         if (base_path.endsWith("/")) { // Remove trailing '/'
             base_path = base_path.substring(0, base_path.length() - 1);
-        }
-        while (base_path.contains("//")) { // Catch corner case where there are multiple '/' together
-            base_path = base_path.replace("//", "/");
         }
         return base_path;
     }

--- a/src/main/java/io/supertokens/config/CoreConfig.java
+++ b/src/main/java/io/supertokens/config/CoreConfig.java
@@ -121,6 +121,9 @@ public class CoreConfig {
         if (base_path.endsWith("/")) { // Remove trailing '/'
             base_path = base_path.substring(0, base_path.length() - 1);
         }
+        while (base_path.contains("//")) { // Catch corner case where there are multiple '/' together
+            base_path = base_path.replace("//", "/");
+        }
         return base_path;
     }
 

--- a/src/main/java/io/supertokens/config/CoreConfig.java
+++ b/src/main/java/io/supertokens/config/CoreConfig.java
@@ -111,8 +111,15 @@ public class CoreConfig {
     private String base_path = "";
 
     public String getBasePath() {
-        if (base_path == null || base_path.equals("/")) {
+        String base_path = this.base_path; // Don't modify the original value from the config
+        if (base_path == null || base_path.equals("/") || base_path.isEmpty()) {
             return "";
+        }
+        if (!base_path.startsWith("/")) { // Add leading '/'
+            base_path = "/" + base_path;
+        }
+        if (base_path.endsWith("/")) { // Remove trailing '/'
+            base_path = base_path.substring(0, base_path.length() - 1);
         }
         return base_path;
     }
@@ -362,12 +369,6 @@ public class CoreConfig {
         if (base_path != null && !base_path.equals("") && !base_path.equals("/")) {
             if (base_path.contains(" ")) {
                 throw new QuitProgramException("Invalid characters in base_path config");
-            }
-            if (!base_path.startsWith("/")) {
-                throw new QuitProgramException("base_path must start with a '/'");
-            }
-            if (base_path.endsWith("/")) {
-                throw new QuitProgramException("base_path cannot end with '/'");
             }
         }
 

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -794,7 +794,7 @@ public class WebserverTest extends Mockito {
             TestingProcess process = TestingProcessManager.start(args);
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
             assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            Utils.reset();
+            process.kill();
         }
         {
             Utils.setValueInConfig("base_path", "/somepath/");
@@ -802,7 +802,7 @@ public class WebserverTest extends Mockito {
             TestingProcess process = TestingProcessManager.start(args);
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
             assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            Utils.reset();
+            process.kill();
         }
         {
             Utils.setValueInConfig("base_path", "somepath");
@@ -810,7 +810,7 @@ public class WebserverTest extends Mockito {
             TestingProcess process = TestingProcessManager.start(args);
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
             assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            Utils.reset();
+            process.kill();
         }
         {
             Utils.setValueInConfig("base_path", "/somepath");
@@ -818,7 +818,7 @@ public class WebserverTest extends Mockito {
             TestingProcess process = TestingProcessManager.start(args);
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
             assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            Utils.reset();
+            process.kill();
         }
         {
             Utils.setValueInConfig("base_path", "/some path");
@@ -827,7 +827,7 @@ public class WebserverTest extends Mockito {
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.INIT_FAILURE);
             assertTrue(e != null && e.exception instanceof QuitProgramException
                     && e.exception.getMessage().equals("Invalid characters in base_path config"));
-            Utils.reset();
+            process.kill();
         }
 
     }

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -801,14 +801,16 @@ public class WebserverTest extends Mockito {
         
         TestingProcess process;
         EventAndException e;
-        tests.forEach((base_path, result) -> {
+        for(String base_path : tests.keySet())
+        {
+            String result = tests.get(base_path);
             Utils.setValueInConfig("base_path", base_path);
             process = TestingProcessManager.start(args);
             e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
             assertEquals(Config.getConfig(process.main).getBasePath(), result);
             process.kill();
             assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
-        });
+        }
     
         Utils.setValueInConfig("base_path", "/some path");
         process = TestingProcessManager.start(args);

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -17,6 +17,7 @@
 package io.supertokens.test;
 
 import com.google.gson.JsonObject;
+import io.supertokens.config.Config;
 import io.supertokens.ProcessState;
 import io.supertokens.ProcessState.EventAndException;
 import io.supertokens.ProcessState.PROCESS_STATE;
@@ -787,6 +788,38 @@ public class WebserverTest extends Mockito {
 
     @Test
     public void invalidBasePathTest() throws InterruptedException, IOException {
+        {
+            Utils.setValueInConfig("base_path", "somepath/");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            Utils.reset();
+        }
+        {
+            Utils.setValueInConfig("base_path", "/somepath/");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            Utils.reset();
+        }
+        {
+            Utils.setValueInConfig("base_path", "somepath");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            Utils.reset();
+        }
+        {
+            Utils.setValueInConfig("base_path", "/somepath");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            Utils.reset();
+        }
         {
             Utils.setValueInConfig("base_path", "/some path");
             String[] args = { "../" };

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -827,7 +827,7 @@ public class WebserverTest extends Mockito {
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.INIT_FAILURE);
             assertTrue(e != null && e.exception instanceof QuitProgramException
                     && e.exception.getMessage().equals("Invalid characters in base_path config"));
-            process.kill();
+            Utils.reset();
         }
 
     }

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -796,6 +796,11 @@ public class WebserverTest extends Mockito {
         tests.put("//somepath//",  "/somepath");
         tests.put("somepath",      "/somepath");
         tests.put("/somepath",     "/somepath");
+        tests.put("some/path",     "/some/path");
+        tests.put("some/path/",    "/some/path");
+        tests.put("some/path//",   "/some/path");
+        tests.put("/some/path",    "/some/path");
+        tests.put("//some/path",   "/some/path");
         tests.put("some//path",    "/some/path");
         tests.put("some/////path", "/some/path");
         
@@ -807,7 +812,7 @@ public class WebserverTest extends Mockito {
             Utils.setValueInConfig("base_path", base_path);
             process = TestingProcessManager.start(args);
             e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), result);
+            assertEquals(result, Config.getConfig(process.main).getBasePath());
             process.kill();
             assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
         }

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -788,26 +788,6 @@ public class WebserverTest extends Mockito {
     @Test
     public void invalidBasePathTest() throws InterruptedException, IOException {
         {
-            Utils.setValueInConfig("base_path", "somepath/");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.INIT_FAILURE);
-            assertTrue(e != null && e.exception instanceof QuitProgramException
-                    && e.exception.getMessage().equals("base_path must start with a '/'"));
-            Utils.reset();
-        }
-
-        {
-            Utils.setValueInConfig("base_path", "/somepath/");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.INIT_FAILURE);
-            assertTrue(e != null && e.exception instanceof QuitProgramException
-                    && e.exception.getMessage().equals("base_path cannot end with '/'"));
-            Utils.reset();
-        }
-
-        {
             Utils.setValueInConfig("base_path", "/some path");
             String[] args = { "../" };
             TestingProcess process = TestingProcessManager.start(args);

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -788,80 +788,34 @@ public class WebserverTest extends Mockito {
 
     @Test
     public void invalidBasePathTest() throws InterruptedException, IOException {
-        {
-            Utils.setValueInConfig("base_path", "somepath/");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+        String[] args = { "../" };
+        HashMap<String, String> tests = new HashMap<>();
+        tests.put("somepath/",     "/somepath");
+        tests.put("somepath//",    "/somepath");
+        tests.put("/somepath/",    "/somepath");
+        tests.put("//somepath//",  "/somepath");
+        tests.put("somepath",      "/somepath");
+        tests.put("/somepath",     "/somepath");
+        tests.put("some//path",    "/some/path");
+        tests.put("some/////path", "/some/path");
+        
+        TestingProcess process;
+        EventAndException e;
+        tests.forEach((base_path, result) -> {
+            Utils.setValueInConfig("base_path", base_path);
+            process = TestingProcessManager.start(args);
+            e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), result);
             process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "somepath//");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "/somepath/");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "//somepath//");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "somepath");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "some//path");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/some/path");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "some/////path");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/some/path");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "/somepath");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
-            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
-            process.kill();
-        }
-        {
-            Utils.setValueInConfig("base_path", "/some path");
-            String[] args = { "../" };
-            TestingProcess process = TestingProcessManager.start(args);
-            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.INIT_FAILURE);
-            assertTrue(e != null && e.exception instanceof QuitProgramException
-                    && e.exception.getMessage().equals("Invalid characters in base_path config"));
-            Utils.reset();
-        }
-
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+        });
+    
+        Utils.setValueInConfig("base_path", "/some path");
+        process = TestingProcessManager.start(args);
+        e = process.checkOrWaitForEvent(PROCESS_STATE.INIT_FAILURE);
+        assertTrue(e != null && e.exception instanceof QuitProgramException
+                           && e.exception.getMessage().equals("Invalid characters in base_path config"));
+        Utils.reset();
     }
 
     @Test

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -797,7 +797,23 @@ public class WebserverTest extends Mockito {
             process.kill();
         }
         {
+            Utils.setValueInConfig("base_path", "somepath//");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            process.kill();
+        }
+        {
             Utils.setValueInConfig("base_path", "/somepath/");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            process.kill();
+        }
+        {
+            Utils.setValueInConfig("base_path", "//somepath//");
             String[] args = { "../" };
             TestingProcess process = TestingProcessManager.start(args);
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
@@ -810,6 +826,22 @@ public class WebserverTest extends Mockito {
             TestingProcess process = TestingProcessManager.start(args);
             EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
             assertEquals(Config.getConfig(process.main).getBasePath(), "/somepath");
+            process.kill();
+        }
+        {
+            Utils.setValueInConfig("base_path", "some//path");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/some/path");
+            process.kill();
+        }
+        {
+            Utils.setValueInConfig("base_path", "some/////path");
+            String[] args = { "../" };
+            TestingProcess process = TestingProcessManager.start(args);
+            EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
+            assertEquals(Config.getConfig(process.main).getBasePath(), "/some/path");
             process.kill();
         }
         {


### PR DESCRIPTION
`supertokens list` previously failed when `base_path` was set in `config.yaml` due to a GET request by the CLI that did not observe `base_path`. I added the base path of the server to the .started file in addition to the PID so that the CLI can GET the /config route without encountering 404 errors.

## Summary of change
- Modifies .started file to include the base_path of the server in addition to the PID
- Ensures that the CLI reads this value in order to correctly query the server to get the config file location
- Changes config validation to gracefully handle leading and trailing '/'
- Updates CHANGELOG.md
- Adds relevant tests

## Related issues
- Closes #408
- Replaces #409 

## Test Plan
- Modified `DotStartedFileTest.java` to test the new .started file structure
- Modified `WebserverTest.java` to remove the now irrelevant `base_path` tests

## Documentation changes
(none)

## Checklist for important updates
- [X] Changelog has been updated
    - [X] If there are any db schema changes, mention those changes clearly
- [X] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [X] `pluginInterfaceSupported.json` file has been updated (if needed)
- [X] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [X] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [X] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [X] Ensure tests pass
- [ ] Make sure nothing else writes to/reads from the .started file that might break