### PR TITLE
feat: adds RemovePermissionsFromRoleAPI + tests

### DIFF
--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -56,6 +56,7 @@ import io.supertokens.pluginInterface.usermetadata.sqlStorage.UserMetadataSQLSto
 import io.supertokens.pluginInterface.userroles.exception.DuplicateUserRoleMappingException;
 import io.supertokens.pluginInterface.userroles.exception.UnknownRoleException;
 import io.supertokens.pluginInterface.userroles.sqlStorage.UserRolesSQLStorage;
+import io.supertokens.userroles.UserRoles;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
@@ -1390,15 +1391,24 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
     @Override
     public boolean deletePermissionForRole_Transaction(TransactionConnection con, String role, String permission)
             throws StorageQueryException {
-        // TODO:
-        return false;
+        Connection sqlCon = (Connection) con.getConnection();
+        try {
+            return UserRoleQueries.deletePermissionForRole_Transaction(this, sqlCon, role, permission);
+        } catch (SQLException e) {
+            throw new StorageQueryException(e);
+        }
+
     }
 
     @Override
     public int deleteAllPermissionsForRole_Transaction(TransactionConnection con, String role)
             throws StorageQueryException {
-        // TODO
-        return 0;
+        Connection sqlCon = (Connection) con.getConnection();
+        try {
+            return UserRoleQueries.deleteAllPermissionsForRole_Transaction(this, sqlCon, role);
+        } catch (SQLException e) {
+            throw new StorageQueryException(e);
+        }
     }
 
     @Override

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -56,7 +56,6 @@ import io.supertokens.pluginInterface.usermetadata.sqlStorage.UserMetadataSQLSto
 import io.supertokens.pluginInterface.userroles.exception.DuplicateUserRoleMappingException;
 import io.supertokens.pluginInterface.userroles.exception.UnknownRoleException;
 import io.supertokens.pluginInterface.userroles.sqlStorage.UserRolesSQLStorage;
-import io.supertokens.userroles.UserRoles;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;

--- a/src/main/java/io/supertokens/inmemorydb/queries/UserRoleQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/UserRoleQueries.java
@@ -244,4 +244,28 @@ public class UserRoleQueries {
         return execute(con, QUERY, pst -> pst.setString(1, role), ResultSet::next);
     }
 
+    public static boolean deletePermissionForRole_Transaction(Start start, Connection con, String role,
+            String permission) throws SQLException, StorageQueryException {
+
+        String QUERY = "DELETE FROM " + getConfig(start).getUserRolesPermissionsTable()
+                + " WHERE role = ? AND permission = ? ";
+        // store the number of rows updated
+        int rowUpdatedCount = update(con, QUERY, pst -> {
+            pst.setString(1, role);
+            pst.setString(2, permission);
+        });
+
+        return rowUpdatedCount > 0;
+    }
+
+    public static int deleteAllPermissionsForRole_Transaction(Start start, Connection con, String role)
+            throws SQLException, StorageQueryException {
+
+        String QUERY = "DELETE FROM " + getConfig(start).getUserRolesPermissionsTable() + " WHERE role = ? ";
+        // return the number of rows updated
+        return update(con, QUERY, pst -> {
+            pst.setString(1, role);
+        });
+    }
+
 }

--- a/src/main/java/io/supertokens/userroles/UserRoles.java
+++ b/src/main/java/io/supertokens/userroles/UserRoles.java
@@ -142,6 +142,7 @@ public class UserRoles {
                 } else {
                     throw new StorageTransactionLogicException(new UnknownRoleException());
                 }
