### PR TITLE
fixes: checks for expiry when returning session handles for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+## [3.14.0] - 2022-06-07
+
+- Fixes `/recipe/session/user GET` to return only session handles that have not expired.
+- Support for new plugin interface version (v2.15)
+- Checks for if the session has expired in `updateSession` before calling the update function.
+
 ## [3.13.0] - 2022-05-05
+
 - Adds UserRoles recipe
 - Fixes base_path config option not being observed when running `supertokens list`
 - Adds base_path normalization logic
+
 ### Database changes
+
 - Adds `roles`, `role_permissions` and `user_roles` table
 
 ## [3.12.1] - 2022-04-02

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "3.13.0"
+version = "3.14.0"
 
 
 repositories {

--- a/pluginInterfaceSupported.json
+++ b/pluginInterfaceSupported.json
@@ -1,6 +1,6 @@
 {
   "_comment": "contains a list of plugin interfaces branch names that this core supports",
   "versions": [
-    "2.14"
+    "2.15"
   ]
 }

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -52,7 +52,6 @@ import io.supertokens.pluginInterface.sqlStorage.TransactionConnection;
 import io.supertokens.pluginInterface.thirdparty.exception.DuplicateThirdPartyUserException;
 import io.supertokens.pluginInterface.thirdparty.sqlStorage.ThirdPartySQLStorage;
 import io.supertokens.pluginInterface.usermetadata.sqlStorage.UserMetadataSQLStorage;
-
 import io.supertokens.pluginInterface.userroles.exception.DuplicateUserRoleMappingException;
 import io.supertokens.pluginInterface.userroles.exception.UnknownRoleException;
 import io.supertokens.pluginInterface.userroles.sqlStorage.UserRolesSQLStorage;
@@ -313,9 +312,9 @@ public class Start implements SessionSQLStorage, EmailPasswordSQLStorage, EmailV
     }
 
     @Override
-    public String[] getAllSessionHandlesForUser(String userId) throws StorageQueryException {
+    public String[] getAllNonExpiredSessionHandlesForUser(String userId) throws StorageQueryException {
         try {
-            return SessionQueries.getAllSessionHandlesForUser(this, userId);
+            return SessionQueries.getAllNonExpiredSessionHandlesForUser(this, userId);
         } catch (SQLException e) {
             throw new StorageQueryException(e);
         }

--- a/src/main/java/io/supertokens/inmemorydb/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/SessionQueries.java
@@ -140,11 +140,15 @@ public class SessionQueries {
         update(start, QUERY.toString(), pst -> pst.setString(1, userId));
     }
 
-    public static String[] getAllSessionHandlesForUser(Start start, String userId)
+    public static String[] getAllNonExpiredSessionHandlesForUser(Start start, String userId)
             throws SQLException, StorageQueryException {
-        String QUERY = "SELECT session_handle FROM " + getConfig(start).getSessionInfoTable() + " WHERE user_id = ?";
+        String QUERY = "SELECT session_handle FROM " + getConfig(start).getSessionInfoTable()
+                + " WHERE user_id = ? AND expires_at >= ?";
 
-        return execute(start, QUERY, pst -> pst.setString(1, userId), result -> {
+        return execute(start, QUERY, pst -> {
+            pst.setString(1, userId);
+            pst.setLong(2, currentTimeMillis());
+        }, result -> {
             List<String> temp = new ArrayList<>();
             while (result.next()) {
                 temp.add(result.getString("session_handle"));

--- a/src/main/java/io/supertokens/webserver/api/session/SessionUserAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionUserAPI.java
@@ -50,7 +50,7 @@ public class SessionUserAPI extends WebserverAPI {
         assert userId != null;
 
         try {
-            String[] sessionHandles = Session.getAllSessionHandlesForUser(main, userId);
+            String[] sessionHandles = Session.getAllNonExpiredSessionHandlesForUser(main, userId);
 
             JsonObject result = new JsonObject();
             result.addProperty("status", "OK");

--- a/src/test/java/io/supertokens/test/AuthRecipeTest.java
+++ b/src/test/java/io/supertokens/test/AuthRecipeTest.java
@@ -16,14 +16,15 @@
 
 package io.supertokens.test;
 
+import com.google.gson.JsonObject;
 import io.supertokens.ProcessState;
 import io.supertokens.authRecipe.AuthRecipe;
 import io.supertokens.authRecipe.UserPaginationContainer;
 import io.supertokens.emailpassword.EmailPassword;
-import io.supertokens.passwordless.Passwordless;
-import io.supertokens.passwordless.Passwordless.CreateCodeResponse;
 import io.supertokens.emailverification.EmailVerification;
 import io.supertokens.emailverification.exception.EmailVerificationInvalidTokenException;
+import io.supertokens.passwordless.Passwordless;
+import io.supertokens.passwordless.Passwordless.CreateCodeResponse;
 import io.supertokens.pluginInterface.RECIPE_ID;
 import io.supertokens.pluginInterface.STORAGE_TYPE;
 import io.supertokens.pluginInterface.authRecipe.AuthRecipeUserInfo;
@@ -32,7 +33,6 @@ import io.supertokens.session.Session;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.thirdparty.ThirdParty;
 import io.supertokens.usermetadata.UserMetadata;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,12 +48,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.google.gson.JsonObject;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class AuthRecipeTest {
     @Rule
@@ -618,14 +613,14 @@ public class AuthRecipeTest {
             assertEquals(2, AuthRecipe.getUsersCount(process.getProcess(), new RECIPE_ID[] { user1.getRecipeId() }));
             AuthRecipe.deleteUser(process.getProcess(), user1.id);
             assertEquals(1, AuthRecipe.getUsersCount(process.getProcess(), new RECIPE_ID[] { user1.getRecipeId() }));
-            assertEquals(0, Session.getAllSessionHandlesForUser(process.getProcess(), user1.id).length);
-            assertEquals(1, Session.getAllSessionHandlesForUser(process.getProcess(), user2.id).length);
+            assertEquals(0, Session.getAllNonExpiredSessionHandlesForUser(process.getProcess(), user1.id).length);
+            assertEquals(1, Session.getAllNonExpiredSessionHandlesForUser(process.getProcess(), user2.id).length);
             assertFalse(EmailVerification.isEmailVerified(process.getProcess(), user1.id, "email"));
             assertEquals(0, UserMetadata.getUserMetadata(process.getProcess(), user1.id).entrySet().size());
 
             AuthRecipe.deleteUser(process.getProcess(), user2.id);
             assertEquals(0, AuthRecipe.getUsersCount(process.getProcess(), new RECIPE_ID[] { user1.getRecipeId() }));
-            assertEquals(0, Session.getAllSessionHandlesForUser(process.getProcess(), user2.id).length);
+            assertEquals(0, Session.getAllNonExpiredSessionHandlesForUser(process.getProcess(), user2.id).length);
             assertEquals(0, UserMetadata.getUserMetadata(process.getProcess(), user2.id).entrySet().size());
 
             Exception error = null;


### PR DESCRIPTION
## Summary of change
- Checks for session expiry when returning session handles for user
- New plugin interface version to use renamed function

## Test Plan
Added new test for checking that expired sessions are not returned (even if the cronjob to remove expired sessions is run)

## Checklist for important updates
- [x] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
