### PR TITLE
fix: updates access token type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+## [4.2.1] - 2022-11-24
+
+- Updates the type of `access_token_validity` in the CoreConfig from `int` to `long`
+
 ## [4.2.0] - 2022-11-07
 
 - Update dependencies for security updates: https://github.com/supertokens/supertokens-core/issues/525

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "4.2.0"
+version = "4.2.1"
 
 
 repositories {

--- a/src/main/java/io/supertokens/config/CoreConfig.java
+++ b/src/main/java/io/supertokens/config/CoreConfig.java
@@ -36,7 +36,7 @@ public class CoreConfig {
     private int core_config_version = -1;
 
     @JsonProperty
-    private int access_token_validity = 3600; // in seconds
+    private long access_token_validity = 3600; // in seconds
 
     @JsonProperty
     private boolean access_token_blacklisting = false;

--- a/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
+++ b/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
@@ -70,6 +70,28 @@ public class JWTCreateTest {
     }
 
     /**
+     * Call JWTSigningFunctions.createJWTToken with valid params and long validity and ensure that it does not throw any
+     * errors
+     */
+    @Test
+    public void testNormalFunctioningOfCreateTokenWithLongValidity() throws Exception {
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String algorithm = "RS256";
+        JsonObject payload = new JsonObject();
+        payload.addProperty("customClaim", "customValue");
+        String jwksDomain = "http://localhost";
+        long validity = 63072000;
+
+        JWTSigningFunctions.createJWTToken(process.getProcess(), algorithm, payload, jwksDomain, validity);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    /**
      * Trying to create a JWT with an unsupported algorithm should throw an error
      */
     @Test

--- a/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
+++ b/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
@@ -31,6 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
@@ -85,7 +86,14 @@ public class JWTCreateTest {
         String jwksDomain = "http://localhost";
         long validity = 63072000;
 
-        JWTSigningFunctions.createJWTToken(process.getProcess(), algorithm, payload, jwksDomain, validity);
+        String jwt = JWTSigningFunctions.createJWTToken(process.getProcess(), algorithm, payload, jwksDomain, validity);
+
+        DecodedJWT decodedJWT = JWT.decode(jwt);
+
+        // compares the (expiry time in seconds) - (issued at time in seconds) -1
+        // 1 is added to expiry time to make sure expiry is atleast 1 second
+        assertEquals((decodedJWT.getExpiresAt().getTime() / 1000 - decodedJWT.getIssuedAt().getTime() / 1000) - 1,
+                validity);
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));

--- a/src/test/java/io/supertokens/test/session/SessionTest4.java
+++ b/src/test/java/io/supertokens/test/session/SessionTest4.java
@@ -17,6 +17,8 @@
 package io.supertokens.test.session;
 
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import io.supertokens.ProcessState;
 import io.supertokens.exceptions.TokenTheftDetectedException;
 import io.supertokens.exceptions.TryRefreshTokenException;
@@ -25,6 +27,7 @@ import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicException;
 import io.supertokens.session.Session;
 import io.supertokens.session.accessToken.AccessTokenSigningKey;
+import io.supertokens.session.info.SessionInfo;
 import io.supertokens.session.info.SessionInformationHolder;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
@@ -416,6 +419,38 @@ public class SessionTest4 {
         assertEquals(sessionInfo2.accessToken.expiry - sessionInfo2.accessToken.createdTime, twoYearsInSeconds * 1000);
         assertEquals(sessionInfo2.refreshToken.expiry - sessionInfo2.refreshToken.createdTime,
                 twoYearsInSeconds * 1000);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void createNewSessionAndUpdateSession() throws Exception {
+
+        Utils.setValueInConfig("access_token_validity", "63072000"); // 2 years in seconds
+        Utils.setValueInConfig("refresh_token_validity", "1051200"); // 2 years in minutes
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        SessionInformationHolder sessionInfo = Session.createNewSession(process.getProcess(), "user", new JsonObject(),
+                new JsonObject());
+        long twoYearsInSeconds = 63072000;
+
+        assertEquals(sessionInfo.accessToken.expiry - sessionInfo.accessToken.createdTime, twoYearsInSeconds * 1000);
+        assertEquals(sessionInfo.refreshToken.expiry - sessionInfo.refreshToken.createdTime, twoYearsInSeconds * 1000);
+        JsonObject sessionData = new JsonObject();
+        sessionData.addProperty("test", "value");
+
+        JsonObject jwtData = new JsonObject();
+        jwtData.addProperty("test", "value");
+
+        Session.updateSession(process.main, sessionInfo.session.handle, sessionData, jwtData, null);
+
+        io.supertokens.pluginInterface.session.SessionInfo sessionInfo2 = Session.getSession(process.main,
+                sessionInfo.session.handle);
+
+        assertEquals(sessionInfo2.expiry - sessionInfo2.timeCreated, twoYearsInSeconds * 1000);
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));

--- a/src/test/java/io/supertokens/test/session/SessionTest4.java
+++ b/src/test/java/io/supertokens/test/session/SessionTest4.java
@@ -367,4 +367,26 @@ public class SessionTest4 {
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
+
+    // session tests with long access and refresh token lifetimes
+    @Test
+    public void testCreatingSessionsWithLongAccessAndRefreshTokenLifeTimes() throws Exception {
+
+        Utils.setValueInConfig("access_token_validity", "63072000"); // 2 years in seconds
+        Utils.setValueInConfig("refresh_token_validity", "1051200"); // 2 years in minutes
+
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        SessionInformationHolder sessionInfo = Session.createNewSession(process.getProcess(), "user", new JsonObject(),
+                new JsonObject());
+        long twoYearsInSeconds = 63072000;
+
+        assertEquals(sessionInfo.accessToken.expiry - sessionInfo.accessToken.createdTime, twoYearsInSeconds * 1000);
+        assertEquals(sessionInfo.refreshToken.expiry - sessionInfo.refreshToken.createdTime, twoYearsInSeconds * 1000);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }


### PR DESCRIPTION
## Summary of change
Updates `access_token_validity` from `int` to `long`

## Related issues
- https://github.com/supertokens/supertokens-core/issues/534

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [x] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- [ ] Item1
- [ ] Item2