+                storage.commitTransaction(con);
                 return null;
             });
         } catch (StorageTransactionLogicException e) {

--- a/src/main/java/io/supertokens/userroles/UserRoles.java
+++ b/src/main/java/io/supertokens/userroles/UserRoles.java
@@ -24,6 +24,8 @@ import io.supertokens.pluginInterface.userroles.exception.UnknownRoleException;
 import io.supertokens.pluginInterface.userroles.sqlStorage.UserRolesSQLStorage;
 import io.supertokens.storageLayer.StorageLayer;
 
+import javax.annotation.Nullable;
+
 public class UserRoles {
     // add a role to a user and return true, if the role is already mapped to the user return false, but if
     // the role does not exist, throw an UNKNOWN_ROLE_EXCEPTION error
@@ -122,27 +124,35 @@ public class UserRoles {
         }
     }
 
-//    // delete permissions from a role, if the role doesn't exist throw an UNKNOWN_ROLE_EXCEPTION
-//    public static void deletePermissionsFromRole(Main main, String role, @Nullable String[] permissions)
-//            throws StorageQueryException, StorageTransactionLogicException {
-//        UserRolesSQLStorage storage = StorageLayer.getUserRolesStorage(main);
-//        storage.startTransaction(con -> {
-//            boolean doesRoleExist = storage.doesRoleExist_Transaction(con, role);
-//            if (doesRoleExist) {
-//                if (permissions == null) {
-//                    storage.deleteAllPermissionsForRole_Transaction(con, role);
-//                } else {
-//                    for (int i = 0; i < permissions.length; i++) {
-//                        storage.deletePermissionForRole_Transaction(con, role, permissions[i]);
-//                    }
-//                }
-//            } else {
-//                throw new UnknownRoleException();
-//            }
-//            return null;
-//        });
-//    }
-//
+    // delete permissions from a role, if the role doesn't exist throw an UNKNOWN_ROLE_EXCEPTION
+    public static void deletePermissionsFromRole(Main main, String role, @Nullable String[] permissions)
+            throws StorageQueryException, StorageTransactionLogicException, UnknownRoleException {
+        UserRolesSQLStorage storage = StorageLayer.getUserRolesStorage(main);
+        try {
+            storage.startTransaction(con -> {
+                boolean doesRoleExist = storage.doesRoleExist_Transaction(con, role);
+                if (doesRoleExist) {
+                    if (permissions == null) {
+                        storage.deleteAllPermissionsForRole_Transaction(con, role);
+                    } else {
+                        for (int i = 0; i < permissions.length; i++) {
+                            storage.deletePermissionForRole_Transaction(con, role, permissions[i]);
+                        }
+                    }
+                } else {
+                    throw new StorageTransactionLogicException(new UnknownRoleException());
+                }
+                return null;
+            });
+        } catch (StorageTransactionLogicException e) {
+            if (e.actualException instanceof UnknownRoleException) {
+                throw (UnknownRoleException) e.actualException;
+            }
+            throw e;
+        }
+
+    }
+
 //    // retrieve roles that have the input permission
 //    public static String[] getRolesThatHavePermission(Main main, String permission) throws StorageQueryException {
 //        return StorageLayer.getUserRolesStorage(main).getRolesThatHavePermission(permission);

--- a/src/main/java/io/supertokens/webserver/Webserver.java
+++ b/src/main/java/io/supertokens/webserver/Webserver.java
@@ -197,6 +197,7 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         addAPI(new GetRolesForUserAPI(main));
         addAPI(new GetUsersForRoleAPI(main));
         addAPI(new GetPermissionsForRoleAPI(main));
+        addAPI(new RemovePermissionsForRoleAPI(main));
         // deprecated APIs:
         addAPI(new RecipeRouter(main, new io.supertokens.webserver.api.emailpassword.UsersAPI(main),
                 new io.supertokens.webserver.api.thirdparty.UsersAPI(main)));

--- a/src/main/java/io/supertokens/webserver/api/userroles/RemovePermissionsForRoleAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/userroles/RemovePermissionsForRoleAPI.java
@@ -1,0 +1,93 @@
+/*
+ *    Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.webserver.api.userroles;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.supertokens.Main;
+import io.supertokens.pluginInterface.RECIPE_ID;
+import io.supertokens.pluginInterface.exceptions.StorageQueryException;
+import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicException;
+import io.supertokens.pluginInterface.userroles.exception.UnknownRoleException;
+import io.supertokens.userroles.UserRoles;
+import io.supertokens.webserver.InputParser;
+import io.supertokens.webserver.WebserverAPI;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Serial;
+
+public class RemovePermissionsForRoleAPI extends WebserverAPI {
+    @Serial
+    private static final long serialVersionUID = 6784464864634266617L;
+
+    public RemovePermissionsForRoleAPI(Main main) {
+        super(main, RECIPE_ID.USER_ROLES.toString());
+    }
+
+    @Override
+    public String getPath() {
+        return "/recipe/role/permissions/remove";
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
+        JsonObject input = InputParser.parseJsonObjectOrThrowError(req);
+
+        String role = InputParser.parseStringOrThrowError(input, "role", false);
+
+        // normalize role
+        role = role.trim();
+        if (role.length() == 0) {
+            throw new ServletException(
+                    new WebserverAPI.BadRequestException("Field name 'role' cannot be an empty String"));
+        }
+
+        JsonArray arr = InputParser.parseArrayOrThrowError(input, "permissions", true);
+        String[] permissions = null;
+        if (arr != null) {
+            permissions = new String[arr.size()];
+            for (int i = 0; i < permissions.length; i++) {
+
+                String permission = InputParser.parseStringFromElementOrThrowError(arr.get(i), "permissions", false);
+
+                // normalize permission
+                permission = permission.trim();
+                if (permission.length() == 0) {
+                    throw new ServletException(new WebserverAPI.BadRequestException(
+                            "Field name 'permissions' cannot contain an empty string"));
+                }
+                permissions[i] = permission;
+            }
+        }
+
+        try {
+            UserRoles.deletePermissionsFromRole(main, role, permissions);
+            JsonObject response = new JsonObject();
+            response.addProperty("status", "OK");
+            super.sendJsonResponse(200, response, resp);
+        } catch (StorageQueryException | StorageTransactionLogicException e) {
+            throw new ServletException(e);
+        } catch (UnknownRoleException e) {
+            JsonObject response = new JsonObject();
+            response.addProperty("status", "UNKNOWN_ROLE_ERROR");
+            super.sendJsonResponse(200, response, resp);
+        }
+    }
+}

--- a/src/test/java/io/supertokens/test/userRoles/UserRolesTest.java
+++ b/src/test/java/io/supertokens/test/userRoles/UserRolesTest.java
@@ -686,6 +686,33 @@ public class UserRolesTest {
     }
 
     @Test
+    public void testDeletingAPermissionWhichDoesNotExistFromARole() throws Exception {
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        // create a role with permissions
+        String role = "role";
+        String[] permissions = new String[] { "permission1", "permission2", "permission3" };
+        UserRoles.createNewRoleOrModifyItsPermissions(process.main, role, permissions);
+
+        // remove all permissions from role
+        String[] permissionToRemove = new String[] { "permission4" };
+        UserRoles.deletePermissionsFromRole(process.main, role, permissionToRemove);
+
+        // check that no permissions have been removed
+        String[] retrievedPermissions = UserRoles.getPermissionsForRole(process.main, role);
+        Utils.checkThatArraysAreEqual(permissions, retrievedPermissions);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
     public void testDeletingPermissionsFromAnUnknownRole() throws Exception {
         String[] args = { "../" };
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);

--- a/src/test/java/io/supertokens/test/userRoles/UserRolesTest.java
+++ b/src/test/java/io/supertokens/test/userRoles/UserRolesTest.java
@@ -735,4 +735,29 @@ public class UserRolesTest {
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
 
+    @Test
+    public void testDeletingAPermissionsFromARoleWithAnEmptyArray() throws Exception {
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        // create a role with permissions
+        String role = "role";
+        String[] permissions = new String[] { "permission1", "permission2", "permission3" };
+        UserRoles.createNewRoleOrModifyItsPermissions(process.main, role, permissions);
+
+        // remove all permissions from role
+        UserRoles.deletePermissionsFromRole(process.main, role, new String[] {});
+
+        // check that no permissions have been removed
+        String[] retrievedPermissions = UserRoles.getPermissionsForRole(process.main, role);
+        Utils.checkThatArraysAreEqual(permissions, retrievedPermissions);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }

--- a/src/test/java/io/supertokens/test/userRoles/UserRolesTest.java
+++ b/src/test/java/io/supertokens/test/userRoles/UserRolesTest.java
@@ -17,7 +17,6 @@
 package io.supertokens.test.userRoles;
 
 import io.supertokens.ProcessState;
-import io.supertokens.emailverification.User;
 import io.supertokens.pluginInterface.STORAGE_TYPE;
 import io.supertokens.pluginInterface.userroles.exception.UnknownRoleException;
 import io.supertokens.pluginInterface.userroles.sqlStorage.UserRolesSQLStorage;

--- a/src/test/java/io/supertokens/test/userRoles/api/RemovePermissionsForRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/RemovePermissionsForRoleAPITest.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright (c) 2022, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.userRoles.api;
+
+import io.supertokens.test.Utils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+
+public class RemovePermissionsForRoleAPITest {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+}

--- a/src/test/java/io/supertokens/test/userRoles/api/RemovePermissionsForRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/RemovePermissionsForRoleAPITest.java
@@ -16,11 +16,27 @@
 
 package io.supertokens.test.userRoles.api;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.supertokens.ProcessState;
+import io.supertokens.pluginInterface.STORAGE_TYPE;
+import io.supertokens.pluginInterface.userroles.sqlStorage.UserRolesSQLStorage;
+import io.supertokens.storageLayer.StorageLayer;
+import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
+import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.userroles.UserRoles;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TestRule;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class RemovePermissionsForRoleAPITest {
     @Rule
@@ -35,4 +51,184 @@ public class RemovePermissionsForRoleAPITest {
     public void beforeEach() {
         Utils.reset();
     }
+
+    @Test
+    public void testBadInput() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        {
+            // request body is empty
+            try {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/role/permissions/remove", new JsonObject(), 1000, 1000, null,
+                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                throw new Exception("should not come here");
+            } catch (HttpResponseException e) {
+                assertTrue(e.statusCode == 400 && e.getMessage().equals(
+                        "Http error. Status Code: 400. Message:" + " Field name 'role' is invalid in JSON input"));
+            }
+        }
+
+        {
+            // role is missing
+            String[] permissions = new String[] { "testPermission" };
+            String permissionsString = "{ permissions : " + Arrays.toString(permissions) + " }";
+
+            JsonObject request = new JsonParser().parse(permissionsString).getAsJsonObject();
+
+            try {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/role/permissions/remove", request, 1000, 1000, null,
+                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                throw new Exception("should not come here");
+            } catch (HttpResponseException e) {
+                assertTrue(e.statusCode == 400 && e.getMessage().equals(
+                        "Http error. Status Code: 400. Message:" + " Field name 'role' is invalid in JSON input"));
+            }
+        }
+
+        {
+            // role is a number
+            String[] permissions = new String[] { "testPermission" };
+            String permissionsString = "{ permissions : " + Arrays.toString(permissions) + " }";
+            JsonObject request = new JsonParser().parse(permissionsString).getAsJsonObject();
+            request.addProperty("role", 1);
+
+            try {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/role/permissions/remove", request, 1000, 1000, null,
+                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                throw new Exception("should not come here");
+            } catch (HttpResponseException e) {
+                assertTrue(e.statusCode == 400 && e.getMessage().equals(
+                        "Http error. Status Code: 400. Message:" + " Field name 'role' is invalid in JSON input"));
+            }
+        }
+        {
+            // role is an empty string
+            JsonObject requestBody = new JsonObject();
+            requestBody.addProperty("userId", "userId");
+            requestBody.addProperty("role", "  ");
+            try {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
+                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                throw new Exception("should not come here");
+            } catch (HttpResponseException e) {
+                assertTrue(e.statusCode == 400 && e.getMessage().equals(
+                        "Http error. Status Code: 400. Message:" + " Field name 'role' cannot be an empty String"));
+            }
+        }
+
+        {
+            // invalid permission in permission array
+            String permissions = "{ permissions: [ testPermission1, \" \" , testPermissions2 ]}";
+            JsonObject request = new JsonParser().parse(permissions).getAsJsonObject();
+            request.addProperty("role", "testRole");
+            try {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/role/permissions/remove", request, 1000, 1000, null,
+                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                throw new Exception("should not come here");
+            } catch (HttpResponseException e) {
+                assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
+                        + " Field name 'permissions' cannot contain an empty string"));
+            }
+        }
+        {
+            // permissions is a number
+            JsonObject requestBody = new JsonObject();
+            requestBody.addProperty("permissions", 1);
+            requestBody.addProperty("role", "testRole");
+            try {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
+                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                throw new Exception("should not come here");
+            } catch (HttpResponseException e) {
+                assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
+                        + " Field name 'permissions' is invalid in JSON input"));
+            }
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void createANewRoleWithPermissionsTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        // create a role with permissions
+        String[] permissions = new String[] { "permission1", "permission2", "permission3" };
+        String role = "role";
+
+        UserRoles.createNewRoleOrModifyItsPermissions(process.main, role, permissions);
+
+        // call api to remove some permissions
+        String[] permissionsToRemove = new String[] { "permission1", "permission2" };
+        String permissionsString = "{ permissions : " + Arrays.toString(permissionsToRemove) + " }";
+        JsonObject requestBody = new JsonParser().parse(permissionsString).getAsJsonObject();
+
+        requestBody.addProperty("role", role);
+
+        JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
+                Utils.getCdiVersion2_14ForTests(), "userroles");
+
+        assertEquals(1, response.entrySet().size());
+        assertEquals("OK", response.get("status").getAsString());
+
+        // check that only 1 permission exists for role
+        String[] retrievedPermissions = UserRoles.getPermissionsForRole(process.main, role);
+        assertEquals(1, retrievedPermissions.length);
+        assertEquals("permission3", retrievedPermissions[0]);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void deletePermissionsFromAnUnknownRole() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        // call api to remove some permissions from an unknownRole
+        String[] permissionsToRemove = new String[] { "testPermission" };
+        String permissionsString = "{ permissions : " + Arrays.toString(permissionsToRemove) + " }";
+        JsonObject requestBody = new JsonParser().parse(permissionsString).getAsJsonObject();
+
+        requestBody.addProperty("role", "unknownRole");
+
+        JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
+                Utils.getCdiVersion2_14ForTests(), "userroles");
+
+        assertEquals(1, response.entrySet().size());
+        assertEquals("UNKNOWN_ROLE_ERROR", response.get("status").getAsString());
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
 }


### PR DESCRIPTION
## Summary of change
Adds RemovePermissionFromRoleAPI, core functions, and inmemory db queries

## Related issues
- https://github.com/supertokens/supertokens-core/pull/414

## Test Plan
### Storage tests
- [x] delete a permission from a role, check that it was deleted
- [x] delete all permissions from a role, check all of them were deleted

### Core function tests
- [ ] test deleting multiple permissions from a role
- [ ] test deleting all permissions from a role
- [ ] test deleting permissions from an unknown role, should throw an UnknownRoleException
- [ ] test deleting a permission that doesn't exist from a role

### API tests
- [ ] badInput test
- [ ] test deleting permissions from a role
- [ ] test deleting all permissions from a role
- [ ] test deleting permissions from an unknown role

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] ~~Changelog has been updated~~
    - [ ] ~~If there are any db schema changes, mention those changes clearly~~
- [ ] ~~`coreDriverInterfaceSupported.json` file has been updated (if needed)~~
- [ ] ~~`pluginInterfaceSupported.json` file has been updated (if needed)~~
- [ ] ~~Changes to the version if needed~~
   - ~~In `build.gradle`~~
- [ ] Had installed and ran the pre-commit hook
- [ ] ~~If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.~~
- [ ] ~~Issue this PR against the latest non released version branch.~~
   - ~~To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.~~
   - ~~If no such branch exists, then create one from the latest released branch.~~

## Remaining TODOs for this PR
- none
