### PR TITLE
chore: Delay in telemetry sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+## [3.13.1] - 2022-05-09
+
+- Delay in sending telemetry ping to solve issue: https://github.com/supertokens/supertokens-core/issues/444
+
 ## [3.13.0] - 2022-05-05
+
 - Adds UserRoles recipe
 - Fixes base_path config option not being observed when running `supertokens list`
 - Adds base_path normalization logic
+
 ### Database changes
+
 - Adds `roles`, `role_permissions` and `user_roles` table
 
 ## [3.12.1] - 2022-04-02

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "3.13.0"
+version = "3.13.1"
 
 
 repositories {


### PR DESCRIPTION
## Summary of change
Changes the telemetry cronjob to delay sending the ping to our APIs to prevent false positive in case of people using it with docker-compose

## Related issues
- https://github.com/supertokens/supertokens-core/issues/444

## Test Plan
TODO..

## Documentation changes
- [ ] Require change to wiki section

## Checklist for important updates
- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Tests
