### PR TITLE
feat: Support for environment variables in config.yaml

### DIFF
--- a/src/main/java/io/supertokens/config/Config.java
+++ b/src/main/java/io/supertokens/config/Config.java
@@ -24,13 +24,22 @@ import io.supertokens.exceptions.QuitProgramException;
 import io.supertokens.output.Logging;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Config extends ResourceDistributor.SingletonResource {
 
     private static final String RESOURCE_KEY = "io.supertokens.config.Config";
     private final Main main;
     private final CoreConfig core;
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+    private static final Pattern envPattern = Pattern.compile("(?:^|[^\\\\])\\$\\{([^}]*)}"); // (?:^|[^\\])\$\{([^}]*)}
+    private static final Pattern escEnvPattern = Pattern.compile("\\\\\\$\\{([^}]*)}"); // \\\$\{([^}]*)}
 
     private Config(Main main, String configFilePath) {
         this.main = main;
@@ -59,10 +68,34 @@ public class Config extends ResourceDistributor.SingletonResource {
         return getInstance(main).core;
     }
 
+    private String preprocessConfig(String configFilePath) throws IOException
+    {
+        List<String> content = Files.readAllLines(new File(configFilePath).toPath());
+        StringBuilder processed = new StringBuilder();
+        for(int i = 0; i < content.size(); i++ ) {
+            String line = content.get(i);
+            Matcher matcher = envPattern.matcher(line);
+            final int lineNum = i + 1; // Make final for use in lambda
+            String processedLine = matcher.replaceAll(match -> {
+                String envVarName = match.group(1).trim();
+                String envVar = System.getenv(envVarName);
+                if(envVar == null)
+                    throw new QuitProgramException("Environment variable \"" + envVarName + "\" does not exist." +
+                            " (Line " + lineNum + " of \"" + configFilePath + "\")" +
+                            "\nUse \"\\${" + envVarName + "}\" if you are not inserting an environment variable here.");
+                return envVar;
+            });
+            matcher = escEnvPattern.matcher(processedLine);
+            processedLine = matcher.replaceAll(match -> match.group().substring(1));
+            processed.append(processedLine);
+        }
+        return processed.toString();
+    }
+
     private CoreConfig loadCoreConfig(String configFilePath) throws IOException {
         Logging.info(main, "Loading supertokens config.");
-        final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        CoreConfig config = mapper.readValue(new File(configFilePath), CoreConfig.class);
+        String configFileContent = preprocessConfig(configFilePath);
+        CoreConfig config = mapper.readValue(configFileContent, CoreConfig.class);
         config.validateAndInitialise(main);
         return config;
     }

--- a/src/main/java/io/supertokens/config/ConfigPreprocessor.java
+++ b/src/main/java/io/supertokens/config/ConfigPreprocessor.java
@@ -1,0 +1,70 @@
+/*
+ *    Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.config;
+
+import io.supertokens.exceptions.QuitProgramException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+public class ConfigPreprocessor {
+    private static final Pattern commentPattern = Pattern.compile("(?:^|[^\\\\])#(.*)"); // (?:^|[^\\])#(.*)
+    private static final Pattern envPattern = Pattern.compile("(?:^|[^\\\\])\\$\\{([^}]*)}"); // (?:^|[^\\])\$\{([^}]*)}
+    private static final Pattern escEnvPattern = Pattern.compile("\\\\\\$\\{([^}]*)}"); // \\\$\{([^}]*)}
+
+    private final String config;
+    private String processedConfig;
+
+    public ConfigPreprocessor(String config) {
+        this.config = config;
+        this.processedConfig = null;
+    }
+
+    private String removeComments(String str) {
+        return commentPattern.matcher(str).replaceAll(match -> match.group().substring(0, match.start(1)));
+    }
+
+    private String substituteEnvironmentVariables(String str) {
+        return envPattern.matcher(str).replaceAll(match -> {
+            String envVarName = match.group(1).trim();
+            String envVar = System.getenv(envVarName);
+            if (envVar == null)
+                throw new QuitProgramException("Environment variable \"" + envVarName + "\" does not exist."
+                        + "\nUse \"\\${" + envVarName + "}\" if you are not inserting an environment variable here.");
+            return envVar;
+        });
+    }
+
+    private String unescapeEscapedEnvironmentVariables(String str) {
+        return escEnvPattern.matcher(str).replaceAll(match -> match.group().substring(1));
+    }
+
+    public String getProcessedConfig() {
+        if (processedConfig == null) {
+            processedConfig = removeComments(config);
+            processedConfig = substituteEnvironmentVariables(processedConfig);
+            processedConfig = unescapeEscapedEnvironmentVariables(processedConfig);
+        }
+        return processedConfig;
+    }
+
+    public static ConfigPreprocessor loadFromFile(String configFilePath) throws IOException {
+        return new ConfigPreprocessor(Files.readString(new File(configFilePath).toPath()));
+    }
+}


### PR DESCRIPTION
## Summary of Change
This PR adds support for environment variables in config.yaml. This implementation allows environment variables to be specified with `${ENV_VAR}`, where `ENV_VAR` is the name of the variable to use.

### Implementation Details
- The environment variable substitution is implemented by loading the config as a string, preprocessing that string, and then passing that preprocessed string into the Jackson ObjectMapper
- The environment variable name can include any character except `}` or linebreak, since the allowed characters for environment variables likely vary by OS
- The environment variable name can optionally have whitespace on either side, since the value is trimmed before use
- The environment variable *value* has no restrictions and can contain any character including colons and linebreaks, so it can even contain multiple config keys & values
- Each line of the config is only processed once, so environment variables cannot reference other environment variables
  - For example, if the config contains`${ENV_VAR_A}` and the value of `ENV_VAR_A` is `${ENV_VAR_B}`, this will not output the value of `ENV_VAR_B`, but will instead output the string `${ENV_VAR_B}`
- A `QuitProgramException` is thrown if an environment variable in the config is not defined
  - It might be desired to instead just ignore the line that contains the nonexistent environment variable, falling back to the default, but this might be confusing in production environments
- If an environment variable replacement is not desired, the sequence can be preceded by a `\`
  - `\${ENV_VAR}` would output the string `${ENV_VAR}`, not the value of the environment variable `ENV_VAR`

### Additional Proposed Features
- I have considered adding support for a default value if an environment variable is not defined
  - `${ENV_VAR, 0}` would try to get `ENV_VAR` and would output `0` if not defined
  - I could use a non-comma separator if desired (`|`, `:`, something else?)
  - This might be considered a more extensible replacement for the current Dockerfile environment variable config values (see Docker MySQL [implementation][1] and [README][2])
  - For example, the config value `host` could default to `${SUPERTOKENS_HOST, 0.0.0.0}`
- I have also considered support for loading from a file, but this is probably beyond the scope of this feature
  - This could be implemented with syntax similar to this: `${file: ../db_config.yaml}`

### Examples
```yaml
# Simple example
core_config_version: 0
host: ${SUPERTOKENS_HOST}
port: ${SUPERTOKENS_PORT}
base_path: ${ SUPERTOKENS_BASE_PATH } # With optional whitespace

${SUPERTOKENS_DB_CONFIG} # This could expand to a multiline string that contains multiple config values
```
```yaml
# Proposed feature examples
core_config_version: 0
host: ${SUPERTOKENS_HOST, 0.0.0.0} # With default
port: ${SUPERTOKENS_PORT, "3567"} # With default in quotes

${file: ../db_config.yaml} # Load from file with relative path
${file: /etc/supertokens_config.yaml} # Load from file with absolute path
${file: C:\Program Files\supertokens\config.yaml} # Load from Windows-style path
```

## Related Issues
(no related issues)

## Test Plan
I have looked into ways of mocking environment variables. Java does not allow directly mocking calls to `System.getenv()`, so I could either extract that call into a mockable class, or we could consider using processes instead of threads for testing. Environment variables are immutable for the current process (including threads), but they could be modified when launching a subprocess (see [ProcessBuilder.environment()][3]).

## Documentation changes
If implemented, the configuration file should probably get its own page in the documentation to explain the various usages of this syntax. **Let me know where this page should go, or if it should be added to an already existing page.** I can submit a PR once the implementation of this feature is finalized.

## Checklist for important updates
- [ ] Changelog has been updated
    - [X] If there are any db schema changes, mention those changes clearly
- [X] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [X] `pluginInterfaceSupported.json` file has been updated (if needed)
- [X] Changes to the version if needed
   - In `build.gradle`
- [X] Had installed and ran the pre-commit hook
- [X] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [X] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [x] Alter implementation to ignore `${}` in comments (comments could easily be stripped before preprocessing)
- [ ] Make sure no other code directly reads the config file other than `CoreConfig.java`

[1]: https://github.com/supertokens/supertokens-docker-mysql/blob/3df3304da880937b0ce9ad988d14307cc015c670/docker-entrypoint.sh#L49
[2]: https://github.com/supertokens/supertokens-docker-mysql/blob/master/README.md#configuration
[3]: https://docs.oracle.com/en/java/javase/15/docs/api/java.base/java/lang/ProcessBuilder.html#environment()