### PR TITLE
build: print failing test at the end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+- Support for collecting and displaying failing tests 
+
 ## [3.14.0] - 2022-06-07
 
 - Fixes `/recipe/session/user GET` to return only session handles that have not expired.

--- a/build.gradle
+++ b/build.gradle
@@ -127,12 +127,30 @@ tasks.withType(Test) {
         info.events = debug.events
         info.exceptionFormat = debug.exceptionFormat
 
+
+        // collect failing test names
+        ext.failedTests = []
+        afterTest { descriptor, result ->
+            if (result.resultType == TestResult.ResultType.FAILURE) {
+                String failedTest = "${descriptor.className}::${descriptor.name}"
+                logger.debug("Adding " + failedTest + " to failedTests...")
+                failedTests << [failedTest]
+            }
+        }
+
         afterSuite { desc, result ->
             if (!desc.parent) { // will match the outermost suite
                 def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
                 def startItem = '|  ', endItem = '  |'
                 def repeatLength = startItem.length() + output.length() + endItem.length()
                 println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+                // print failing tests
+                if (!failedTests.empty) {
+                    println("\nFailed tests:")
+                    failedTests.each { failedTest ->
+                        logger.lifecycle("${failedTest}")
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary of change
the failing tests are collected and printed
after the test suite completes execution
which helps in finding failing tests easily
when running from CLI