### PR TITLE
fix: renames addPermissionToRole function

### DIFF
--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -1367,8 +1367,8 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
     }
 
     @Override
-    public void addPermissionToRole_Transaction(TransactionConnection con, String role, String permission)
-            throws StorageQueryException, UnknownRoleException {
+    public void addPermissionToRoleOrDoNothingIfExists_Transaction(TransactionConnection con, String role,
+            String permission) throws StorageQueryException, UnknownRoleException {
         Connection sqlCon = (Connection) con.getConnection();
 
         try {
@@ -1379,7 +1379,7 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
                 throw new UnknownRoleException();
             }
 
-            UserRoleQueries.addPermissionToRole_Transaction(this, sqlCon, role, permission);
+            UserRoleQueries.addPermissionToRoleOrDoNothingIfExists_Transaction(this, sqlCon, role, permission);
         } catch (SQLException e) {
 
             throw new StorageQueryException(e);

--- a/src/main/java/io/supertokens/inmemorydb/queries/UserRoleQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/UserRoleQueries.java
@@ -217,8 +217,8 @@ public class UserRoleQueries {
         });
     }
 
-    public static void addPermissionToRole_Transaction(Start start, Connection con, String role, String permission)
-            throws SQLException, StorageQueryException {
+    public static void addPermissionToRoleOrDoNothingIfExists_Transaction(Start start, Connection con, String role,
+            String permission) throws SQLException, StorageQueryException {
 
         String QUERY = "INSERT INTO " + getConfig(start).getUserRolesPermissionsTable()
                 + " (role, permission) VALUES(?, ?) ON CONFLICT(role, permission) DO NOTHING";

--- a/src/main/java/io/supertokens/userroles/UserRoles.java
+++ b/src/main/java/io/supertokens/userroles/UserRoles.java
@@ -46,7 +46,7 @@ public class UserRoles {
             if (permissions != null) {
                 for (int i = 0; i < permissions.length; i++) {
                     try {
-                        storage.addPermissionToRole_Transaction(con, role, permissions[i]);
+                        storage.addPermissionToRoleOrDoNothingIfExists_Transaction(con, role, permissions[i]);
                     } catch (UnknownRoleException e) {
                         // ignore exception, should not come here since role should always exist in this transaction
                     }

--- a/src/test/java/io/supertokens/test/userRoles/UserRolesStorageTest.java
+++ b/src/test/java/io/supertokens/test/userRoles/UserRolesStorageTest.java
@@ -101,7 +101,7 @@ public class UserRolesStorageTest {
 
                     // add permissions
                     try {
-                        storage.addPermissionToRole_Transaction(con, role, permissions[0]);
+                        storage.addPermissionToRoleOrDoNothingIfExists_Transaction(con, role, permissions[0]);
                     } catch (UnknownRoleException e) {
                         throw new StorageQueryException(e);
                     }
@@ -207,7 +207,8 @@ public class UserRolesStorageTest {
             try {
                 storage.startTransaction(con -> {
                     try {
-                        storage.addPermissionToRole_Transaction(con, "unknown_role", "testPermission");
+                        storage.addPermissionToRoleOrDoNothingIfExists_Transaction(con, "unknown_role",
+                                "testPermission");
                     } catch (UnknownRoleException e) {
                         throw new StorageTransactionLogicException(e);
                     }
@@ -233,7 +234,7 @@ public class UserRolesStorageTest {
             try {
                 storage.startTransaction(con -> {
                     try {
-                        storage.addPermissionToRole_Transaction(con, role, permission);
+                        storage.addPermissionToRoleOrDoNothingIfExists_Transaction(con, role, permission);
                     } catch (UnknownRoleException e) {
                         throw new StorageTransactionLogicException(e);
                     }


### PR DESCRIPTION
## Summary of change
- The `addPermissionToRole_Transaction` in the plugin-interface has been changed to `addPermissionToRoleOrDoNothingIfExists_Transaction` this PR reflects that change in the core

## Related issues
- https://github.com/supertokens/supertokens-plugin-interface/pull/35

## Test Plan
- Testing for these functions already exist

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- none
