### PR TITLE
refactor: adding/using a semver class instead of version strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+### Changed
+
+- Using an internal `SemVer` class to handle version numbers. This will make handling CDI version ranges easier.
+
 ## [4.4.0] - 2023-02-21
 
 ### Added

--- a/ee/src/test/java/io/supertokens/ee/test/api/DeleteLicenseKeyAPITest.java
+++ b/ee/src/test/java/io/supertokens/ee/test/api/DeleteLicenseKeyAPITest.java
@@ -51,7 +51,7 @@ public class DeleteLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonDELETERequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 
@@ -83,7 +83,7 @@ public class DeleteLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonDELETERequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 

--- a/ee/src/test/java/io/supertokens/ee/test/api/GetFeatureFlagAPITest.java
+++ b/ee/src/test/java/io/supertokens/ee/test/api/GetFeatureFlagAPITest.java
@@ -42,7 +42,7 @@ public class GetFeatureFlagAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/featureflag",
-                null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(3, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertEquals(0, response.get("features").getAsJsonArray().size());
@@ -64,7 +64,7 @@ public class GetFeatureFlagAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/featureflag",
-                null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(3, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertEquals(1, response.get("features").getAsJsonArray().size());

--- a/ee/src/test/java/io/supertokens/ee/test/api/GetLicenseKeyAPITest.java
+++ b/ee/src/test/java/io/supertokens/ee/test/api/GetLicenseKeyAPITest.java
@@ -42,7 +42,7 @@ public class GetLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         Assert.assertEquals(1, response.entrySet().size());
         Assert.assertEquals("NO_LICENSE_KEY_FOUND_ERROR", response.get("status").getAsString());
 
@@ -64,7 +64,7 @@ public class GetLicenseKeyAPITest {
         // retrieve license key
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
 
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -93,7 +93,7 @@ public class GetLicenseKeyAPITest {
         // retrieve license key
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
 
         Assert.assertEquals(1, response.entrySet().size());
         Assert.assertEquals("NO_LICENSE_KEY_FOUND_ERROR", response.get("status").getAsString());

--- a/ee/src/test/java/io/supertokens/ee/test/api/SetLicenseKeyAPITest.java
+++ b/ee/src/test/java/io/supertokens/ee/test/api/SetLicenseKeyAPITest.java
@@ -58,7 +58,7 @@ public class SetLicenseKeyAPITest {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/ee/license",
-                    requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                    requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
             throw new Exception("should never come here");
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -91,7 +91,7 @@ public class SetLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(1, response.entrySet().size());
         assertEquals("MISSING_EE_FOLDER_ERROR", response.get("status").getAsString());
 
@@ -110,7 +110,7 @@ public class SetLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 
@@ -138,7 +138,7 @@ public class SetLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                new JsonObject(), 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                new JsonObject(), 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 
@@ -163,7 +163,7 @@ public class SetLicenseKeyAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/license",
-                requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion(), "");
+                requestBody, 10000, 10000, null, WebserverAPI.getLatestCDIVersion().get(), "");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("INVALID_LICENSE_KEY_ERROR", response.get("status").getAsString());

--- a/src/main/java/io/supertokens/inmemorydb/ConnectionPool.java
+++ b/src/main/java/io/supertokens/inmemorydb/ConnectionPool.java
@@ -17,6 +17,7 @@
 package io.supertokens.inmemorydb;
 
 import io.supertokens.ResourceDistributor;
+import org.sqlite.SQLiteConfig;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -32,7 +33,9 @@ public class ConnectionPool extends ResourceDistributor.SingletonResource {
     private Lock lock = new Lock();
 
     public ConnectionPool() throws SQLException {
-        this.alwaysAlive = DriverManager.getConnection(URL);
+        SQLiteConfig config = new SQLiteConfig();
+        config.enforceForeignKeys(true);
+        this.alwaysAlive = DriverManager.getConnection(URL, config.toProperties());
     }
 
     static void initPool(Start start) throws SQLException {
@@ -43,7 +46,10 @@ public class ConnectionPool extends ResourceDistributor.SingletonResource {
         if (!start.enabled) {
             throw new SQLException("Storage layer disabled");
         }
-        return new ConnectionWithLocks(DriverManager.getConnection(URL), ConnectionPool.getInstance(start));
+        SQLiteConfig config = new SQLiteConfig();
+        config.enforceForeignKeys(true);
+        return new ConnectionWithLocks(DriverManager.getConnection(URL, config.toProperties()),
+                ConnectionPool.getInstance(start));
     }
 
     private static ConnectionPool getInstance(Start start) {

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -20,8 +20,6 @@ import com.google.gson.JsonObject;
 import io.supertokens.Main;
 import io.supertokens.ProcessState;
 import io.supertokens.ResourceDistributor;
-import io.supertokens.dashboard.Dashboard;
-import io.supertokens.emailpassword.exceptions.UnsupportedPasswordHashingFormatException;
 import io.supertokens.emailverification.EmailVerification;
 import io.supertokens.emailverification.exception.EmailAlreadyVerifiedException;
 import io.supertokens.inmemorydb.config.Config;
@@ -32,7 +30,6 @@ import io.supertokens.pluginInterface.RECIPE_ID;
 import io.supertokens.pluginInterface.STORAGE_TYPE;
 import io.supertokens.pluginInterface.authRecipe.AuthRecipeUserInfo;
 import io.supertokens.pluginInterface.dashboard.DashboardSessionInfo;
-import io.supertokens.pluginInterface.dashboard.DashboardStorage;
 import io.supertokens.pluginInterface.dashboard.DashboardUser;
 import io.supertokens.pluginInterface.dashboard.exceptions.UserIdNotFoundException;
 import io.supertokens.pluginInterface.dashboard.sqlStorage.DashboardSQLStorage;
@@ -304,7 +301,8 @@ public class Start
 
     @Override
     public void createNewSession(String sessionHandle, String userId, String refreshTokenHash2,
-            JsonObject userDataInDatabase, long expiry, JsonObject userDataInJWT, long createdAtTime)
+                                 JsonObject userDataInDatabase, long expiry, JsonObject userDataInJWT,
+                                 long createdAtTime)
             throws StorageQueryException {
         try {
             SessionQueries.createNewSession(this, sessionHandle, userId, refreshTokenHash2, userDataInDatabase, expiry,
@@ -417,7 +415,8 @@ public class Start
 
     @Override
     public AuthRecipeUserInfo[] getUsers(@NotNull Integer limit, @NotNull String timeJoinedOrder,
-            @Nullable RECIPE_ID[] includeRecipeIds, @Nullable String userId, @Nullable Long timeJoined)
+                                         @Nullable RECIPE_ID[] includeRecipeIds, @Nullable String userId,
+                                         @Nullable Long timeJoined)
             throws StorageQueryException {
         try {
             return GeneralQueries.getUsers(this, limit, timeJoinedOrder, includeRecipeIds, userId, timeJoined);
@@ -448,7 +447,7 @@ public class Start
 
     @Override
     public void updateSessionInfo_Transaction(TransactionConnection con, String sessionHandle, String refreshTokenHash2,
-            long expiry) throws StorageQueryException {
+                                              long expiry) throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             SessionQueries.updateSessionInfo_Transaction(this, sqlCon, sessionHandle, refreshTokenHash2, expiry);
@@ -493,8 +492,8 @@ public class Start
                     .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
                             + Config.getConfig(this).getEmailPasswordUsersTable() + ".user_id)")
                     || e.getMessage()
-                            .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
-                                    + Config.getConfig(this).getUsersTable() + ".user_id)")) {
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
+                            + Config.getConfig(this).getUsersTable() + ".user_id)")) {
                 throw new DuplicateUserIdException();
             }
             throw new StorageQueryException(e);
@@ -532,12 +531,6 @@ public class Start
     public void addPasswordResetToken(PasswordResetTokenInfo passwordResetTokenInfo)
             throws StorageQueryException, UnknownUserIdException, DuplicatePasswordResetTokenException {
         try {
-            // SQLite is not compiled with foreign key constraint and so we must check for
-            // the userId manually
-            if (this.getUserInfoUsingId(passwordResetTokenInfo.userId) == null) {
-                throw new UnknownUserIdException();
-            }
-
             EmailPasswordQueries.addPasswordResetToken(this, passwordResetTokenInfo.userId,
                     passwordResetTokenInfo.token, passwordResetTokenInfo.tokenExpiry);
         } catch (SQLException e) {
@@ -546,6 +539,9 @@ public class Start
                             + Config.getConfig(this).getPasswordResetTokensTable() + ".user_id, "
                             + Config.getConfig(this).getPasswordResetTokensTable() + ".token)")) {
                 throw new DuplicatePasswordResetTokenException();
+            } else if (e.getMessage()
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (FOREIGN KEY constraint failed)")) {
+                throw new UnknownUserIdException();
             }
             throw new StorageQueryException(e);
         }
@@ -571,7 +567,8 @@ public class Start
 
     @Override
     public PasswordResetTokenInfo[] getAllPasswordResetTokenInfoForUser_Transaction(TransactionConnection con,
-            String userId) throws StorageQueryException {
+                                                                                    String userId)
+            throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             return EmailPasswordQueries.getAllPasswordResetTokenInfoForUser_Transaction(this, sqlCon, userId);
@@ -633,7 +630,7 @@ public class Start
     @Override
     @Deprecated
     public UserInfo[] getUsers(@NotNull String userId, @NotNull Long timeJoined, @NotNull Integer limit,
-            @NotNull String timeJoinedOrder) throws StorageQueryException {
+                               @NotNull String timeJoinedOrder) throws StorageQueryException {
         try {
             return EmailPasswordQueries.getUsersInfo(this, userId, timeJoined, limit, timeJoinedOrder);
         } catch (SQLException e) {
@@ -672,7 +669,8 @@ public class Start
 
     @Override
     public EmailVerificationTokenInfo[] getAllEmailVerificationTokenInfoForUser_Transaction(TransactionConnection con,
-            String userId, String email) throws StorageQueryException {
+                                                                                            String userId, String email)
+            throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             return EmailVerificationQueries.getAllEmailVerificationTokenInfoForUser_Transaction(this, sqlCon, userId,
@@ -702,7 +700,7 @@ public class Start
 
     @Override
     public void deleteAllEmailVerificationTokensForUser_Transaction(TransactionConnection con, String userId,
-            String email) throws StorageQueryException {
+                                                                    String email) throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             EmailVerificationQueries.deleteAllEmailVerificationTokensForUser_Transaction(this, sqlCon, userId, email);
@@ -713,7 +711,7 @@ public class Start
 
     @Override
     public void updateIsEmailVerified_Transaction(TransactionConnection con, String userId, String email,
-            boolean isEmailVerified) throws StorageQueryException {
+                                                  boolean isEmailVerified) throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             EmailVerificationQueries.updateUsersIsEmailVerified_Transaction(this, sqlCon, userId, email,
@@ -795,7 +793,9 @@ public class Start
 
     @Override
     public io.supertokens.pluginInterface.thirdparty.UserInfo getUserInfoUsingId_Transaction(TransactionConnection con,
-            String thirdPartyId, String thirdPartyUserId) throws StorageQueryException {
+                                                                                             String thirdPartyId,
+                                                                                             String thirdPartyUserId)
+            throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             return ThirdPartyQueries.getUserInfoUsingId_Transaction(this, sqlCon, thirdPartyId, thirdPartyUserId);
@@ -806,7 +806,7 @@ public class Start
 
     @Override
     public void updateUserEmail_Transaction(TransactionConnection con, String thirdPartyId, String thirdPartyUserId,
-            String newEmail) throws StorageQueryException {
+                                            String newEmail) throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             ThirdPartyQueries.updateUserEmail_Transaction(this, sqlCon, thirdPartyId, thirdPartyUserId, newEmail);
@@ -832,8 +832,8 @@ public class Start
                     .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
                             + Config.getConfig(this).getThirdPartyUsersTable() + ".user_id)")
                     || e.getMessage()
-                            .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
-                                    + Config.getConfig(this).getUsersTable() + ".user_id)")) {
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
+                            + Config.getConfig(this).getUsersTable() + ".user_id)")) {
                 throw new io.supertokens.pluginInterface.thirdparty.exception.DuplicateUserIdException();
             }
             throw new StorageQueryException(e);
@@ -851,7 +851,8 @@ public class Start
 
     @Override
     public io.supertokens.pluginInterface.thirdparty.UserInfo getThirdPartyUserInfoUsingId(String thirdPartyId,
-            String thirdPartyUserId) throws StorageQueryException {
+                                                                                           String thirdPartyUserId)
+            throws StorageQueryException {
         try {
             return ThirdPartyQueries.getThirdPartyUserInfoUsingId(this, thirdPartyId, thirdPartyUserId);
         } catch (SQLException e) {
@@ -872,7 +873,9 @@ public class Start
     @Override
     @Deprecated
     public io.supertokens.pluginInterface.thirdparty.UserInfo[] getThirdPartyUsers(@NotNull String userId,
-            @NotNull Long timeJoined, @NotNull Integer limit, @NotNull String timeJoinedOrder)
+                                                                                   @NotNull Long timeJoined,
+                                                                                   @NotNull Integer limit,
+                                                                                   @NotNull String timeJoinedOrder)
             throws StorageQueryException {
         try {
             return ThirdPartyQueries.getThirdPartyUsers(this, userId, timeJoined, limit, timeJoinedOrder);
@@ -884,7 +887,8 @@ public class Start
     @Override
     @Deprecated
     public io.supertokens.pluginInterface.thirdparty.UserInfo[] getThirdPartyUsers(@NotNull Integer limit,
-            @NotNull String timeJoinedOrder) throws StorageQueryException {
+                                                                                   @NotNull String timeJoinedOrder)
+            throws StorageQueryException {
         try {
             return ThirdPartyQueries.getThirdPartyUsers(this, limit, timeJoinedOrder);
         } catch (SQLException e) {
@@ -1036,7 +1040,8 @@ public class Start
 
     @Override
     public void createDeviceWithCode(@Nullable String email, @Nullable String phoneNumber, String linkCodeSalt,
-            PasswordlessCode code) throws StorageQueryException, DuplicateDeviceIdHashException,
+                                     PasswordlessCode code)
+            throws StorageQueryException, DuplicateDeviceIdHashException,
             DuplicateCodeIdException, DuplicateLinkCodeHashException {
         if (email == null && phoneNumber == null) {
             throw new IllegalArgumentException("Both email and phoneNumber can't be null");
@@ -1186,8 +1191,8 @@ public class Start
                     .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
                             + Config.getConfig(this).getPasswordlessUsersTable() + ".user_id)")
                     || message
-                            .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
-                                    + Config.getConfig(this).getUsersTable() + ".user_id)")) {
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
+                            + Config.getConfig(this).getUsersTable() + ".user_id)")) {
                 throw new DuplicateUserIdException();
             }
 
@@ -1292,11 +1297,6 @@ public class Start
     public void addRoleToUser(String userId, String role)
             throws StorageQueryException, UnknownRoleException, DuplicateUserRoleMappingException {
         try {
-            // SQLite is not compiled with foreign key constraint and so we must check for
-            // role manually
-            if (!this.doesRoleExist(role)) {
-                throw new UnknownRoleException();
-            }
             UserRoleQueries.addRoleToUser(this, userId, role);
         } catch (SQLException e) {
             if (e.getMessage()
@@ -1304,6 +1304,9 @@ public class Start
                             + Config.getConfig(this).getUserRolesTable() + ".user_id, "
                             + Config.getConfig(this).getUserRolesTable() + ".role" + ")")) {
                 throw new DuplicateUserRoleMappingException();
+            } else if (e.getMessage()
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (FOREIGN KEY constraint failed)")) {
+                throw new UnknownRoleException();
             }
 
             throw new StorageQueryException(e);
@@ -1407,20 +1410,17 @@ public class Start
 
     @Override
     public void addPermissionToRoleOrDoNothingIfExists_Transaction(TransactionConnection con, String role,
-            String permission) throws StorageQueryException, UnknownRoleException {
+                                                                   String permission)
+            throws StorageQueryException, UnknownRoleException {
         Connection sqlCon = (Connection) con.getConnection();
 
         try {
-            // SQLite is not compiled with foreign key constraint and so we must check for
-            // role manually
-
-            if (!this.doesRoleExist_Transaction(con, role)) {
-                throw new UnknownRoleException();
-            }
-
             UserRoleQueries.addPermissionToRoleOrDoNothingIfExists_Transaction(this, sqlCon, role, permission);
         } catch (SQLException e) {
-
+            if (e.getMessage()
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (FOREIGN KEY constraint failed)")) {
+                throw new UnknownRoleException();
+            }
             throw new StorageQueryException(e);
         }
     }
@@ -1460,17 +1460,8 @@ public class Start
 
     @Override
     public void createUserIdMapping(String superTokensUserId, String externalUserId,
-            @Nullable String externalUserIdInfo)
+                                    @Nullable String externalUserIdInfo)
             throws StorageQueryException, UnknownSuperTokensUserIdException, UserIdMappingAlreadyExistsException {
-
-        // SQLite is not compiled with foreign key constraint, so we need an explicit
-        // check to see if superTokensUserId
-        // is a valid
-        // userId.
-        if (!doesUserIdExist(superTokensUserId)) {
-            throw new UnknownSuperTokensUserIdException();
-        }
-
         try {
             UserIdMappingQueries.createUserIdMapping(this, superTokensUserId, externalUserId, externalUserIdInfo);
         } catch (SQLException e) {
@@ -1491,6 +1482,10 @@ public class Start
                     .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (UNIQUE constraint failed: "
                             + Config.getConfig(this).getUserIdMappingTable() + ".external_user_id" + ")")) {
                 throw new UserIdMappingAlreadyExistsException(false, true);
+            }
+            if (e.getMessage()
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (FOREIGN KEY constraint failed)")) {
+                throw new UnknownSuperTokensUserIdException();
             }
             throw new StorageQueryException(e);
         }
@@ -1535,7 +1530,7 @@ public class Start
 
     @Override
     public boolean updateOrDeleteExternalUserIdInfo(String userId, boolean isSuperTokensUserId,
-            @Nullable String externalUserIdInfo) throws StorageQueryException {
+                                                    @Nullable String externalUserIdInfo) throws StorageQueryException {
         try {
             if (isSuperTokensUserId) {
                 return UserIdMappingQueries.updateOrDeleteExternalUserIdInfoWithSuperTokensUserId(this, userId,
@@ -1682,11 +1677,12 @@ public class Start
 
     @Override
     public void updateDashboardUsersEmailWithUserId_Transaction(TransactionConnection con, String userId,
-            String newEmail)
-            throws StorageQueryException, io.supertokens.pluginInterface.dashboard.exceptions.DuplicateEmailException, UserIdNotFoundException {
+                                                                String newEmail)
+            throws StorageQueryException, io.supertokens.pluginInterface.dashboard.exceptions.DuplicateEmailException,
+            UserIdNotFoundException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
-            if(!DashboardQueries.updateDashboardUsersEmailWithUserId_Transaction(this, sqlCon, userId, newEmail)){
+            if (!DashboardQueries.updateDashboardUsersEmailWithUserId_Transaction(this, sqlCon, userId, newEmail)) {
                 throw new UserIdNotFoundException();
             }
         } catch (SQLException e) {
@@ -1701,10 +1697,12 @@ public class Start
 
     @Override
     public void updateDashboardUsersPasswordWithUserId_Transaction(TransactionConnection con, String userId,
-            String newPassword) throws StorageQueryException, UserIdNotFoundException {
+                                                                   String newPassword)
+            throws StorageQueryException, UserIdNotFoundException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
-            if(!DashboardQueries.updateDashboardUsersPasswordWithUserId_Transaction(this, sqlCon, userId, newPassword)){
+            if (!DashboardQueries.updateDashboardUsersPasswordWithUserId_Transaction(this, sqlCon, userId,
+                    newPassword)) {
                 throw new UserIdNotFoundException();
             }
         } catch (SQLException e) {
@@ -1743,14 +1741,13 @@ public class Start
     @Override
     public void createNewDashboardUserSession(String userId, String sessionId, long timeCreated, long expiry)
             throws StorageQueryException, UserIdNotFoundException {
-        // SQLite is not compiled with foreign key constraint and so we must check if
-        // the user exists
-        if (this.getDashboardUserByUserId(userId) == null) {
-            throw new UserIdNotFoundException();
-        }
         try {
             DashboardQueries.createDashboardSession(this, userId, sessionId, timeCreated, expiry);
         } catch (SQLException e) {
+            if (e.getMessage()
+                    .equals("[SQLITE_CONSTRAINT]  Abort due to constraint violation (FOREIGN KEY constraint failed)")) {
+                throw new UserIdNotFoundException();
+            }
             throw new StorageQueryException(e);
         }
 

--- a/src/main/java/io/supertokens/inmemorydb/queries/GeneralQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/GeneralQueries.java
@@ -306,7 +306,8 @@ public class GeneralQueries {
     }
 
     public static AuthRecipeUserInfo[] getUsers(Start start, @NotNull Integer limit, @NotNull String timeJoinedOrder,
-            @Nullable RECIPE_ID[] includeRecipeIds, @Nullable String userId, @Nullable Long timeJoined)
+                                                @Nullable RECIPE_ID[] includeRecipeIds, @Nullable String userId,
+                                                @Nullable Long timeJoined)
             throws SQLException, StorageQueryException {
 
         // This list will be used to keep track of the result's order from the db
@@ -415,7 +416,8 @@ public class GeneralQueries {
     }
 
     private static List<? extends AuthRecipeUserInfo> getUserInfoForRecipeIdFromUserIds(Start start, RECIPE_ID recipeId,
-            List<String> userIds) throws StorageQueryException, SQLException {
+                                                                                        List<String> userIds)
+            throws StorageQueryException, SQLException {
         if (recipeId == RECIPE_ID.EMAIL_PASSWORD) {
             return EmailPasswordQueries.getUsersInfoUsingIdList(start, userIds);
         } else if (recipeId == RECIPE_ID.THIRD_PARTY) {

--- a/src/main/java/io/supertokens/utils/SemVer.java
+++ b/src/main/java/io/supertokens/utils/SemVer.java
@@ -39,40 +39,67 @@ public class SemVer implements Comparable<SemVer> {
     }
 
     public SemVer(String version) {
-        if(version == null)
+        if(version == null) {
             throw new IllegalArgumentException("Version can not be null");
-        if(!version.matches("[0-9]+(\\.[0-9]+)*"))
+        }
+
+        if(!version.matches("[0-9]+(\\.[0-9]+)*")) {
             throw new IllegalArgumentException("Invalid version format");
+        }
+
         this.version = version;
     }
 
+    public boolean betweenInclusive(SemVer min, SemVer max) {
+        return min.compareTo(this) <= 0 && this.compareTo(max) <= 0;
+    }
+
+    public boolean greaterThanOrEqualTo(SemVer min) {
+        return min.compareTo(this) <= 0;
+    }
+
+    public boolean lesserThan(SemVer max) {
+        return this.compareTo(max) < 0;
+    }
+
     @Override public int compareTo(SemVer that) {
-        if(that == null)
+        if (that == null) {
             return 1;
+        }
+
         String[] thisParts = this.get().split("\\.");
         String[] thatParts = that.get().split("\\.");
+
         int length = Math.max(thisParts.length, thatParts.length);
-        for(int i = 0; i < length; i++) {
-            int thisPart = i < thisParts.length ?
-                    Integer.parseInt(thisParts[i]) : 0;
-            int thatPart = i < thatParts.length ?
-                    Integer.parseInt(thatParts[i]) : 0;
-            if(thisPart < thatPart)
+
+        for (int i = 0; i < length; i++) {
+            int thisPart = i < thisParts.length ? Integer.parseInt(thisParts[i]) : 0;
+            int thatPart = i < thatParts.length ? Integer.parseInt(thatParts[i]) : 0;
+
+            if(thisPart < thatPart) {
                 return -1;
-            if(thisPart > thatPart)
+            }
+
+            if(thisPart > thatPart) {
                 return 1;
+            }
         }
+
         return 0;
     }
 
     @Override public boolean equals(Object that) {
-        if(this == that)
+        if(this == that) {
             return true;
-        if(that == null)
-            return false;
+        }
 
-        if(!(that instanceof SemVer))
+        if(that == null) {
             return false;
+        }
+
+        if(!(that instanceof SemVer)) {
+            return false;
+        }
 
         return this.compareTo((SemVer) that) == 0;
     }

--- a/src/main/java/io/supertokens/utils/SemVer.java
+++ b/src/main/java/io/supertokens/utils/SemVer.java
@@ -71,14 +71,15 @@ public class SemVer implements Comparable<SemVer> {
         if(that == null)
             return false;
 
-        if(this.getClass() != that.getClass())
+        if(!(that instanceof SemVer))
             return false;
+
         return this.compareTo((SemVer) that) == 0;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(version);
+        return version.hashCode();
     }
 
     @Override

--- a/src/main/java/io/supertokens/utils/SemVer.java
+++ b/src/main/java/io/supertokens/utils/SemVer.java
@@ -1,0 +1,88 @@
+/*
+ *    Copyright (c) 2023, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.utils;
+
+import java.util.Objects;
+
+public class SemVer implements Comparable<SemVer> {
+    public static final SemVer v2_7 = new SemVer("2.7");
+    public static final SemVer v2_8 = new SemVer("2.8");
+    public static final SemVer v2_9 = new SemVer("2.9");
+    public static final SemVer v2_10 = new SemVer("2.10");
+    public static final SemVer v2_11 = new SemVer("2.11");
+    public static final SemVer v2_12 = new SemVer("2.12");
+    public static final SemVer v2_13 = new SemVer("2.13");
+    public static final SemVer v2_14 = new SemVer("2.14");
+    public static final SemVer v2_15 = new SemVer("2.15");
+    public static final SemVer v2_16 = new SemVer("2.16");
+    public static final SemVer v2_17 = new SemVer("2.17");
+    public static final SemVer v2_18 = new SemVer("2.18");
+
+    final private String version;
+
+    public final String get() {
+        return this.version;
+    }
+
+    public SemVer(String version) {
+        if(version == null)
+            throw new IllegalArgumentException("Version can not be null");
+        if(!version.matches("[0-9]+(\\.[0-9]+)*"))
+            throw new IllegalArgumentException("Invalid version format");
+        this.version = version;
+    }
+
+    @Override public int compareTo(SemVer that) {
+        if(that == null)
+            return 1;
+        String[] thisParts = this.get().split("\\.");
+        String[] thatParts = that.get().split("\\.");
+        int length = Math.max(thisParts.length, thatParts.length);
+        for(int i = 0; i < length; i++) {
+            int thisPart = i < thisParts.length ?
+                    Integer.parseInt(thisParts[i]) : 0;
+            int thatPart = i < thatParts.length ?
+                    Integer.parseInt(thatParts[i]) : 0;
+            if(thisPart < thatPart)
+                return -1;
+            if(thisPart > thatPart)
+                return 1;
+        }
+        return 0;
+    }
+
+    @Override public boolean equals(Object that) {
+        if(this == that)
+            return true;
+        if(that == null)
+            return false;
+
+        if(this.getClass() != that.getClass())
+            return false;
+        return this.compareTo((SemVer) that) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version);
+    }
+
+    @Override
+    public String toString() {
+        return version;
+    }
+}

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -22,6 +22,7 @@ import io.supertokens.config.Config;
 import io.supertokens.exceptions.QuitProgramException;
 import io.supertokens.featureflag.exceptions.FeatureNotEnabledException;
 import io.supertokens.output.Logging;
+import io.supertokens.utils.SemVer;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,26 +36,26 @@ public abstract class WebserverAPI extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
     protected final Main main;
-    public static final Set<String> supportedVersions = new HashSet<>();
+    public static final Set<SemVer> supportedVersions = new HashSet<>();
     private String rid;
 
     static {
-        supportedVersions.add("2.7");
-        supportedVersions.add("2.8");
-        supportedVersions.add("2.9");
-        supportedVersions.add("2.10");
-        supportedVersions.add("2.11");
-        supportedVersions.add("2.12");
-        supportedVersions.add("2.13");
-        supportedVersions.add("2.14");
-        supportedVersions.add("2.15");
-        supportedVersions.add("2.16");
-        supportedVersions.add("2.17");
-        supportedVersions.add("2.18");
+        supportedVersions.add(SemVer.v2_7);
+        supportedVersions.add(SemVer.v2_8);
+        supportedVersions.add(SemVer.v2_9);
+        supportedVersions.add(SemVer.v2_10);
+        supportedVersions.add(SemVer.v2_11);
+        supportedVersions.add(SemVer.v2_12);
+        supportedVersions.add(SemVer.v2_13);
+        supportedVersions.add(SemVer.v2_14);
+        supportedVersions.add(SemVer.v2_15);
+        supportedVersions.add(SemVer.v2_16);
+        supportedVersions.add(SemVer.v2_17);
+        supportedVersions.add(SemVer.v2_18);
     }
 
-    public static String getLatestCDIVersion() {
-        return "2.18";
+    public static SemVer getLatestCDIVersion() {
+        return SemVer.v2_18;
     }
 
     public WebserverAPI(Main main, String rid) {
@@ -116,7 +117,7 @@ public abstract class WebserverAPI extends HttpServlet {
         this.sendTextResponse(405, "Method not supported", resp);
     }
 
-    private void assertThatVersionIsCompatible(String version) throws ServletException {
+    private void assertThatVersionIsCompatible(SemVer version) throws ServletException {
         if (version == null) {
             throw new ServletException(new BadRequestException("cdi-version not provided"));
         }
@@ -157,7 +158,7 @@ public abstract class WebserverAPI extends HttpServlet {
                 assertThatAPIKeyCheckPasses(req.getHeader("api-key"));
             }
             if (this.versionNeeded(req)) {
-                String version = getVersionFromRequest(req);
+                SemVer version = getVersionFromRequest(req);
                 assertThatVersionIsCompatible(version);
                 Logging.info(main,
                         "API called: " + this.getPath() + ". Method: " + req.getMethod() + ". Version: " + version,
@@ -196,12 +197,12 @@ public abstract class WebserverAPI extends HttpServlet {
         return req.getHeader("rId");
     }
 
-    protected String getVersionFromRequest(HttpServletRequest req) {
+    protected SemVer getVersionFromRequest(HttpServletRequest req) {
         String version = req.getHeader("cdi-version");
         if (version == null) {
-            version = getLatestCDIVersion();
+            return getLatestCDIVersion();
         }
-        return version;
+        return new SemVer(version);
     }
 
     public static class BadRequestException extends Exception {

--- a/src/main/java/io/supertokens/webserver/api/core/ApiVersionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/core/ApiVersionAPI.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import io.supertokens.Main;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.WebserverAPI;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -47,8 +48,8 @@ public class ApiVersionAPI extends WebserverAPI {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         JsonObject result = new JsonObject();
         JsonArray versions = new JsonArray();
-        for (String s : WebserverAPI.supportedVersions) {
-            versions.add(new JsonPrimitive(s));
+        for (SemVer s : WebserverAPI.supportedVersions) {
+            versions.add(new JsonPrimitive(s.get()));
         }
         result.add("versions", versions);
         super.sendJsonResponse(200, result, resp);

--- a/src/main/java/io/supertokens/webserver/api/emailpassword/ResetPasswordAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/emailpassword/ResetPasswordAPI.java
@@ -26,6 +26,7 @@ import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicException;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import io.supertokens.utils.Utils;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.WebserverAPI;
@@ -81,9 +82,9 @@ public class ResetPasswordAPI extends WebserverAPI {
             JsonObject result = new JsonObject();
             result.addProperty("status", "OK");
 
-            if (!(super.getVersionFromRequest(req).equals("2.7") || super.getVersionFromRequest(req).equals("2.8")
-                    || super.getVersionFromRequest(req).equals("2.9") || super.getVersionFromRequest(req).equals("2.10")
-                    || super.getVersionFromRequest(req).equals("2.11"))) {
+            if (!(super.getVersionFromRequest(req).equals(SemVer.v2_7) || super.getVersionFromRequest(req).equals(SemVer.v2_8)
+                    || super.getVersionFromRequest(req).equals(SemVer.v2_9) || super.getVersionFromRequest(req).equals(SemVer.v2_10)
+                    || super.getVersionFromRequest(req).equals(SemVer.v2_11))) {
                 // >= 2.12
                 result.addProperty("userId", userId);
             }

--- a/src/main/java/io/supertokens/webserver/api/emailpassword/SignUpAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/emailpassword/SignUpAPI.java
@@ -70,9 +70,6 @@ public class SignUpAPI extends WebserverAPI {
             JsonObject result = new JsonObject();
             result.addProperty("status", "OK");
             JsonObject userJson = new JsonParser().parse(new Gson().toJson(user)).getAsJsonObject();
-            if (super.getVersionFromRequest(req).equals("2.4")) {
-                userJson.remove("timeJoined");
-            }
             result.add("user", userJson);
             super.sendJsonResponse(200, result, resp);
 

--- a/src/main/java/io/supertokens/webserver/api/emailpassword/UserAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/emailpassword/UserAPI.java
@@ -103,9 +103,6 @@ public class UserAPI extends WebserverAPI {
                 JsonObject result = new JsonObject();
                 result.addProperty("status", "OK");
                 JsonObject userJson = new JsonParser().parse(new Gson().toJson(user)).getAsJsonObject();
-                if (super.getVersionFromRequest(req).equals("2.4")) {
-                    userJson.remove("timeJoined");
-                }
                 result.add("user", userJson);
                 super.sendJsonResponse(200, result, resp);
             }

--- a/src/main/java/io/supertokens/webserver/api/session/HandshakeAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/HandshakeAPI.java
@@ -25,6 +25,7 @@ import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicException;
 import io.supertokens.session.accessToken.AccessTokenSigningKey;
 import io.supertokens.session.accessToken.AccessTokenSigningKey.KeyInfo;
+import io.supertokens.utils.SemVer;
 import io.supertokens.utils.Utils;
 import io.supertokens.webserver.WebserverAPI;
 
@@ -57,7 +58,7 @@ public class HandshakeAPI extends WebserverAPI {
             result.addProperty("jwtSigningPublicKeyExpiryTime",
                     AccessTokenSigningKey.getInstance(main).getKeyExpiryTime());
 
-            if (!super.getVersionFromRequest(req).equals("2.7") && !super.getVersionFromRequest(req).equals("2.8")) {
+            if (!super.getVersionFromRequest(req).equals(SemVer.v2_7) && !super.getVersionFromRequest(req).equals(SemVer.v2_8)) {
                 List<KeyInfo> keys = AccessTokenSigningKey.getInstance(main).getAllKeys();
                 JsonArray jwtSigningPublicKeyListJSON = Utils.keyListToJson(keys);
                 result.add("jwtSigningPublicKeyList", jwtSigningPublicKeyListJSON);

--- a/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
@@ -31,6 +31,7 @@ import io.supertokens.session.Session;
 import io.supertokens.session.accessToken.AccessTokenSigningKey;
 import io.supertokens.session.accessToken.AccessTokenSigningKey.KeyInfo;
 import io.supertokens.session.info.SessionInformationHolder;
+import io.supertokens.utils.SemVer;
 import io.supertokens.utils.Utils;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.WebserverAPI;
@@ -86,7 +87,7 @@ public class SessionAPI extends WebserverAPI {
             result.addProperty("jwtSigningPublicKeyExpiryTime",
                     AccessTokenSigningKey.getInstance(main).getKeyExpiryTime());
 
-            if (!super.getVersionFromRequest(req).equals("2.7") && !super.getVersionFromRequest(req).equals("2.8")) {
+            if (!super.getVersionFromRequest(req).equals(SemVer.v2_7) && !super.getVersionFromRequest(req).equals(SemVer.v2_8)) {
                 List<KeyInfo> keys = AccessTokenSigningKey.getInstance(main).getAllKeys();
                 JsonArray jwtSigningPublicKeyListJSON = Utils.keyListToJson(keys);
                 result.add("jwtSigningPublicKeyList", jwtSigningPublicKeyListJSON);

--- a/src/main/java/io/supertokens/webserver/api/session/VerifySessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/VerifySessionAPI.java
@@ -31,6 +31,7 @@ import io.supertokens.session.Session;
 import io.supertokens.session.accessToken.AccessTokenSigningKey;
 import io.supertokens.session.accessToken.AccessTokenSigningKey.KeyInfo;
 import io.supertokens.session.info.SessionInformationHolder;
+import io.supertokens.utils.SemVer;
 import io.supertokens.utils.Utils;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.WebserverAPI;
@@ -77,7 +78,7 @@ public class VerifySessionAPI extends WebserverAPI {
             result.addProperty("jwtSigningPublicKeyExpiryTime",
                     AccessTokenSigningKey.getInstance(main).getKeyExpiryTime());
 
-            if (!super.getVersionFromRequest(req).equals("2.7") && !super.getVersionFromRequest(req).equals("2.8")) {
+            if (!super.getVersionFromRequest(req).equals(SemVer.v2_7) && !super.getVersionFromRequest(req).equals(SemVer.v2_8)) {
                 List<KeyInfo> keys = AccessTokenSigningKey.getInstance(main).getAllKeys();
                 JsonArray jwtSigningPublicKeyListJSON = Utils.keyListToJson(keys);
                 result.add("jwtSigningPublicKeyList", jwtSigningPublicKeyListJSON);
@@ -103,8 +104,8 @@ public class VerifySessionAPI extends WebserverAPI {
                 reply.addProperty("jwtSigningPublicKeyExpiryTime",
                         AccessTokenSigningKey.getInstance(main).getKeyExpiryTime());
 
-                if (!super.getVersionFromRequest(req).equals("2.7")
-                        && !super.getVersionFromRequest(req).equals("2.8")) {
+                if (!super.getVersionFromRequest(req).equals(SemVer.v2_7)
+                        && !super.getVersionFromRequest(req).equals(SemVer.v2_8)) {
                     List<KeyInfo> keys = AccessTokenSigningKey.getInstance(main).getAllKeys();
                     JsonArray jwtSigningPublicKeyListJSON = Utils.keyListToJson(keys);
                     reply.add("jwtSigningPublicKeyList", jwtSigningPublicKeyListJSON);

--- a/src/main/java/io/supertokens/webserver/api/thirdparty/SignInUpAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/thirdparty/SignInUpAPI.java
@@ -25,6 +25,7 @@ import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.thirdparty.ThirdParty;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import io.supertokens.utils.Utils;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.WebserverAPI;
@@ -49,7 +50,7 @@ public class SignInUpAPI extends WebserverAPI {
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
-        if (super.getVersionFromRequest(req).equals("2.7")) {
+        if (super.getVersionFromRequest(req).equals(SemVer.v2_7)) {
             JsonObject input = InputParser.parseJsonObjectOrThrowError(req);
             String thirdPartyId = InputParser.parseStringOrThrowError(input, "thirdPartyId", false);
             String thirdPartyUserId = InputParser.parseStringOrThrowError(input, "thirdPartyUserId", false);

--- a/src/test/java/io/supertokens/test/APIKeysTest.java
+++ b/src/test/java/io/supertokens/test/APIKeysTest.java
@@ -163,7 +163,7 @@ public class APIKeysTest {
 
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), null);
+                    request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), null);
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 401
@@ -171,14 +171,14 @@ public class APIKeysTest {
         }
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 apiKey, "");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
 
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), "abd#%034t0g4in40t40v0j");
+                    request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "abd#%034t0g4in40t40v0j");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 401
@@ -201,14 +201,14 @@ public class APIKeysTest {
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 
         String response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/hello", null, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), "");
+                "http://localhost:3567/hello", null, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
         assertEquals(response, "Hello");
 
         // map to store pid as parameter
         Map<String, String> map = new HashMap<>();
         map.put("pid", ProcessHandle.current().pid() + "");
         JsonObject response2 = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/config", map, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), "");
+                "http://localhost:3567/config", map, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
 
         File f = new File(CLIOptions.get(process.getProcess()).getInstallationPath() + "config.yaml");
         String path = f.getAbsolutePath();
@@ -249,19 +249,19 @@ public class APIKeysTest {
 
         // check that any one of the keys can be used
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 apiKey1, "");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
 
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 apiKey2, "");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
 
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 apiKey3, "");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
@@ -269,7 +269,7 @@ public class APIKeysTest {
         // sending request with no api key
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), null);
+                    request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), null);
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 401
@@ -279,7 +279,7 @@ public class APIKeysTest {
         // sending request with invalid api key
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), "abd#%034t0g4in40t40v0j");
+                    request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "abd#%034t0g4in40t40v0j");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 401
@@ -321,28 +321,28 @@ public class APIKeysTest {
 
         // check that any one of the keys can be used
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 " " + apiKey1 + " ", "");
 
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
 
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 " " + apiKey2, "");
 
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
 
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 apiKey3, "");
 
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         checkSessionResponse(sessionInfo, process, userId, userDataInJWT);
 
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 apiKey4, "");
 
         assertEquals(sessionInfo.get("status").getAsString(), "OK");

--- a/src/test/java/io/supertokens/test/APITestsWithTrailingSlash.java
+++ b/src/test/java/io/supertokens/test/APITestsWithTrailingSlash.java
@@ -22,6 +22,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,7 +66,7 @@ public class APITestsWithTrailingSlash {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signup/", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
 
             assertEquals(response.get("status").getAsString(), "OK");
         }
@@ -78,7 +79,7 @@ public class APITestsWithTrailingSlash {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signup////////", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
 
             assertEquals(response.get("status").getAsString(), "OK");
         }
@@ -94,7 +95,7 @@ public class APITestsWithTrailingSlash {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signup/random", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                        SemVer.v2_16.get(), "emailpassword");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -124,7 +125,7 @@ public class APITestsWithTrailingSlash {
             requestBody.addProperty("role", role);
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/role/", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("createdNewRole").getAsBoolean());
@@ -141,7 +142,7 @@ public class APITestsWithTrailingSlash {
             requestBody.add("metadataUpdate", metadata);
             JsonObject resp = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/metadata/", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                    SemVer.v2_13.get(), "usermetadata");
 
             assertEquals("OK", resp.get("status").getAsString());
         }

--- a/src/test/java/io/supertokens/test/ApiVersionAPITest.java
+++ b/src/test/java/io/supertokens/test/ApiVersionAPITest.java
@@ -22,6 +22,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import io.supertokens.ProcessState;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.WebserverAPI;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -100,7 +101,7 @@ public class ApiVersionAPITest {
 
         // with setting cdi-version header
         apiVersionResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/apiversion", null, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), "");
+                "http://localhost:3567/apiversion", null, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
         assertNotNull(apiVersionResponse.getAsJsonArray("versions"));
         assertTrue(apiVersionResponse.getAsJsonArray("versions").size() >= 1);
 
@@ -120,10 +121,10 @@ public class ApiVersionAPITest {
         JsonObject apiVersionResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/apiversion", null, 1000, 1000, null, null, "");
 
-        Set<String> supportedVersions = WebserverAPI.supportedVersions;
+        Set<SemVer> supportedVersions = WebserverAPI.supportedVersions;
         JsonArray apiSupportedVersions = apiVersionResponse.getAsJsonArray("versions");
         for (int i = 0; i < supportedVersions.size(); i++) {
-            assertTrue(supportedVersions.contains(apiSupportedVersions.get(i).getAsString()));
+            assertTrue(supportedVersions.contains(new SemVer(apiSupportedVersions.get(i).getAsString())));
         }
         assertEquals(supportedVersions.size(), apiSupportedVersions.size());
         process.kill();

--- a/src/test/java/io/supertokens/test/AuthRecipeAPITest2_10.java
+++ b/src/test/java/io/supertokens/test/AuthRecipeAPITest2_10.java
@@ -24,6 +24,7 @@ import io.supertokens.pluginInterface.emailpassword.UserInfo;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.*;
 import org.junit.rules.TestRule;
 
@@ -61,7 +62,7 @@ public class AuthRecipeAPITest2_10 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/user/remove", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "");
+                    SemVer.v2_10.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.entrySet().size(), 1);
         }
@@ -74,7 +75,7 @@ public class AuthRecipeAPITest2_10 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/user/remove", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "");
+                    SemVer.v2_10.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.entrySet().size(), 1);
         }
@@ -100,7 +101,7 @@ public class AuthRecipeAPITest2_10 {
         try {
             JsonObject requestBody = new JsonObject();
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/user/remove",
-                    requestBody, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(), "");
+                    requestBody, 1000, 1000, null, SemVer.v2_10.get(), "");
         } catch (HttpResponseException e) {
             error = e;
         }

--- a/src/test/java/io/supertokens/test/AuthRecipeAPITest2_8.java
+++ b/src/test/java/io/supertokens/test/AuthRecipeAPITest2_8.java
@@ -23,6 +23,7 @@ import io.supertokens.pluginInterface.STORAGE_TYPE;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.thirdparty.ThirdParty;
+import io.supertokens.utils.SemVer;
 import org.junit.*;
 import org.junit.rules.TestRule;
 
@@ -58,7 +59,7 @@ public class AuthRecipeAPITest2_8 {
 
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/users/count", null, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "");
+                    "http://localhost:3567/users/count", null, 1000, 1000, null, SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 0);
         }
@@ -68,7 +69,7 @@ public class AuthRecipeAPITest2_8 {
 
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/users/count", null, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "");
+                    "http://localhost:3567/users/count", null, 1000, 1000, null, SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 2);
         }
@@ -76,7 +77,7 @@ public class AuthRecipeAPITest2_8 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users/count?includeRecipeIds=emailpassword", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), "");
+                    SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 2);
         }
@@ -84,7 +85,7 @@ public class AuthRecipeAPITest2_8 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users/count?includeRecipeIds=thirdparty", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), "");
+                    SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 0);
         }
@@ -97,7 +98,7 @@ public class AuthRecipeAPITest2_8 {
 
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/users/count", null, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "");
+                    "http://localhost:3567/users/count", null, 1000, 1000, null, SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 3);
         }
@@ -105,7 +106,7 @@ public class AuthRecipeAPITest2_8 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users/count?includeRecipeIds=emailpassword,thirdparty", null, 1000, 1000,
-                    null, Utils.getCdiVersion2_8ForTests(), "");
+                    null, SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 3);
         }
@@ -113,7 +114,7 @@ public class AuthRecipeAPITest2_8 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users/count?includeRecipeIds=emailpassword", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), "");
+                    SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 2);
         }
@@ -121,7 +122,7 @@ public class AuthRecipeAPITest2_8 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users/count?includeRecipeIds=thirdparty", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), "");
+                    SemVer.v2_8.get(), "");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 1);
         }
@@ -144,7 +145,7 @@ public class AuthRecipeAPITest2_8 {
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users/count?includeRecipeIds=thirdparty,random", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), "");
+                    SemVer.v2_8.get(), "");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -169,7 +170,7 @@ public class AuthRecipeAPITest2_8 {
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/users?includeRecipeIds=thirdparty,random", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), "");
+                    SemVer.v2_8.get(), "");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -178,7 +179,7 @@ public class AuthRecipeAPITest2_8 {
 
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/users?limit=-1", null,
-                    1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "");
+                    1000, 1000, null, SemVer.v2_8.get(), "");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -187,7 +188,7 @@ public class AuthRecipeAPITest2_8 {
 
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/users?limit=501",
-                    null, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "");
+                    null, 1000, 1000, null, SemVer.v2_8.get(), "");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -199,7 +200,7 @@ public class AuthRecipeAPITest2_8 {
             QueryParams.put("paginationToken", "randomString");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -238,7 +239,7 @@ public class AuthRecipeAPITest2_8 {
             HashMap<String, String> queryParams = new HashMap<>();
             queryParams.put("limit", "1");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/users", queryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                    "http://localhost:3567/users", queryParams, 1000, 1000, null, SemVer.v2_7.get(), "");
 
             Assert.assertEquals("OK", response.get("status").getAsString());
             assertNotNull(response.get("nextPaginationToken"));
@@ -259,7 +260,7 @@ public class AuthRecipeAPITest2_8 {
         // no params passed should return 5 users
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/users", new HashMap<>(), 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/users", new HashMap<>(), 1000, 1000, null, SemVer.v2_7.get(),
                     "");
             Assert.assertEquals(5, response.getAsJsonArray("users").size());
 

--- a/src/test/java/io/supertokens/test/ConfigAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/ConfigAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.cliOptions.CLIOptions;
 import io.supertokens.httpRequest.HttpRequest;
 import io.supertokens.httpRequest.HttpResponseException;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -94,7 +95,7 @@ public class ConfigAPITest2_7 {
         // null for parameters
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/config", null, 1000,
-                    1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                    1000, null, SemVer.v2_7.get(), "");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.getMessage()
@@ -107,7 +108,7 @@ public class ConfigAPITest2_7 {
             HashMap<String, String> map = new HashMap<>();
             map.put("pd", ProcessHandle.current().pid() + "");
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/config", map, 1000,
-                    1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                    1000, null, SemVer.v2_7.get(), "");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.getMessage()
@@ -158,7 +159,7 @@ public class ConfigAPITest2_7 {
 
         // check regular output
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/config", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                "http://localhost:3567/config", map, 1000, 1000, null, SemVer.v2_7.get(), "");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertEquals(response.get("path").getAsString(), path);
@@ -228,7 +229,7 @@ public class ConfigAPITest2_7 {
 
         // check regular output
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/config", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                "http://localhost:3567/config", map, 1000, 1000, null, SemVer.v2_7.get(), "");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertEquals(response.get("path").getAsString(), path);
@@ -239,7 +240,7 @@ public class ConfigAPITest2_7 {
         map.put("pid", "-1");
 
         response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/config", map,
-                1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "");
+                1000, 1000, null, SemVer.v2_7.get(), "");
 
         assertEquals(response.get("status").getAsString(), "NOT_ALLOWED");
         assertEquals(response.entrySet().size(), 1);

--- a/src/test/java/io/supertokens/test/FeatureFlagTest.java
+++ b/src/test/java/io/supertokens/test/FeatureFlagTest.java
@@ -103,7 +103,7 @@ public class FeatureFlagTest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/ee/featureflag",
-                null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion().get(), "");
         Assert.assertEquals("OK", response.get("status").getAsString());
         Assert.assertNotNull(response.get("features"));
         Assert.assertEquals(0, response.get("features").getAsJsonArray().size());

--- a/src/test/java/io/supertokens/test/SemVerTest.java
+++ b/src/test/java/io/supertokens/test/SemVerTest.java
@@ -1,0 +1,62 @@
+/*
+ *    Copyright (c) 2020, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test;
+
+import io.supertokens.utils.SemVer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+public class SemVerTest {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void betweenInclusive() {
+        assert(!SemVer.v2_7.betweenInclusive(SemVer.v2_8, SemVer.v2_10));
+        assert(SemVer.v2_8.betweenInclusive(SemVer.v2_8, SemVer.v2_10));
+        assert(SemVer.v2_9.betweenInclusive(SemVer.v2_8, SemVer.v2_10));
+        assert(SemVer.v2_10.betweenInclusive(SemVer.v2_8, SemVer.v2_10));
+        assert(!SemVer.v2_11.betweenInclusive(SemVer.v2_8, SemVer.v2_10));
+    }
+
+    @Test
+    public void greaterThanOrEqualTo() {
+        assert(!SemVer.v2_7.greaterThanOrEqualTo(SemVer.v2_8));
+        assert(SemVer.v2_8.greaterThanOrEqualTo(SemVer.v2_8));
+        assert(SemVer.v2_9.greaterThanOrEqualTo(SemVer.v2_8));
+    }
+
+    @Test
+    public void lesserThan() {
+        assert(SemVer.v2_7.lesserThan(SemVer.v2_8));
+        assert(!SemVer.v2_8.lesserThan(SemVer.v2_8));
+        assert(!SemVer.v2_9.lesserThan(SemVer.v2_8));
+    }
+}

--- a/src/test/java/io/supertokens/test/StorageTest.java
+++ b/src/test/java/io/supertokens/test/StorageTest.java
@@ -670,7 +670,7 @@ public class StorageTest {
 
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(), "session");
+                    request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "session");
             fail();
         } catch (HttpResponseException ex) {
             assertEquals(ex.statusCode, 500);
@@ -680,7 +680,7 @@ public class StorageTest {
         storage.setStorageLayerEnabled(true);
 
         JsonObject sessionCreated = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionLatestForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(),
                 "session");
 
         JsonObject jsonBody = new JsonObject();
@@ -693,7 +693,7 @@ public class StorageTest {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", jsonBody, 1000, 1000, null,
-                    Utils.getCdiVersionLatestForTests(), "session");
+                    Utils.getCdiVersionStringLatestForTests(), "session");
             fail();
         } catch (HttpResponseException ex) {
             assertEquals(ex.statusCode, 500);
@@ -704,7 +704,7 @@ public class StorageTest {
 
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", jsonBody, 1000, 1000, null,
-                Utils.getCdiVersionLatestForTests(), "session");
+                Utils.getCdiVersionStringLatestForTests(), "session");
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
@@ -762,7 +762,7 @@ public class StorageTest {
                             + "\"version\": \"nDVersion\"" + "}" + "}" + "}";
                     HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                             "http://localhost:3567/recipe/handshake", new JsonParser().parse(jsonInput), 10000, 20000,
-                            null, Utils.getCdiVersionLatestForTests(), "session");
+                            null, Utils.getCdiVersionStringLatestForTests(), "session");
                     success = true;
                     break;
                 } catch (Exception error) {

--- a/src/test/java/io/supertokens/test/TelemetryAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/TelemetryAPITest2_7.java
@@ -19,6 +19,7 @@ package io.supertokens.test;
 import com.google.gson.JsonObject;
 import io.supertokens.ProcessState;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import io.supertokens.version.Version;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -60,7 +61,7 @@ public class TelemetryAPITest2_7 {
         }
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, SemVer.v2_7.get(),
                 "");
         assertFalse(response.get("exists").getAsBoolean());
 
@@ -80,7 +81,7 @@ public class TelemetryAPITest2_7 {
         }
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, SemVer.v2_7.get(),
                 "");
         assertTrue(response.get("exists").getAsBoolean());
         assertNotNull(response.get("telemetryId"));
@@ -102,7 +103,7 @@ public class TelemetryAPITest2_7 {
         }
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, SemVer.v2_7.get(),
                 "");
         assertFalse(response.get("exists").getAsBoolean());
 
@@ -123,7 +124,7 @@ public class TelemetryAPITest2_7 {
         }
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/telemetry", new HashMap<>(), 1000, 1000, null, SemVer.v2_7.get(),
                 "");
         assertTrue(response.get("exists").getAsBoolean());
         assertNotNull(response.get("telemetryId"));

--- a/src/test/java/io/supertokens/test/Utils.java
+++ b/src/test/java/io/supertokens/test/Utils.java
@@ -25,6 +25,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.WebserverAPI;
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 import org.junit.rules.TestRule;
@@ -74,56 +75,8 @@ public abstract class Utils extends Mockito {
         }
     }
 
-    public static String getCdiVersion2_7ForTests() {
-        return "2.7";
-    }
-
-    public static String getCdiVersion2_8ForTests() {
-        return "2.8";
-    }
-
-    public static String getCdiVersion2_9ForTests() {
-        return "2.9";
-    }
-
-    public static String getCdiVersion2_10ForTests() {
-        return "2.10";
-    }
-
-    public static String getCdiVersion2_11ForTests() {
-        return "2.11";
-    }
-
-    public static String getCdiVersion2_12ForTests() {
-        return "2.12";
-    }
-
-    public static String getCdiVersion2_13ForTests() {
-        return "2.13";
-    }
-
-    public static String getCdiVersion2_14ForTests() {
-        return "2.14";
-    }
-
-    public static String getCdiVersion2_15ForTests() {
-        return "2.15";
-    }
-
-    public static String getCdiVersion2_16ForTests() {
-        return "2.16";
-    }
-
-    public static String getCdiVersion2_17ForTests() {
-        return "2.17";
-    }
-
-    public static String getCdiVersion2_18ForTests() {
-        return "2.18";
-    }
-
-    public static String getCdiVersionLatestForTests() {
-        return WebserverAPI.getLatestCDIVersion();
+    public static String getCdiVersionStringLatestForTests() {
+        return WebserverAPI.getLatestCDIVersion().get();
     }
 
     public static void reset() {
@@ -224,7 +177,7 @@ public abstract class Utils extends Mockito {
         signUpRequestBody.addProperty("password", password);
 
         return HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/signup", signUpRequestBody, 1000, 1000, null, getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/signup", signUpRequestBody, 1000, 1000, null, SemVer.v2_7.get(),
                 "emailpassword");
     }
 
@@ -236,7 +189,7 @@ public abstract class Utils extends Mockito {
         signUpRequestBody.addProperty("password", password);
 
         return HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/signup", signUpRequestBody, 1000, 1000, null, getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/signup", signUpRequestBody, 1000, 1000, null, SemVer.v2_7.get(),
                 "emailpassword");
     }
 
@@ -255,7 +208,7 @@ public abstract class Utils extends Mockito {
 
         return HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup", signUpRequestBody, 1000, 1000, null,
-                getCdiVersion2_7ForTests(), "thirdparty");
+                SemVer.v2_7.get(), "thirdparty");
     }
 
     public static JsonObject signInUpRequest_2_8(TestingProcessManager.TestingProcess process, String email,
@@ -272,7 +225,7 @@ public abstract class Utils extends Mockito {
 
         return HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup", signUpRequestBody, 1000, 1000, null,
-                getCdiVersion2_8ForTests(), "thirdparty");
+                SemVer.v2_8.get(), "thirdparty");
     }
 
     public static void checkThatArraysAreEqual(String[] arr1, String[] arr2) {

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -27,6 +27,7 @@ import io.supertokens.httpRequest.HttpResponseException;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager.TestingProcess;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.RecipeRouter;
 import io.supertokens.webserver.Webserver;
@@ -46,6 +47,7 @@ import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.SocketTimeoutException;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -93,25 +95,25 @@ public class WebserverTest extends Mockito {
             // get request
             String response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new HashMap<>(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "");
+                    SemVer.v2_7.get(), "");
             assertEquals("get request from Recipe1", response);
 
             // post request
             response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "");
+                    SemVer.v2_7.get(), "");
             assertEquals("post request from Recipe1", response);
 
             // put request
             response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "");
+                    SemVer.v2_7.get(), "");
             assertEquals("put request from Recipe1", response);
 
             // delete request
             response = HttpRequestForTesting.sendJsonDELETERequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "");
+                    SemVer.v2_7.get(), "");
             assertEquals("delete request from Recipe1", response);
 
         }
@@ -121,25 +123,25 @@ public class WebserverTest extends Mockito {
             // get request
             String response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new HashMap<>(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_1);
+                    SemVer.v2_7.get(), recipe_1);
             assertEquals("get request from Recipe1", response);
 
             // post request
             response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_1);
+                    SemVer.v2_7.get(), recipe_1);
             assertEquals("post request from Recipe1", response);
 
             // put request
             response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_1);
+                    SemVer.v2_7.get(), recipe_1);
             assertEquals("put request from Recipe1", response);
 
             // delete request
             response = HttpRequestForTesting.sendJsonDELETERequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_1);
+                    SemVer.v2_7.get(), recipe_1);
             assertEquals("delete request from Recipe1", response);
 
         }
@@ -148,22 +150,22 @@ public class WebserverTest extends Mockito {
         {
             String response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new HashMap<>(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_2);
+                    SemVer.v2_7.get(), recipe_2);
             assertEquals("get request from Recipe2", response);
 
             response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_2);
+                    SemVer.v2_7.get(), recipe_2);
             assertEquals("post request from Recipe2", response);
 
             response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_2);
+                    SemVer.v2_7.get(), recipe_2);
             assertEquals("put request from Recipe2", response);
 
             response = HttpRequestForTesting.sendJsonDELETERequest(process.getProcess(), "",
                     "http://localhost:3567/testRecipe", new JsonObject(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), recipe_2);
+                    SemVer.v2_7.get(), recipe_2);
             assertEquals("delete request from Recipe2", response);
         }
 
@@ -235,11 +237,12 @@ public class WebserverTest extends Mockito {
             }
         });
 
-        Object[] supportedVersions = WebserverAPI.supportedVersions.toArray();
+        SemVer[] supportedVersions = new SemVer[WebserverAPI.supportedVersions.size()];
+        supportedVersions = WebserverAPI.supportedVersions.toArray(supportedVersions);
         for (int i = 0; i < supportedVersions.length; i++) {
             String response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/testSupportedVersions", null, 1000, 1000, null,
-                    supportedVersions[i].toString(), "");
+                    supportedVersions[i].get(), "");
             assertEquals(response, "version supported");
         }
 
@@ -274,13 +277,13 @@ public class WebserverTest extends Mockito {
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp)
                     throws IOException, ServletException {
-                sendTextResponse(200, super.getVersionFromRequest(req), resp);
+                sendTextResponse(200, super.getVersionFromRequest(req).get(), resp);
             }
         });
 
         String response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/defaultVersion", null, 1000, 1000, null, null, "");
-        assertEquals(response, Utils.getCdiVersionLatestForTests());
+        assertEquals(response, Utils.getCdiVersionStringLatestForTests());
     }
 
     @Test

--- a/src/test/java/io/supertokens/test/authRecipe/DeleteUserAPIWithUserIdMappingTest.java
+++ b/src/test/java/io/supertokens/test/authRecipe/DeleteUserAPIWithUserIdMappingTest.java
@@ -31,6 +31,7 @@ import io.supertokens.thirdparty.ThirdParty;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
 import io.supertokens.usermetadata.UserMetadata;
+import io.supertokens.utils.SemVer;
 import junit.framework.TestCase;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -86,7 +87,7 @@ public class DeleteUserAPIWithUserIdMappingTest {
 
             JsonObject deleteResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/user/remove", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "");
+                    SemVer.v2_15.get(), "");
             assertEquals("OK", deleteResponse.get("status").getAsString());
 
             // check that user doesnt exist
@@ -147,7 +148,7 @@ public class DeleteUserAPIWithUserIdMappingTest {
 
             JsonObject deleteResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/user/remove", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", deleteResponse.get("status").getAsString());
 
         }
@@ -207,7 +208,7 @@ public class DeleteUserAPIWithUserIdMappingTest {
 
             JsonObject deleteResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/user/remove", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "thirdparty");
+                    SemVer.v2_15.get(), "thirdparty");
             assertEquals("OK", deleteResponse.get("status").getAsString());
 
         }

--- a/src/test/java/io/supertokens/test/authRecipe/GetUsersAPIWithUserIdMappingTest.java
+++ b/src/test/java/io/supertokens/test/authRecipe/GetUsersAPIWithUserIdMappingTest.java
@@ -28,6 +28,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -79,7 +80,7 @@ public class GetUsersAPIWithUserIdMappingTest {
         }
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/users", null, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(), null);
+                "http://localhost:3567/users", null, 1000, 1000, null, SemVer.v2_15.get(), null);
         assertEquals("OK", response.get("status").getAsString());
         JsonArray users = response.getAsJsonArray("users");
         assertEquals(10, users.size());
@@ -121,7 +122,7 @@ public class GetUsersAPIWithUserIdMappingTest {
         queryParams.put("limit", "10");
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/users", queryParams, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(), null);
+                "http://localhost:3567/users", queryParams, 1000, 1000, null, SemVer.v2_15.get(), null);
 
         assertEquals("OK", response.get("status").getAsString());
         JsonArray users = response.getAsJsonArray("users");
@@ -139,7 +140,7 @@ public class GetUsersAPIWithUserIdMappingTest {
         queryParams_2.put("paginationToken", paginationToken);
 
         JsonObject response_2 = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/users", queryParams_2, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                "http://localhost:3567/users", queryParams_2, 1000, 1000, null, SemVer.v2_15.get(),
                 null);
 
         assertEquals("OK", response_2.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/dashboard/DashboardTest.java
+++ b/src/test/java/io/supertokens/test/dashboard/DashboardTest.java
@@ -281,7 +281,7 @@ public class DashboardTest {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/ee/featureflag",
-                    null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                    null, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
             assertEquals(3, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(0, response.get("features").getAsJsonArray().size());
@@ -294,7 +294,7 @@ public class DashboardTest {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/ee/featureflag",
-                    null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                    null, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
             assertEquals(3, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(0, response.get("features").getAsJsonArray().size());
@@ -307,7 +307,7 @@ public class DashboardTest {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/ee/featureflag",
-                    null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                    null, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
             assertEquals(3, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(1, response.get("features").getAsJsonArray().size());
@@ -330,7 +330,7 @@ public class DashboardTest {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/ee/featureflag",
-                    null, 1000, 1000, null, WebserverAPI.getLatestCDIVersion(), "");
+                    null, 1000, 1000, null, Utils.getCdiVersionStringLatestForTests(), "");
             assertEquals(3, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(1, response.get("features").getAsJsonArray().size());

--- a/src/test/java/io/supertokens/test/dashboard/apis/CreateDashboardUserAPITests.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/CreateDashboardUserAPITests.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,7 +70,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -85,7 +86,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -102,7 +103,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -119,7 +120,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -135,7 +136,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -152,7 +153,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -169,7 +170,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -202,7 +203,7 @@ public class CreateDashboardUserAPITests {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 
@@ -255,7 +256,7 @@ public class CreateDashboardUserAPITests {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(1, response.entrySet().size());
         assertEquals("EMAIL_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
 
@@ -287,7 +288,7 @@ public class CreateDashboardUserAPITests {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(1, response.entrySet().size());
         assertEquals("INVALID_EMAIL_ERROR", response.get("status").getAsString());
 
@@ -315,7 +316,7 @@ public class CreateDashboardUserAPITests {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("PASSWORD_WEAK_ERROR", response.get("status").getAsString());
             assertEquals("Password must contain at least 8 characters, including a number",
@@ -330,7 +331,7 @@ public class CreateDashboardUserAPITests {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("PASSWORD_WEAK_ERROR", response.get("status").getAsString());
             assertEquals("Password must contain at least one alphabet",
@@ -345,7 +346,7 @@ public class CreateDashboardUserAPITests {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("PASSWORD_WEAK_ERROR", response.get("status").getAsString());
             assertEquals("Password must contain at least one number",
@@ -388,7 +389,7 @@ public class CreateDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", requestBody, 5000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 402 && e.getMessage().equals(

--- a/src/test/java/io/supertokens/test/dashboard/apis/DeleteDashboardUserAPITests.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/DeleteDashboardUserAPITests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,7 @@ public class DeleteDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -87,7 +88,7 @@ public class DeleteDashboardUserAPITests {
             try {
                 HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", inputParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -102,7 +103,7 @@ public class DeleteDashboardUserAPITests {
         try {
             HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/user", inputParams, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
             throw new Exception("Should never come here");
 
         } catch (HttpResponseException e) {
@@ -138,7 +139,7 @@ public class DeleteDashboardUserAPITests {
             inputParams.put("userId", user.userId);
             JsonObject response = HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", inputParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("didUserExist").getAsBoolean());            
@@ -150,7 +151,7 @@ public class DeleteDashboardUserAPITests {
             inputParams.put("userId", user.userId);
             JsonObject response = HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/user", inputParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didUserExist").getAsBoolean());  

--- a/src/test/java/io/supertokens/test/dashboard/apis/DeleteDashboardUserSessionAPITest.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/DeleteDashboardUserSessionAPITest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,7 @@ public class DeleteDashboardUserSessionAPITest {
             try {
                 HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/session", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        Utils.getCdiVersionStringLatestForTests(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -86,7 +87,7 @@ public class DeleteDashboardUserSessionAPITest {
             try {
                 HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/session", requestParams, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -134,7 +135,7 @@ public class DeleteDashboardUserSessionAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonDELETERequestWithQueryParams(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/session", requestParams, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/dashboard/apis/GetDashboardUserSessionsAPITest.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/GetDashboardUserSessionsAPITest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,7 +73,7 @@ public class GetDashboardUserSessionsAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user/sessions", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -87,7 +88,7 @@ public class GetDashboardUserSessionsAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user/sessions", requestParams, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -128,7 +129,7 @@ public class GetDashboardUserSessionsAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/user/sessions", requestParams, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/dashboard/apis/GetDashboardUsersAPITests.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/GetDashboardUsersAPITests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotNull;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -86,7 +87,7 @@ public class GetDashboardUsersAPITests {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/users", new HashMap<>(), 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 
@@ -136,7 +137,7 @@ public class GetDashboardUsersAPITests {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/users", new HashMap<>(), 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/dashboard/apis/SignInAPITest.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/SignInAPITest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,7 +76,7 @@ public class SignInAPITest {
         requestBody.addProperty("password", password);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/signin", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertNotNull(response.get("sessionId").getAsString());
@@ -122,7 +123,7 @@ public class SignInAPITest {
             requestBody.addProperty("password", "password123");
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/signin", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertNotNull(response.get("sessionId").getAsString());
@@ -135,7 +136,7 @@ public class SignInAPITest {
             requestBody.addProperty("password", password);
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/signin", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, response.entrySet().size());
             assertEquals("USER_SUSPENDED_ERROR", response.get("status").getAsString());
             assertEquals("User is currently suspended, please sign in with another account, or reactivate the SuperTokens core license key",

--- a/src/test/java/io/supertokens/test/dashboard/apis/UpdateUserAPITest.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/UpdateUserAPITest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -70,7 +71,7 @@ public class UpdateUserAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -87,7 +88,7 @@ public class UpdateUserAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", requestObject, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -103,7 +104,7 @@ public class UpdateUserAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", requestObject, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -119,7 +120,7 @@ public class UpdateUserAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", requestObject, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -135,7 +136,7 @@ public class UpdateUserAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", requestObject, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -151,7 +152,7 @@ public class UpdateUserAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/dashboard/user", requestObject, 1000, 1000, null,
-                        Utils.getCdiVersion2_18ForTests(), "dashboard");
+                        SemVer.v2_18.get(), "dashboard");
                 throw new Exception("Should never come here");
 
             } catch (HttpResponseException e) {
@@ -196,7 +197,7 @@ public class UpdateUserAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/user", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
 
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -213,7 +214,7 @@ public class UpdateUserAPITest {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/signin", signInResponseObject, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(1, signInResponse.entrySet().size());
             assertEquals("INVALID_CREDENTIALS_ERROR", signInResponse.get("status").getAsString());
         }
@@ -226,7 +227,7 @@ public class UpdateUserAPITest {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/dashboard/signin", signInResponseObject, 1000, 1000, null,
-                    Utils.getCdiVersion2_18ForTests(), "dashboard");
+                    SemVer.v2_18.get(), "dashboard");
             assertEquals(2, signInResponse.entrySet().size());
             assertEquals("OK", signInResponse.get("status").getAsString());
             assertNotNull(signInResponse.get("sessionId").getAsString());

--- a/src/test/java/io/supertokens/test/dashboard/apis/VerifySessionAPITest.java
+++ b/src/test/java/io/supertokens/test/dashboard/apis/VerifySessionAPITest.java
@@ -19,6 +19,7 @@ package io.supertokens.test.dashboard.apis;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,7 +75,7 @@ public class VerifySessionAPITest {
         requestBody.addProperty("sessionId", sessionId);
         JsonObject verifyResponse1 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/session/verify", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
         assertEquals(1, verifyResponse1.entrySet().size());
         assertEquals("OK", verifyResponse1.get("status").getAsString());
 
@@ -82,7 +83,7 @@ public class VerifySessionAPITest {
 
         JsonObject verifyResponse2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/dashboard/session/verify", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_18ForTests(), "dashboard");
+                SemVer.v2_18.get(), "dashboard");
 
         assertEquals(1, verifyResponse2.entrySet().size());
         assertEquals("INVALID_SESSION_ERROR", verifyResponse2.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/emailpassword/api/EmailPasswordGetUserAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/EmailPasswordGetUserAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class EmailPasswordGetUserAPITest2_7 {
         {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user",
-                        null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        null, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -77,7 +78,7 @@ public class EmailPasswordGetUserAPITest2_7 {
             map.put("email", "random@gmail.com");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user", map,
-                        1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -114,7 +115,7 @@ public class EmailPasswordGetUserAPITest2_7 {
             map.put("email", "random@gmail.com");
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                     "emailpassword");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.entrySet().size(), 2);
@@ -139,7 +140,7 @@ public class EmailPasswordGetUserAPITest2_7 {
             map.put("userId", signUpUser.get("id").getAsString());
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                     "emailpassword");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.entrySet().size(), 2);
@@ -173,7 +174,7 @@ public class EmailPasswordGetUserAPITest2_7 {
             map.put("email", "random@gmail.com");
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                     "emailpassword");
             assertEquals(response.get("status").getAsString(), "UNKNOWN_EMAIL_ERROR");
             assertEquals(response.entrySet().size(), 1);
@@ -184,7 +185,7 @@ public class EmailPasswordGetUserAPITest2_7 {
             map.put("userId", "randomId");
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                     "emailpassword");
             assertEquals(response.get("status").getAsString(), "UNKNOWN_USER_ID_ERROR");
             assertEquals(response.entrySet().size(), 1);

--- a/src/test/java/io/supertokens/test/emailpassword/api/EmailPasswordUsersAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/EmailPasswordUsersAPITest2_7.java
@@ -22,6 +22,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class EmailPasswordUsersAPITest2_7 {
             QueryParams.put("limit", "1001");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -76,7 +77,7 @@ public class EmailPasswordUsersAPITest2_7 {
             QueryParams.put("limit", "-1");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -90,7 +91,7 @@ public class EmailPasswordUsersAPITest2_7 {
             QueryParams.put("timeJoinedOrder", "AESC");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -103,7 +104,7 @@ public class EmailPasswordUsersAPITest2_7 {
             QueryParams.put("paginationToken", "randomString");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -116,7 +117,7 @@ public class EmailPasswordUsersAPITest2_7 {
             QueryParams.put("paginationToken", "cmFuZG9tU3RyaW5n");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -129,7 +130,7 @@ public class EmailPasswordUsersAPITest2_7 {
             QueryParams.put("paginationToken", "OWIxZGViNGQtM2I3ZC00YmFkLTliZGQtMmIwZDdiM2RjYjZkOzNzZHNkczQyMzQyMzQ=");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400

--- a/src/test/java/io/supertokens/test/emailpassword/api/EmailPasswordUsersCountAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/EmailPasswordUsersCountAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -60,7 +61,7 @@ public class EmailPasswordUsersCountAPITest2_7 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/count", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 0);
         }

--- a/src/test/java/io/supertokens/test/emailpassword/api/GenerateEmailVerificationTokenAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/GenerateEmailVerificationTokenAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class GenerateEmailVerificationTokenAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify/token", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -76,7 +77,7 @@ public class GenerateEmailVerificationTokenAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -90,7 +91,7 @@ public class GenerateEmailVerificationTokenAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -124,7 +125,7 @@ public class GenerateEmailVerificationTokenAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
 
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "OK");
@@ -159,7 +160,7 @@ public class GenerateEmailVerificationTokenAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailverification");
+                    SemVer.v2_7.get(), "emailverification");
 
             assertEquals(response.entrySet().size(), 2);
             assertEquals(response.get("status").getAsString(), "OK");
@@ -169,7 +170,7 @@ public class GenerateEmailVerificationTokenAPITest2_7 {
 
             JsonObject response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailverification");
+                    SemVer.v2_7.get(), "emailverification");
             assertEquals(response2.get("status").getAsString(), "EMAIL_ALREADY_VERIFIED_ERROR");
         }
 

--- a/src/test/java/io/supertokens/test/emailpassword/api/GeneratePasswordResetTokenAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/GeneratePasswordResetTokenAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -62,7 +63,7 @@ public class GeneratePasswordResetTokenAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset/token", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -75,7 +76,7 @@ public class GeneratePasswordResetTokenAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset/token", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -90,7 +91,7 @@ public class GeneratePasswordResetTokenAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset/token", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -124,7 +125,7 @@ public class GeneratePasswordResetTokenAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertNotNull(response.get("token"));
@@ -152,7 +153,7 @@ public class GeneratePasswordResetTokenAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "UNKNOWN_USER_ID_ERROR");
         assertEquals(response.entrySet().size(), 1);

--- a/src/test/java/io/supertokens/test/emailpassword/api/GetUsersByEmailAPITest2_8.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/GetUsersByEmailAPITest2_8.java
@@ -25,6 +25,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -83,7 +84,7 @@ public class GetUsersByEmailAPITest2_8 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/by-email", query, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), RECIPE_ID.THIRD_PARTY.toString());
+                    SemVer.v2_8.get(), RECIPE_ID.THIRD_PARTY.toString());
 
             // then
             JsonArray jsonUsers = response.get("users").getAsJsonArray();
@@ -134,7 +135,7 @@ public class GetUsersByEmailAPITest2_8 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/by-email", query, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), RECIPE_ID.THIRD_PARTY.toString());
+                    SemVer.v2_8.get(), RECIPE_ID.THIRD_PARTY.toString());
 
             JsonArray users = response.getAsJsonArray("users");
             JsonElement status = response.get("status");
@@ -171,7 +172,7 @@ public class GetUsersByEmailAPITest2_8 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/by-email", query, 1000, 1000, null,
-                    Utils.getCdiVersion2_8ForTests(), RECIPE_ID.THIRD_PARTY.toString());
+                    SemVer.v2_8.get(), RECIPE_ID.THIRD_PARTY.toString());
 
             JsonArray users = response.getAsJsonArray("users");
             JsonElement status = response.get("status");
@@ -206,7 +207,7 @@ public class GetUsersByEmailAPITest2_8 {
     private void testBadInput(TestingProcessManager.TestingProcess process, Map<String, String> query)
             throws Exception {
         HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users/by-email",
-                query, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(), RECIPE_ID.THIRD_PARTY.toString());
+                query, 1000, 1000, null, SemVer.v2_8.get(), RECIPE_ID.THIRD_PARTY.toString());
 
         throw new Exception("Request didn't throw as expected");
     }

--- a/src/test/java/io/supertokens/test/emailpassword/api/ImportUserWithPasswordHashAPITest.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/ImportUserWithPasswordHashAPITest.java
@@ -28,6 +28,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,7 +69,7 @@ public class ImportUserWithPasswordHashAPITest {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -81,7 +82,7 @@ public class ImportUserWithPasswordHashAPITest {
             JsonObject requestBody = new JsonObject();
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -93,7 +94,7 @@ public class ImportUserWithPasswordHashAPITest {
             JsonObject requestBody = new JsonObject();
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -106,7 +107,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("passwordHash", "somePasswordHash");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -119,7 +120,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("email", "test@example.com");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -133,7 +134,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("passwordHash", "");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -147,7 +148,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("passwordHash", "invalidPasswordHash");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -162,7 +163,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("hashingAlgorithm", "random");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -177,7 +178,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("hashingAlgorithm", "bcrypt");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -192,7 +193,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("hashingAlgorithm", "argon2");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -207,7 +208,7 @@ public class ImportUserWithPasswordHashAPITest {
             requestBody.addProperty("hashingAlgorithm", "firebase_scrypt");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -252,7 +253,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                SemVer.v2_16.get(), "emailpassword");
         assertEquals(signInResponse.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
 
         process.kill();
@@ -289,7 +290,7 @@ public class ImportUserWithPasswordHashAPITest {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", importUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 500
@@ -338,7 +339,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                SemVer.v2_16.get(), "emailpassword");
         assertEquals("WRONG_CREDENTIALS_ERROR", response.get("status").getAsString());
 
         process.kill();
@@ -381,7 +382,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/signin",
-                    signInRequestBody, 1000, 1000, null, Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    signInRequestBody, 1000, 1000, null, SemVer.v2_16.get(), "emailpassword");
             throw new Exception("Should not come here");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 500
@@ -424,7 +425,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                SemVer.v2_16.get(), "emailpassword");
 
         assertEquals("OK", response.get("status").getAsString());
         assertFalse(response.get("didUserAlreadyExist").getAsBoolean());
@@ -437,7 +438,7 @@ public class ImportUserWithPasswordHashAPITest {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             assertEquals("WRONG_CREDENTIALS_ERROR", signInResponse.get("status").getAsString());
         }
 
@@ -449,7 +450,7 @@ public class ImportUserWithPasswordHashAPITest {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             assertEquals("OK", signInResponse.get("status").getAsString());
             assertEquals(signInResponse.get("user").getAsJsonObject(), response.get("user").getAsJsonObject());
         }
@@ -479,7 +480,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                SemVer.v2_16.get(), "emailpassword");
 
         assertEquals("OK", response.get("status").getAsString());
         assertFalse(response.get("didUserAlreadyExist").getAsBoolean());
@@ -491,7 +492,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                SemVer.v2_16.get(), "emailpassword");
         assertEquals("OK", signInResponse.get("status").getAsString());
         assertEquals(signInResponse.get("user").getAsJsonObject(), response.get("user").getAsJsonObject());
 
@@ -527,7 +528,7 @@ public class ImportUserWithPasswordHashAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                SemVer.v2_16.get(), "emailpassword");
         assertEquals("OK", response.get("status").getAsString());
         assertTrue(response.get("didUserAlreadyExist").getAsBoolean());
 
@@ -566,7 +567,7 @@ public class ImportUserWithPasswordHashAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didUserAlreadyExist").getAsBoolean());
 
@@ -590,7 +591,7 @@ public class ImportUserWithPasswordHashAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didUserAlreadyExist").getAsBoolean());
 
@@ -627,7 +628,7 @@ public class ImportUserWithPasswordHashAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didUserAlreadyExist").getAsBoolean());
 
@@ -651,7 +652,7 @@ public class ImportUserWithPasswordHashAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/passwordhash/import", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_16ForTests(), "emailpassword");
+                    SemVer.v2_16.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didUserAlreadyExist").getAsBoolean());
 

--- a/src/test/java/io/supertokens/test/emailpassword/api/ResetPasswordAPITest2_12.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/ResetPasswordAPITest2_12.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -79,7 +80,7 @@ public class ResetPasswordAPITest2_12 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_12ForTests(), "emailpassword");
+                SemVer.v2_12.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertEquals(response.entrySet().size(), 2);
@@ -93,7 +94,7 @@ public class ResetPasswordAPITest2_12 {
 
         JsonObject passwordResetResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset", resetPasswordBody, 1000, 1000, null,
-                Utils.getCdiVersion2_12ForTests(), "emailpassword");
+                SemVer.v2_12.get(), "emailpassword");
         assertEquals(passwordResetResponse.get("status").getAsString(), "OK");
         assertEquals(passwordResetResponse.get("userId").getAsString(), userId);
         assertEquals(passwordResetResponse.entrySet().size(), 2);
@@ -104,7 +105,7 @@ public class ResetPasswordAPITest2_12 {
 
         response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_12ForTests(), "emailpassword");
+                SemVer.v2_12.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
         assertEquals(response.entrySet().size(), 1);
@@ -115,7 +116,7 @@ public class ResetPasswordAPITest2_12 {
 
         response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_12ForTests(), "emailpassword");
+                SemVer.v2_12.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertEquals(response.entrySet().size(), 2);

--- a/src/test/java/io/supertokens/test/emailpassword/api/ResetPasswordAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/ResetPasswordAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,7 @@ public class ResetPasswordAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -84,7 +85,7 @@ public class ResetPasswordAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -99,7 +100,7 @@ public class ResetPasswordAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -115,7 +116,7 @@ public class ResetPasswordAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -131,7 +132,7 @@ public class ResetPasswordAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/password/reset", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -167,7 +168,7 @@ public class ResetPasswordAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertEquals(response.entrySet().size(), 2);
@@ -181,7 +182,7 @@ public class ResetPasswordAPITest2_7 {
 
         JsonObject passwordResetResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset", resetPasswordBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
         assertEquals(passwordResetResponse.get("status").getAsString(), "OK");
         assertEquals(passwordResetResponse.entrySet().size(), 1);
 
@@ -191,7 +192,7 @@ public class ResetPasswordAPITest2_7 {
 
         response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
         assertEquals(response.entrySet().size(), 1);
@@ -202,7 +203,7 @@ public class ResetPasswordAPITest2_7 {
 
         response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signin", signInRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
 
         assertEquals(response.get("status").getAsString(), "OK");
         assertEquals(response.entrySet().size(), 2);
@@ -231,7 +232,7 @@ public class ResetPasswordAPITest2_7 {
 
         JsonObject passwordResetResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/password/reset", resetPasswordBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                SemVer.v2_7.get(), "emailpassword");
 
         assertEquals(passwordResetResponse.get("status").getAsString(), "RESET_PASSWORD_INVALID_TOKEN_ERROR");
         assertEquals(passwordResetResponse.entrySet().size(), 1);
@@ -261,7 +262,7 @@ public class ResetPasswordAPITest2_7 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/password/reset", resetPasswordBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
 
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -292,7 +293,7 @@ public class ResetPasswordAPITest2_7 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/password/reset", resetPasswordBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
 
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()

--- a/src/test/java/io/supertokens/test/emailpassword/api/SignInAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/SignInAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,7 @@ public class SignInAPITest2_7 {
         {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                        "http://localhost:3567/recipe/signin", null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                        "http://localhost:3567/recipe/signin", null, 1000, 1000, null, SemVer.v2_7.get(),
                         "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
@@ -86,7 +87,7 @@ public class SignInAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signin", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -99,7 +100,7 @@ public class SignInAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signin", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -134,7 +135,7 @@ public class SignInAPITest2_7 {
         responseBody.addProperty("password", "validPass123");
 
         JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null, SemVer.v2_7.get(),
                 "emailpassword");
 
         assertEquals(signInResponse.get("status").getAsString(), "OK");
@@ -174,7 +175,7 @@ public class SignInAPITest2_7 {
         responseBody.addProperty("password", "validPass123");
 
         JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null, SemVer.v2_7.get(),
                 "emailpassword");
 
         assertEquals(signInResponse.get("status").getAsString(), "OK");
@@ -210,7 +211,7 @@ public class SignInAPITest2_7 {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
 
             assertEquals(signInResponse.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
             assertEquals(signInResponse.entrySet().size(), 1);
@@ -223,7 +224,7 @@ public class SignInAPITest2_7 {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
 
             assertEquals(signInResponse.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
             assertEquals(signInResponse.entrySet().size(), 1);
@@ -236,7 +237,7 @@ public class SignInAPITest2_7 {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
 
             assertEquals(signInResponse.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
             assertEquals(signInResponse.entrySet().size(), 1);
@@ -253,7 +254,7 @@ public class SignInAPITest2_7 {
 
             JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                    SemVer.v2_7.get(), "emailpassword");
 
             assertEquals(signInResponse.get("status").getAsString(), "WRONG_CREDENTIALS_ERROR");
             assertEquals(signInResponse.entrySet().size(), 1);

--- a/src/test/java/io/supertokens/test/emailpassword/api/SignUpAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/SignUpAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,7 @@ public class SignUpAPITest2_7 {
         {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                        "http://localhost:3567/recipe/signup", null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                        "http://localhost:3567/recipe/signup", null, 1000, 1000, null, SemVer.v2_7.get(),
                         "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
@@ -86,7 +87,7 @@ public class SignUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -99,7 +100,7 @@ public class SignUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailpassword");
+                        SemVer.v2_7.get(), "emailpassword");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -141,7 +142,7 @@ public class SignUpAPITest2_7 {
         responseBody.addProperty("password", "validPass123");
 
         JsonObject signInResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/signin", responseBody, 1000, 1000, null, SemVer.v2_7.get(),
                 "emailpassword");
 
         assertEquals(signInResponse.get("status").getAsString(), "OK");

--- a/src/test/java/io/supertokens/test/emailpassword/api/UserPutAPITest2_8.java
+++ b/src/test/java/io/supertokens/test/emailpassword/api/UserPutAPITest2_8.java
@@ -25,6 +25,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +60,7 @@ public class UserPutAPITest2_8 {
             body.addProperty("email", "someemail@gmail.com");
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", body, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(),
+                    "http://localhost:3567/recipe/user", body, 1000, 1000, null, SemVer.v2_8.get(),
                     RECIPE_ID.EMAIL_PASSWORD.toString());
 
             assertEquals("UNKNOWN_USER_ID_ERROR", response.get("status").getAsString());
@@ -82,7 +83,7 @@ public class UserPutAPITest2_8 {
             body.addProperty("email", user2.email);
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", body, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(),
+                    "http://localhost:3567/recipe/user", body, 1000, 1000, null, SemVer.v2_8.get(),
                     RECIPE_ID.EMAIL_PASSWORD.toString());
 
             assertEquals("EMAIL_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
@@ -102,7 +103,7 @@ public class UserPutAPITest2_8 {
 
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/user",
-                        body, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(), RECIPE_ID.EMAIL_PASSWORD.toString());
+                        body, 1000, 1000, null, SemVer.v2_8.get(), RECIPE_ID.EMAIL_PASSWORD.toString());
 
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertEquals(400, e.statusCode);
@@ -126,7 +127,7 @@ public class UserPutAPITest2_8 {
             body.addProperty("email", "someOtherEmail@gmail.com");
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", body, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(),
+                    "http://localhost:3567/recipe/user", body, 1000, 1000, null, SemVer.v2_8.get(),
                     RECIPE_ID.EMAIL_PASSWORD.toString());
 
             assertEquals("OK", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/emailverification/api/IsEmailVerifiedAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailverification/api/IsEmailVerifiedAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class IsEmailVerifiedAPITest2_7 {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -79,7 +80,7 @@ public class IsEmailVerifiedAPITest2_7 {
 
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -115,7 +116,7 @@ public class IsEmailVerifiedAPITest2_7 {
 
         JsonObject verifyResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify", map, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
         assertEquals(verifyResponse.entrySet().size(), 2);
         assertEquals(verifyResponse.get("status").getAsString(), "OK");
         assertEquals(verifyResponse.get("isVerified").getAsBoolean(), false);
@@ -126,7 +127,7 @@ public class IsEmailVerifiedAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
 
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "OK");
@@ -138,7 +139,7 @@ public class IsEmailVerifiedAPITest2_7 {
 
         JsonObject response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify", verifyResponseBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
 
         assertEquals(response2.entrySet().size(), 3);
         assertEquals(response2.get("status").getAsString(), "OK");
@@ -148,7 +149,7 @@ public class IsEmailVerifiedAPITest2_7 {
 
         verifyResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify", map, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
         assertEquals(verifyResponse.entrySet().size(), 2);
         assertEquals(verifyResponse.get("status").getAsString(), "OK");
         assertTrue(verifyResponse.get("isVerified").getAsBoolean());

--- a/src/test/java/io/supertokens/test/emailverification/api/RevokeTokenAPITest2_8.java
+++ b/src/test/java/io/supertokens/test/emailverification/api/RevokeTokenAPITest2_8.java
@@ -25,6 +25,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -92,6 +93,6 @@ public class RevokeTokenAPITest2_8 {
     private JsonObject makeRequest(Main main, JsonObject body) throws IOException, HttpResponseException {
         return HttpRequestForTesting.sendJsonPOSTRequest(main, "",
                 "http://localhost:3567/recipe/user/email/verify/token/remove", body, 1000, 1000, null,
-                Utils.getCdiVersion2_8ForTests(), RECIPE_ID.EMAIL_VERIFICATION.toString());
+                SemVer.v2_8.get(), RECIPE_ID.EMAIL_VERIFICATION.toString());
     }
 }

--- a/src/test/java/io/supertokens/test/emailverification/api/UnverifyEmailAPITest2_8.java
+++ b/src/test/java/io/supertokens/test/emailverification/api/UnverifyEmailAPITest2_8.java
@@ -26,6 +26,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.*;
 import org.junit.rules.TestRule;
 
@@ -97,6 +98,6 @@ public class UnverifyEmailAPITest2_8 {
     private JsonObject unverifyEmail(Main main, JsonObject body) throws IOException, HttpResponseException {
         return HttpRequestForTesting.sendJsonPOSTRequest(main, "",
                 "http://localhost:3567/recipe/user/email/verify/remove", body, 1000, 1000, null,
-                Utils.getCdiVersion2_8ForTests(), RECIPE_ID.EMAIL_VERIFICATION.toString());
+                SemVer.v2_8.get(), RECIPE_ID.EMAIL_VERIFICATION.toString());
     }
 }

--- a/src/test/java/io/supertokens/test/emailverification/api/VerifyEmailAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/emailverification/api/VerifyEmailAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -61,7 +62,7 @@ public class VerifyEmailAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -74,7 +75,7 @@ public class VerifyEmailAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -89,7 +90,7 @@ public class VerifyEmailAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -124,7 +125,7 @@ public class VerifyEmailAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify/token", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
 
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "OK");
@@ -136,7 +137,7 @@ public class VerifyEmailAPITest2_7 {
 
         JsonObject response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/email/verify", verifyResponseBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "emailverification");
+                SemVer.v2_7.get(), "emailverification");
 
         assertEquals(response2.entrySet().size(), 3);
         assertEquals(response2.get("status").getAsString(), "OK");
@@ -169,7 +170,7 @@ public class VerifyEmailAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/email/verify", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "emailverification");
+                        SemVer.v2_7.get(), "emailverification");
                 throw new Exception("Should not have come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -185,7 +186,7 @@ public class VerifyEmailAPITest2_7 {
 
             JsonObject response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/email/verify", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "emailverification");
+                    SemVer.v2_7.get(), "emailverification");
             assertEquals(response2.get("status").getAsString(), "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR");
             assertEquals(response2.entrySet().size(), 1);
         }

--- a/src/test/java/io/supertokens/test/jwt/api/JWKSAPITest2_9.java
+++ b/src/test/java/io/supertokens/test/jwt/api/JWKSAPITest2_9.java
@@ -27,6 +27,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,10 +74,10 @@ public class JWKSAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/jwt",
-                requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "jwt");
+                requestBody, 1000, 1000, null, SemVer.v2_9.get(), "jwt");
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/jwks", null, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt/jwks", null, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         JsonArray keys = response.getAsJsonArray("keys");
@@ -103,7 +104,7 @@ public class JWKSAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject jwtResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         String jwt = jwtResponse.get("jwt").getAsString();
@@ -112,7 +113,7 @@ public class JWKSAPITest2_9 {
         String keyIdFromHeader = decodedJWT.getHeaderClaim("kid").asString();
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/jwks", null, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt/jwks", null, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         JsonArray keys = response.getAsJsonArray("keys");
@@ -150,7 +151,7 @@ public class JWKSAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject jwtResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         String jwt = jwtResponse.get("jwt").getAsString();
@@ -159,7 +160,7 @@ public class JWKSAPITest2_9 {
         String keyIdFromHeader = decodedJWT.getHeaderClaim("kid").asString();
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/jwks", null, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt/jwks", null, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         JsonArray keys = response.getAsJsonArray("keys");

--- a/src/test/java/io/supertokens/test/jwt/api/JWTSigningAPITest2_9.java
+++ b/src/test/java/io/supertokens/test/jwt/api/JWTSigningAPITest2_9.java
@@ -27,6 +27,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.api.jwt.JWTSigningAPI;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -71,7 +72,7 @@ public class JWTSigningAPITest2_9 {
 
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                     "jwt");
             fail();
         } catch (HttpResponseException e) {
@@ -100,7 +101,7 @@ public class JWTSigningAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
         assertEquals(response.get("status").getAsString(), JWTSigningAPI.UNSUPPORTED_ALGORITHM_ERROR_STATUS);
 
@@ -125,7 +126,7 @@ public class JWTSigningAPITest2_9 {
 
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                     "jwt");
             fail();
         } catch (HttpResponseException e) {
@@ -154,7 +155,7 @@ public class JWTSigningAPITest2_9 {
 
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/jwt",
-                    requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "jwt");
+                    requestBody, 1000, 1000, null, SemVer.v2_9.get(), "jwt");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -183,7 +184,7 @@ public class JWTSigningAPITest2_9 {
 
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/jwt",
-                    requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "jwt");
+                    requestBody, 1000, 1000, null, SemVer.v2_9.get(), "jwt");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -211,7 +212,7 @@ public class JWTSigningAPITest2_9 {
 
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                     "jwt");
             fail();
         } catch (HttpResponseException e) {
@@ -241,7 +242,7 @@ public class JWTSigningAPITest2_9 {
 
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                    "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                     "jwt");
             fail();
         } catch (HttpResponseException e) {
@@ -270,7 +271,7 @@ public class JWTSigningAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         assertEquals(response.get("status").getAsString(), "OK");
@@ -297,7 +298,7 @@ public class JWTSigningAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         String jwt = response.get("jwt").getAsString();
@@ -338,7 +339,7 @@ public class JWTSigningAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         String jwt = response.get("jwt").getAsString();
@@ -391,7 +392,7 @@ public class JWTSigningAPITest2_9 {
         requestBody.addProperty("validity", 3600);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/jwt", requestBody, 1000, 1000, null, SemVer.v2_9.get(),
                 "jwt");
 
         String jwt = response.get("jwt").getAsString();

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessConsumeCodeAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessConsumeCodeAPITest2_11.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 
 import com.google.gson.JsonObject;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,7 +72,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -91,7 +92,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -114,7 +115,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -136,7 +137,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -156,7 +157,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -176,7 +177,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -198,7 +199,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -218,7 +219,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -241,7 +242,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -264,7 +265,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException ex) {
                 error = ex;
             }
@@ -300,7 +301,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(response, true, email, null);
 
@@ -330,7 +331,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("RESTART_FLOW_ERROR", response.get("status").getAsString());
 
@@ -359,7 +360,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(response, true, email, null);
 
@@ -390,7 +391,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("EXPIRED_USER_INPUT_CODE_ERROR", response.get("status").getAsString());
 
@@ -422,7 +423,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
         {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("INCORRECT_USER_INPUT_CODE_ERROR", response.get("status").getAsString());
         }
@@ -430,7 +431,7 @@ public class PasswordlessConsumeCodeAPITest2_11 {
         {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("RESTART_FLOW_ERROR", response.get("status").getAsString());
         }

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessCreateCodeAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessCreateCodeAPITest2_11.java
@@ -25,6 +25,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(response);
 
@@ -91,7 +92,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(response, exampleCode);
 
@@ -115,7 +116,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
         checkResponse(response);
 
         process.kill();
@@ -139,7 +140,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(response, exampleCode);
 
@@ -163,14 +164,14 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject createResp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         JsonObject resendCodeRequestBody = new JsonObject();
         resendCodeRequestBody.addProperty("deviceId", createResp.get("deviceId").getAsString());
 
         JsonObject resendResp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", resendCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(resendResp);
 
@@ -195,7 +196,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject createResp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         JsonObject resendCodeRequestBody = new JsonObject();
         resendCodeRequestBody.addProperty("deviceId", createResp.get("deviceId").getAsString());
@@ -203,7 +204,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject resendResp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", resendCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         checkResponse(resendResp, exampleCode);
 
@@ -229,7 +230,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject createResp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         JsonObject resendCodeRequestBody = new JsonObject();
         resendCodeRequestBody.addProperty("deviceId", createResp.get("deviceId").getAsString());
@@ -237,7 +238,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject resendResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", resendCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("USER_INPUT_CODE_ALREADY_USED_ERROR", resendResponse.get("status").getAsString());
 
@@ -261,7 +262,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
 
         JsonObject resendResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code", resendCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("RESTART_FLOW_ERROR", resendResponse.get("status").getAsString());
 
@@ -289,7 +290,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -323,7 +324,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -357,7 +358,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -391,7 +392,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -429,7 +430,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -465,7 +466,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -497,7 +498,7 @@ public class PasswordlessCreateCodeAPITest2_11 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
         } catch (HttpResponseException ex) {
             error = ex;
         }

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessDeleteCodeAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessDeleteCodeAPITest2_11.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -76,7 +77,7 @@ public class PasswordlessDeleteCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code/remove", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -104,7 +105,7 @@ public class PasswordlessDeleteCodeAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/code/remove", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -134,7 +135,7 @@ public class PasswordlessDeleteCodeAPITest2_11 {
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code/remove", createCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
         } catch (HttpResponseException ex) {
             error = ex;

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessDeleteCodesAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessDeleteCodesAPITest2_11.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class PasswordlessDeleteCodesAPITest2_11 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes/remove", createCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -84,7 +85,7 @@ public class PasswordlessDeleteCodesAPITest2_11 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes/remove", createCodeRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -114,7 +115,7 @@ public class PasswordlessDeleteCodesAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/codes/remove", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -138,7 +139,7 @@ public class PasswordlessDeleteCodesAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/codes/remove", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -176,7 +177,7 @@ public class PasswordlessDeleteCodesAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/codes/remove", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -218,7 +219,7 @@ public class PasswordlessDeleteCodesAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/signinup/codes/remove", createCodeRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessGetCodesAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessGetCodesAPITest2_11.java
@@ -30,6 +30,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,7 +74,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -91,7 +92,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -110,7 +111,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -137,7 +138,7 @@ public class PasswordlessGetCodesAPITest2_11 {
         HashMap<String, String> map = new HashMap<>();
         map.put("deviceId", "nothing");
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null, SemVer.v2_10.get(),
                 "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
@@ -175,7 +176,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             map.put("preAuthSessionId", deviceIdHash);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(2, response.entrySet().size());
@@ -194,7 +195,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             map.put("preAuthSessionId", deviceIdHash);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(2, response.entrySet().size());
@@ -232,7 +233,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             map.put("email", email);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(2, response.entrySet().size());
@@ -251,7 +252,7 @@ public class PasswordlessGetCodesAPITest2_11 {
                 map.put("email", email);
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
 
                 assertEquals("OK", response.get("status").getAsString());
                 assertEquals(2, response.entrySet().size());
@@ -289,7 +290,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             map.put("phoneNumber", phoneNumber);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(2, response.entrySet().size());
@@ -308,7 +309,7 @@ public class PasswordlessGetCodesAPITest2_11 {
                 map.put("phoneNumber", phoneNumber);
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
 
                 assertEquals("OK", response.get("status").getAsString());
                 assertEquals(2, response.entrySet().size());
@@ -343,7 +344,7 @@ public class PasswordlessGetCodesAPITest2_11 {
             map.put("deviceId", deviceID);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(2, response.entrySet().size());
@@ -366,7 +367,7 @@ public class PasswordlessGetCodesAPITest2_11 {
                 map.put("deviceId", deviceID);
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup/codes", map, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
 
                 assertEquals("OK", response.get("status").getAsString());
                 assertEquals(2, response.entrySet().size());

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessUserGetAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessUserGetAPITest2_11.java
@@ -27,6 +27,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HttpResponseException error = null;
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user", map,
-                        1000, 1000, null, Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        1000, 1000, null, SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -85,7 +86,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HttpResponseException error = null;
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user", map,
-                        1000, 1000, null, Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        1000, 1000, null, SemVer.v2_10.get(), "passwordless");
             } catch (HttpResponseException e) {
                 error = e;
             }
@@ -99,7 +100,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HashMap<String, String> map = new HashMap<>();
             map.put("userId", "notExists");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                     "passwordless");
 
             assertEquals("UNKNOWN_USER_ID_ERROR", response.get("status").getAsString());
@@ -108,7 +109,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HashMap<String, String> map = new HashMap<>();
             map.put("email", "notExists");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                     "passwordless");
 
             assertEquals("UNKNOWN_EMAIL_ERROR", response.get("status").getAsString());
@@ -117,7 +118,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HashMap<String, String> map = new HashMap<>();
             map.put("phoneNumber", "notExists");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                     "passwordless");
 
             assertEquals("UNKNOWN_PHONE_NUMBER_ERROR", response.get("status").getAsString());
@@ -129,7 +130,7 @@ public class PasswordlessUserGetAPITest2_11 {
             Exception exception = null;
             try {
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                        "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                        "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                         "passwordless");
             } catch (Exception ex) {
                 exception = ex;
@@ -170,7 +171,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HashMap<String, String> map = new HashMap<>();
             map.put("userId", userIdEmail);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                     "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
@@ -180,7 +181,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HashMap<String, String> map = new HashMap<>();
             map.put("email", email);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                     "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());
@@ -195,7 +196,7 @@ public class PasswordlessUserGetAPITest2_11 {
             HashMap<String, String> map = new HashMap<>();
             map.put("phoneNumber", phoneNumber);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, Utils.getCdiVersion2_10ForTests(),
+                    "http://localhost:3567/recipe/user", map, 1000, 1000, null, SemVer.v2_10.get(),
                     "passwordless");
 
             assertEquals("OK", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/passwordless/api/PasswordlessUserPutAPITest2_11.java
+++ b/src/test/java/io/supertokens/test/passwordless/api/PasswordlessUserPutAPITest2_11.java
@@ -28,6 +28,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -78,7 +79,7 @@ public class PasswordlessUserPutAPITest2_11 {
             try {
                 JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_10ForTests(), "passwordless");
+                        SemVer.v2_10.get(), "passwordless");
             } catch (Exception e) {
                 ex = e;
             }
@@ -98,7 +99,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("UNKNOWN_USER_ID_ERROR", response.get("status").getAsString());
         }
@@ -110,7 +111,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("EMAIL_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
         }
@@ -122,7 +123,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
             assertEquals("PHONE_NUMBER_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
         }
@@ -156,7 +157,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -196,7 +197,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -238,7 +239,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -284,7 +285,7 @@ public class PasswordlessUserPutAPITest2_11 {
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
         } catch (Exception e) {
             ex = e;
@@ -330,7 +331,7 @@ public class PasswordlessUserPutAPITest2_11 {
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
         } catch (Exception e) {
             ex = e;
@@ -377,7 +378,7 @@ public class PasswordlessUserPutAPITest2_11 {
         try {
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_10ForTests(), "passwordless");
+                    SemVer.v2_10.get(), "passwordless");
 
         } catch (Exception e) {
             ex = e;
@@ -422,7 +423,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -462,7 +463,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -501,7 +502,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -542,7 +543,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 
@@ -582,7 +583,7 @@ public class PasswordlessUserPutAPITest2_11 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_10ForTests(), "passwordless");
+                SemVer.v2_10.get(), "passwordless");
 
         assertEquals("OK", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/session/api/HandshakeAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/HandshakeAPITest2_7.java
@@ -27,6 +27,7 @@ import io.supertokens.session.accessToken.AccessTokenSigningKey;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +60,7 @@ public class HandshakeAPITest2_7 {
         // null in request body with cdi-version set to 2.0
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/handshake", null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/handshake", null, 1000, 1000, null, SemVer.v2_7.get(),
                     "session");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -94,7 +95,7 @@ public class HandshakeAPITest2_7 {
 
         JsonObject handshakeResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", deviceDriverInfo, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         checkHandshakeAPIResponse(handshakeResponse, process);
         assertEquals(handshakeResponse.entrySet().size(), 6);
 
@@ -129,7 +130,7 @@ public class HandshakeAPITest2_7 {
 
         JsonObject handshakeResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", deviceDriverInfo, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         checkHandshakeAPIResponse(handshakeResponse, process);
         assertEquals(handshakeResponse.entrySet().size(), 6);
 
@@ -151,7 +152,7 @@ public class HandshakeAPITest2_7 {
                 + "\"version\": \"nDVersion\"" + "}" + "}" + "}";
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", new JsonParser().parse(jsonInput), 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.entrySet().size(), 6);
 
@@ -162,7 +163,7 @@ public class HandshakeAPITest2_7 {
 
         JsonObject changedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", new JsonParser().parse(jsonInput), 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(changedResponse.entrySet().size(), 6);
 

--- a/src/test/java/io/supertokens/test/session/api/HandshakeAPITest2_9.java
+++ b/src/test/java/io/supertokens/test/session/api/HandshakeAPITest2_9.java
@@ -28,6 +28,7 @@ import io.supertokens.session.accessToken.AccessTokenSigningKey.KeyInfo;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class HandshakeAPITest2_9 {
         // null in request body with cdi-version set to 2.0
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/handshake", null, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                    "http://localhost:3567/recipe/handshake", null, 1000, 1000, null, SemVer.v2_9.get(),
                     "session");
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -98,7 +99,7 @@ public class HandshakeAPITest2_9 {
 
         JsonObject handshakeResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", deviceDriverInfo, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
         checkHandshakeAPIResponse(handshakeResponse, process);
         assertEquals(handshakeResponse.entrySet().size(), 7);
 
@@ -133,7 +134,7 @@ public class HandshakeAPITest2_9 {
 
         JsonObject handshakeResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", deviceDriverInfo, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
         checkHandshakeAPIResponse(handshakeResponse, process);
         assertEquals(handshakeResponse.entrySet().size(), 7);
 
@@ -156,7 +157,7 @@ public class HandshakeAPITest2_9 {
                 + "\"version\": \"nDVersion\"" + "}" + "}" + "}";
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", new JsonParser().parse(jsonInput), 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(response.entrySet().size(), 7);
 
@@ -176,7 +177,7 @@ public class HandshakeAPITest2_9 {
 
         JsonObject changedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/handshake", new JsonParser().parse(jsonInput), 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(changedResponse.entrySet().size(), 7);
 

--- a/src/test/java/io/supertokens/test/session/api/JWTDataAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/JWTDataAPITest2_7.java
@@ -22,6 +22,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,7 +70,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
@@ -81,7 +82,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("sessionHandle", sessionHandle);
         request.add("userDataInJWT", newUserDataInJwt);
         JsonObject putJwtData = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(putJwtData.get("status").getAsString(), "OK");
 
@@ -90,7 +91,7 @@ public class JWTDataAPITest2_7 {
 
         // check this is reflected in db
         JsonObject getJwtData = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(getJwtData.get("status").getAsString(), "OK");
         assertEquals(getJwtData.get("userDataInJWT"), newUserDataInJwt);
@@ -124,7 +125,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
@@ -135,7 +136,7 @@ public class JWTDataAPITest2_7 {
 
         JsonObject putRequest = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/jwt/data", jwtPutRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(putRequest.get("status").getAsString(), "OK");
 
         HashMap<String, String> params = new HashMap<>();
@@ -143,7 +144,7 @@ public class JWTDataAPITest2_7 {
 
         // check that getData returns empty userDataInJwt
         JsonObject getJwtData = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(getJwtData.get("status").getAsString(), "OK");
         assertEquals(getJwtData.get("userDataInJWT").getAsJsonObject(), emptyJwtUserData);
@@ -178,7 +179,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
@@ -191,7 +192,7 @@ public class JWTDataAPITest2_7 {
 
         JsonObject sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", removeSessionBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(sessionRemovedResponse.get("status").getAsString(), "OK");
 
         // change JWT payload using API
@@ -202,7 +203,7 @@ public class JWTDataAPITest2_7 {
         request.add("userDataInJWT", newUserDataInJwt);
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
         assertEquals(response.get("message").getAsString(), "Session does not exist.");
@@ -238,7 +239,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
@@ -251,7 +252,7 @@ public class JWTDataAPITest2_7 {
 
         JsonObject sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", removeSessionBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(sessionRemovedResponse.get("status").getAsString(), "OK");
 
         // call get api
@@ -260,7 +261,7 @@ public class JWTDataAPITest2_7 {
         params.put("sessionHandle", sessionHandle);
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         // make sure you get unauthorised error
@@ -294,7 +295,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
@@ -306,7 +307,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("sessionHandle", sessionHandle);
         request.add("userDataInJWT", newUserDataInJwt);
         JsonObject putJwtData = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(putJwtData.get("status").getAsString(), "OK");
@@ -318,7 +319,7 @@ public class JWTDataAPITest2_7 {
 
         // check this is reflected in db
         JsonObject getJwtData = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/jwt/data", params, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(getJwtData.get("status").getAsString(), "OK");
         assertEquals(getJwtData.get("userDataInJWT").getAsJsonObject().get("key").getAsString(), "łukasz 馬 / 马 value2");
@@ -341,7 +342,7 @@ public class JWTDataAPITest2_7 {
 
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/jwt/data",
-                    invalidJsonObject, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    invalidJsonObject, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -351,7 +352,7 @@ public class JWTDataAPITest2_7 {
 
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/jwt/data",
-                    null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    null, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -373,7 +374,7 @@ public class JWTDataAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
@@ -382,7 +383,7 @@ public class JWTDataAPITest2_7 {
         invalidUserData.addProperty("sessionHandle", sessionHandle);
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/jwt/data",
-                    invalidUserData, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    invalidUserData, 1000, 1000, null, SemVer.v2_7.get(), "session");
 
             fail();
 

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_7.java
@@ -22,6 +22,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import io.supertokens.version.Version;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -69,7 +70,7 @@ public class RefreshSessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -93,7 +94,7 @@ public class RefreshSessionAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             checkRefreshSessionResponse(response, process, userId, userDataInJWT, true);
         }
@@ -124,7 +125,7 @@ public class RefreshSessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", true);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -148,7 +149,7 @@ public class RefreshSessionAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             checkRefreshSessionResponse(response, process, userId, userDataInJWT, false);
         }
@@ -168,7 +169,7 @@ public class RefreshSessionAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             assertEquals(response.entrySet().size(), 2);
             assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -190,7 +191,7 @@ public class RefreshSessionAPITest2_7 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals("Http error. Status Code: 400. Message: Invalid Json Input", e.getMessage());
@@ -206,7 +207,7 @@ public class RefreshSessionAPITest2_7 {
             jsonBody.addProperty("random", "random");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", jsonBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.getMessage(),
@@ -227,7 +228,7 @@ public class RefreshSessionAPITest2_7 {
             request.addProperty("enableAntiCsrf", false);
 
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                     "session");
             assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -238,7 +239,7 @@ public class RefreshSessionAPITest2_7 {
 
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.getMessage(),
@@ -259,7 +260,7 @@ public class RefreshSessionAPITest2_7 {
             request.addProperty("enableAntiCsrf", false);
 
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                    "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                     "session");
             assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -271,7 +272,7 @@ public class RefreshSessionAPITest2_7 {
 
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.getMessage(),
@@ -305,7 +306,7 @@ public class RefreshSessionAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", jsonBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -345,7 +346,7 @@ public class RefreshSessionAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", jsonBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -376,7 +377,7 @@ public class RefreshSessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -388,7 +389,7 @@ public class RefreshSessionAPITest2_7 {
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false);
         process.kill();
@@ -417,7 +418,7 @@ public class RefreshSessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", true);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -431,7 +432,7 @@ public class RefreshSessionAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             assertEquals(response.entrySet().size(), 2);
             assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -447,7 +448,7 @@ public class RefreshSessionAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             assertEquals(response.entrySet().size(), 2);
             assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -464,7 +465,7 @@ public class RefreshSessionAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             checkRefreshSessionResponse(response, process, userId, userDataInJWT, true);
         }
@@ -494,7 +495,7 @@ public class RefreshSessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -507,7 +508,7 @@ public class RefreshSessionAPITest2_7 {
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false);
         process.kill();
@@ -537,7 +538,7 @@ public class RefreshSessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -549,7 +550,7 @@ public class RefreshSessionAPITest2_7 {
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false);
         process.kill();

--- a/src/test/java/io/supertokens/test/session/api/SessionAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionAPITest2_7.java
@@ -21,6 +21,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class SessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", true);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         checkSessionResponse(response, process, userId, userDataInJWT);
@@ -97,7 +98,7 @@ public class SessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         checkSessionResponse(response, process, userId, userDataInJWT);
@@ -127,7 +128,7 @@ public class SessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         checkSessionResponse(response, process, userId, userDataInJWT);
         assertFalse(response.has("antiCsrfToken"));
@@ -155,7 +156,7 @@ public class SessionAPITest2_7 {
             request.add("userDataInJWT", userDataInJWT);
             request.add("userDataInDatabase", userDataInDatabase);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -169,7 +170,7 @@ public class SessionAPITest2_7 {
             request.add("userDataInDatabase", userDataInDatabase);
             request.addProperty("enableAntiCsrf", false);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -183,7 +184,7 @@ public class SessionAPITest2_7 {
             request.add("userDataInDatabase", userDataInDatabase);
             request.addProperty("enableAntiCsrf", "false");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -196,7 +197,7 @@ public class SessionAPITest2_7 {
             request.addProperty("userId", userId);
             request.add("userDataInDatabase", userDataInDatabase);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -210,7 +211,7 @@ public class SessionAPITest2_7 {
             request.add("userDataInJWT", userDataInJWT);
             request.addProperty("enableAntiCsrf", false);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -225,7 +226,7 @@ public class SessionAPITest2_7 {
         request.add("userDataInDatabase", userDataInDatabase);
         request.addProperty("enableAntiCsrf", false);
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                request, 1000, 1000, null, SemVer.v2_7.get(), "session");
 
         request = new JsonObject();
         request.addProperty("userId", userId);
@@ -233,7 +234,7 @@ public class SessionAPITest2_7 {
         request.add("userDataInDatabase", userDataInDatabase);
         request.addProperty("enableAntiCsrf", false);
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                request, 1000, 1000, null, SemVer.v2_7.get(), "session");
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));

--- a/src/test/java/io/supertokens/test/session/api/SessionAPITest2_9.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionAPITest2_9.java
@@ -23,6 +23,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,7 +70,7 @@ public class SessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", true);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_9.get(),
                 "session");
 
         checkSessionResponse(response, process, userId, userDataInJWT);
@@ -99,7 +100,7 @@ public class SessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_9.get(),
                 "session");
 
         checkSessionResponse(response, process, userId, userDataInJWT);
@@ -129,7 +130,7 @@ public class SessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_9.get(),
                 "session");
         checkSessionResponse(response, process, userId, userDataInJWT);
         assertFalse(response.has("antiCsrfToken"));
@@ -162,7 +163,7 @@ public class SessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_9.get(),
                 "session");
         checkSessionResponse(response, process, userId, userDataInJWT);
 
@@ -188,7 +189,7 @@ public class SessionAPITest2_9 {
             request.add("userDataInJWT", userDataInJWT);
             request.add("userDataInDatabase", userDataInDatabase);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -202,7 +203,7 @@ public class SessionAPITest2_9 {
             request.add("userDataInDatabase", userDataInDatabase);
             request.addProperty("enableAntiCsrf", false);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -216,7 +217,7 @@ public class SessionAPITest2_9 {
             request.add("userDataInDatabase", userDataInDatabase);
             request.addProperty("enableAntiCsrf", "false");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -229,7 +230,7 @@ public class SessionAPITest2_9 {
             request.addProperty("userId", userId);
             request.add("userDataInDatabase", userDataInDatabase);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -243,7 +244,7 @@ public class SessionAPITest2_9 {
             request.add("userDataInJWT", userDataInJWT);
             request.addProperty("enableAntiCsrf", false);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                    request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                    request, 1000, 1000, null, SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -258,7 +259,7 @@ public class SessionAPITest2_9 {
         request.add("userDataInDatabase", userDataInDatabase);
         request.addProperty("enableAntiCsrf", false);
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                request, 1000, 1000, null, SemVer.v2_9.get(), "session");
 
         request = new JsonObject();
         request.addProperty("userId", userId);
@@ -266,7 +267,7 @@ public class SessionAPITest2_9 {
         request.add("userDataInDatabase", userDataInDatabase);
         request.addProperty("enableAntiCsrf", false);
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "", "http://localhost:3567/recipe/session",
-                request, 1000, 1000, null, Utils.getCdiVersion2_9ForTests(), "session");
+                request, 1000, 1000, null, SemVer.v2_9.get(), "session");
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));

--- a/src/test/java/io/supertokens/test/session/api/SessionDataAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionDataAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +60,7 @@ public class SessionDataAPITest2_7 {
         // null is sent in parameters
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/session/data",
-                    null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    null, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -73,7 +74,7 @@ public class SessionDataAPITest2_7 {
 
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/session/data",
-                    map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    map, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -86,7 +87,7 @@ public class SessionDataAPITest2_7 {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/data", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400
@@ -101,7 +102,7 @@ public class SessionDataAPITest2_7 {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/data", jsonBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.getMessage().equals(
@@ -117,7 +118,7 @@ public class SessionDataAPITest2_7 {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/data", jsonBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -148,7 +149,7 @@ public class SessionDataAPITest2_7 {
         map.put("sessionHandle", "");
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/data", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/data", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -157,7 +158,7 @@ public class SessionDataAPITest2_7 {
 
         // Get request when session exists
         JsonObject session = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionBody, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionBody, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(session.get("status").getAsString(), "OK");
@@ -166,7 +167,7 @@ public class SessionDataAPITest2_7 {
         map.put("sessionHandle", session.get("session").getAsJsonObject().get("handle").getAsString());
 
         response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/data", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/data", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
@@ -204,7 +205,7 @@ public class SessionDataAPITest2_7 {
 
         JsonObject sessionDataResponse = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/data", putRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(sessionDataResponse.entrySet().size(), 2);
         assertEquals(sessionDataResponse.get("status").getAsString(), "UNAUTHORISED");
@@ -214,7 +215,7 @@ public class SessionDataAPITest2_7 {
 
         JsonObject session = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(sessionJsonInput), 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(session.get("status").getAsString(), "OK");
 
@@ -225,7 +226,7 @@ public class SessionDataAPITest2_7 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/data", putRequestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.entrySet().size(), 1);
         assertEquals(response.get("status").getAsString(), "OK");
@@ -234,7 +235,7 @@ public class SessionDataAPITest2_7 {
         map.put("sessionHandle", session.get("session").getAsJsonObject().get("handle").getAsString());
 
         response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/data", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/data", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(response.get("status").getAsString(), "OK");

--- a/src/test/java/io/supertokens/test/session/api/SessionGetAPIJWTTest2_8.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionGetAPIJWTTest2_8.java
@@ -24,6 +24,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -59,7 +60,7 @@ public class SessionGetAPIJWTTest2_8 {
         // null is sent in parameters
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/session", null,
-                    1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "session");
+                    1000, 1000, null, SemVer.v2_8.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -73,7 +74,7 @@ public class SessionGetAPIJWTTest2_8 {
 
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/session", map,
-                    1000, 1000, null, Utils.getCdiVersion2_8ForTests(), "session");
+                    1000, 1000, null, SemVer.v2_8.get(), "session");
             fail();
         } catch (HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -96,7 +97,7 @@ public class SessionGetAPIJWTTest2_8 {
         map.put("sessionHandle", "");
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", map, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(),
+                "http://localhost:3567/recipe/session", map, 1000, 1000, null, SemVer.v2_8.get(),
                 "session");
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
@@ -123,7 +124,7 @@ public class SessionGetAPIJWTTest2_8 {
 
         // Create session
         JsonObject session = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionBody, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(),
+                "http://localhost:3567/recipe/session", sessionBody, 1000, 1000, null, SemVer.v2_8.get(),
                 "session");
 
         assertEquals(session.get("status").getAsString(), "OK");
@@ -133,7 +134,7 @@ public class SessionGetAPIJWTTest2_8 {
         map.put("sessionHandle", session.get("session").getAsJsonObject().get("handle").getAsString());
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", map, 1000, 1000, null, Utils.getCdiVersion2_8ForTests(),
+                "http://localhost:3567/recipe/session", map, 1000, 1000, null, SemVer.v2_8.get(),
                 "session");
 
         // Validate response

--- a/src/test/java/io/supertokens/test/session/api/SessionRegenerateAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionRegenerateAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.session.accessToken.AccessToken;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class SessionRegenerateAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String accessToken = sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString();
@@ -84,7 +85,7 @@ public class SessionRegenerateAPITest2_7 {
 
         JsonObject sessionRegenerateResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/regenerate", sessionRegenerateRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(sessionRegenerateResponse.get("status").getAsString(), "OK");
 
@@ -130,7 +131,7 @@ public class SessionRegenerateAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String accessToken = sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString();
@@ -149,7 +150,7 @@ public class SessionRegenerateAPITest2_7 {
 
         JsonObject sessionRegenerateResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/regenerate", sessionRegenerateRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(sessionRegenerateResponse.get("status").getAsString(), "OK");
 
         // session object and all has new payload info
@@ -191,7 +192,7 @@ public class SessionRegenerateAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", request, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
         String accessToken = sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString();
@@ -204,7 +205,7 @@ public class SessionRegenerateAPITest2_7 {
 
         JsonObject sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", removeSessionBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(sessionRemovedResponse.get("status").getAsString(), "OK");
 
         // call regenerate API with new JWT payload
@@ -217,7 +218,7 @@ public class SessionRegenerateAPITest2_7 {
 
         JsonObject sessionRegenerateResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/regenerate", sessionRegenerateRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         // throws UNAUTHORISED response.
         assertEquals(sessionRegenerateResponse.get("status").getAsString(), "UNAUTHORISED");

--- a/src/test/java/io/supertokens/test/session/api/SessionRemoveAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionRemoveAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,25 +75,25 @@ public class SessionRemoveAPITest2_7 {
 
         // create session s1
         JsonObject s1Info = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(s1Info.get("status").getAsString(), "OK");
 
         // create session s2
         JsonObject s2Info = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(s2Info.get("status").getAsString(), "OK");
 
         // create session s3
         JsonObject s3Info = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(s3Info.get("status").getAsString(), "OK");
 
         // create session s4
         JsonObject s4Info = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(s4Info.get("status").getAsString(), "OK");
 
@@ -104,7 +105,7 @@ public class SessionRemoveAPITest2_7 {
         JsonObject sessionRemoveBody = new JsonParser().parse(sessionRemoveBodyString).getAsJsonObject();
         JsonObject sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", sessionRemoveBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         JsonArray revokedSessions = sessionRemovedResponse.getAsJsonArray("sessionHandlesRevoked");
 
         for (int i = 0; i < revokedSessions.size(); i++) {
@@ -122,7 +123,7 @@ public class SessionRemoveAPITest2_7 {
 
         sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", sessionRemoveBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         revokedSessions = sessionRemovedResponse.getAsJsonArray("sessionHandlesRevoked");
 
         // check that response should only contain s1 and s3 session handles
@@ -157,7 +158,7 @@ public class SessionRemoveAPITest2_7 {
 
         // create Session
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
@@ -168,7 +169,7 @@ public class SessionRemoveAPITest2_7 {
         // remove session using sessionHandle
         JsonObject sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", sessionRemoveBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(sessionRemovedResponse.get("status").getAsString(), "OK");
         assertEquals(sessionRemovedResponse.get("sessionHandlesRevoked").getAsJsonArray().size(), 1);
@@ -181,7 +182,7 @@ public class SessionRemoveAPITest2_7 {
 
         JsonObject userResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/user", userParams, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(userResponse.get("status").getAsString(), "OK");
         assertEquals(userResponse.get("sessionHandles").getAsJsonArray().size(), 0);
 
@@ -212,12 +213,12 @@ public class SessionRemoveAPITest2_7 {
 
         // create Session
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(sessionInfo.get("status").getAsString(), "OK");
 
         JsonObject session2Info = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, 2, SemVer.v2_7.get(),
                 "session");
         assertEquals(session2Info.get("status").getAsString(), "OK");
 
@@ -227,7 +228,7 @@ public class SessionRemoveAPITest2_7 {
 
         JsonObject sessionRemovedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", removeSessionBody, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(sessionRemovedResponse.get("status").getAsString(), "OK");
 
         assertEquals(sessionRemovedResponse.get("sessionHandlesRevoked").getAsJsonArray().size(), 2);
@@ -243,7 +244,7 @@ public class SessionRemoveAPITest2_7 {
 
         JsonObject userResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/user", userParams, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
         assertEquals(userResponse.get("status").getAsString(), "OK");
         assertEquals(userResponse.get("sessionHandles").getAsJsonArray().size(), 0);
 

--- a/src/test/java/io/supertokens/test/session/api/SessionUserAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionUserAPITest2_7.java
@@ -23,6 +23,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -57,7 +58,7 @@ public class SessionUserAPITest2_7 {
         // null is sent as the parameter
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/session/user",
-                    null, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    null, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -70,7 +71,7 @@ public class SessionUserAPITest2_7 {
 
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/session/user",
-                    map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                    map, 1000, 1000, null, SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertTrue(e.statusCode == 400 && e.getMessage()
@@ -98,7 +99,7 @@ public class SessionUserAPITest2_7 {
         map.put("userId", "");
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
@@ -108,14 +109,14 @@ public class SessionUserAPITest2_7 {
         JsonObject sessionCreatedResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session",
                 new JsonParser().parse(createSessionJsonInput).getAsJsonObject(), 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals("OK", sessionCreatedResponse.get("status").getAsString());
 
         map = new HashMap<>();
         map.put("userId", "UserID");
         response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
@@ -130,7 +131,7 @@ public class SessionUserAPITest2_7 {
         JsonObject sessionCreatedResponse1 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session",
                 new JsonParser().parse(createSessionJsonInput).getAsJsonObject(), 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(sessionCreatedResponse1.get("status").getAsString(), "OK");
 
@@ -138,12 +139,12 @@ public class SessionUserAPITest2_7 {
         JsonObject sessionCreatedResponse2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session",
                 new JsonParser().parse(createSessionJsonInput).getAsJsonObject(), 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(sessionCreatedResponse2.get("status").getAsString(), "OK");
 
         JsonObject multiResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals(multiResponse.get("status").getAsString(), "OK");
@@ -186,21 +187,21 @@ public class SessionUserAPITest2_7 {
         // session 1
         JsonObject user1Response1 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput1).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user1Response1.get("status").getAsString());
 
         // session 2
         JsonObject user1Response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput1).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user1Response2.get("status").getAsString());
 
         // session 3
         JsonObject user1Response3 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput1).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user1Response3.get("status").getAsString());
 
@@ -210,7 +211,7 @@ public class SessionUserAPITest2_7 {
 
         JsonObject user2Response1 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput2).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user2Response1.get("status").getAsString());
 
@@ -218,7 +219,7 @@ public class SessionUserAPITest2_7 {
 
         JsonObject user2Response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput2).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user2Response2.get("status").getAsString());
 
@@ -226,7 +227,7 @@ public class SessionUserAPITest2_7 {
 
         JsonObject user2Response3 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput2).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user2Response3.get("status").getAsString());
 
@@ -236,7 +237,7 @@ public class SessionUserAPITest2_7 {
 
         JsonObject user3Response1 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput3).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user3Response1.get("status").getAsString());
 
@@ -244,7 +245,7 @@ public class SessionUserAPITest2_7 {
 
         JsonObject user3Response2 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput3).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user3Response2.get("status").getAsString());
 
@@ -252,7 +253,7 @@ public class SessionUserAPITest2_7 {
 
         JsonObject user3Response3 = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", new JsonParser().parse(userJsonInput3).getAsJsonObject(), 1000,
-                1000, null, Utils.getCdiVersion2_7ForTests(), "session");
+                1000, null, SemVer.v2_7.get(), "session");
 
         assertEquals("OK", user3Response3.get("status").getAsString());
 
@@ -261,7 +262,7 @@ public class SessionUserAPITest2_7 {
         map.put("userId", "UserID1");
 
         JsonObject multiResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
 
         assertEquals("OK", multiResponse.get("status").getAsString());
@@ -278,7 +279,7 @@ public class SessionUserAPITest2_7 {
         map.put("userId", "UserID2");
 
         multiResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals("OK", multiResponse.get("status").getAsString());
 
@@ -293,7 +294,7 @@ public class SessionUserAPITest2_7 {
         map.put("userId", "UserID3");
 
         multiResponse = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(),
+                "http://localhost:3567/recipe/session/user", map, 1000, 1000, null, SemVer.v2_7.get(),
                 "session");
         assertEquals("OK", multiResponse.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/session/api/VerifySessionAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/session/api/VerifySessionAPITest2_7.java
@@ -22,6 +22,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,7 +66,7 @@ public class VerifySessionAPITest2_7 {
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -73,7 +74,7 @@ public class VerifySessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
 
@@ -110,7 +111,7 @@ public class VerifySessionAPITest2_7 {
         sessionRequest.addProperty("enableAntiCsrf", false);
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         JsonObject refreshRequest = new JsonObject();
         refreshRequest.addProperty("refreshToken",
@@ -118,7 +119,7 @@ public class VerifySessionAPITest2_7 {
         refreshRequest.addProperty("enableAntiCsrf", false);
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", refreshRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -126,7 +127,7 @@ public class VerifySessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
 
@@ -171,7 +172,7 @@ public class VerifySessionAPITest2_7 {
         sessionRequest.addProperty("enableAntiCsrf", false);
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         JsonObject refreshRequest = new JsonObject();
         refreshRequest.addProperty("refreshToken",
@@ -179,7 +180,7 @@ public class VerifySessionAPITest2_7 {
         refreshRequest.addProperty("enableAntiCsrf", false);
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", refreshRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -187,7 +188,7 @@ public class VerifySessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
 
@@ -233,7 +234,7 @@ public class VerifySessionAPITest2_7 {
         sessionRequest.addProperty("enableAntiCsrf", false);
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         String sessionRemoveBodyString = "{" + " sessionHandles : [ "
                 + sessionInfo.get("session").getAsJsonObject().get("handle").getAsString() + " ] " + "}";
@@ -241,7 +242,7 @@ public class VerifySessionAPITest2_7 {
 
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", deleteRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -249,7 +250,7 @@ public class VerifySessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
         assertEquals(response.get("message").getAsString(), "Either the session has ended or has been blacklisted");
@@ -276,7 +277,7 @@ public class VerifySessionAPITest2_7 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_7ForTests(), "session");
+                SemVer.v2_7.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "TRY_REFRESH_TOKEN");
         assertEquals(response.get("message").getAsString(), "io.supertokens.session.jwt.JWT$JWTException: Invalid JWT");
@@ -307,14 +308,14 @@ public class VerifySessionAPITest2_7 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("doAntiCsrfCheck", true);
             request.addProperty("enableAntiCsrf", true);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -330,7 +331,7 @@ public class VerifySessionAPITest2_7 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -338,7 +339,7 @@ public class VerifySessionAPITest2_7 {
             request.addProperty("doAntiCsrfCheck", true);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -354,7 +355,7 @@ public class VerifySessionAPITest2_7 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -363,7 +364,7 @@ public class VerifySessionAPITest2_7 {
             request.addProperty("enableAntiCsrf", "true");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -379,7 +380,7 @@ public class VerifySessionAPITest2_7 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -388,7 +389,7 @@ public class VerifySessionAPITest2_7 {
             request.addProperty("enableAntiCsrf", true);
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             assertEquals(response.get("status").getAsString(), "TRY_REFRESH_TOKEN");
             assertEquals(response.get("message").getAsString(), "anti-csrf check failed");
@@ -400,7 +401,7 @@ public class VerifySessionAPITest2_7 {
             request.addProperty("enableAntiCsrf", true);
             response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             assertEquals(response.get("status").getAsString(), "OK");
         }
 
@@ -412,7 +413,7 @@ public class VerifySessionAPITest2_7 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -421,7 +422,7 @@ public class VerifySessionAPITest2_7 {
             request.addProperty("enableAntiCsrf", true);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "session");
+                    SemVer.v2_7.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);

--- a/src/test/java/io/supertokens/test/session/api/VerifySessionAPITest2_9.java
+++ b/src/test/java/io/supertokens/test/session/api/VerifySessionAPITest2_9.java
@@ -24,6 +24,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,7 +69,7 @@ public class VerifySessionAPITest2_9 {
 
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -76,7 +77,7 @@ public class VerifySessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
 
@@ -122,7 +123,7 @@ public class VerifySessionAPITest2_9 {
         sessionRequest.addProperty("enableAntiCsrf", false);
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         JsonObject refreshRequest = new JsonObject();
         refreshRequest.addProperty("refreshToken",
@@ -130,7 +131,7 @@ public class VerifySessionAPITest2_9 {
         refreshRequest.addProperty("enableAntiCsrf", false);
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", refreshRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -138,7 +139,7 @@ public class VerifySessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
 
@@ -191,7 +192,7 @@ public class VerifySessionAPITest2_9 {
         sessionRequest.addProperty("enableAntiCsrf", false);
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         JsonObject refreshRequest = new JsonObject();
         refreshRequest.addProperty("refreshToken",
@@ -199,7 +200,7 @@ public class VerifySessionAPITest2_9 {
         refreshRequest.addProperty("enableAntiCsrf", false);
         sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", refreshRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -207,7 +208,7 @@ public class VerifySessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "OK");
 
@@ -262,7 +263,7 @@ public class VerifySessionAPITest2_9 {
         sessionRequest.addProperty("enableAntiCsrf", false);
         JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         String sessionRemoveBodyString = "{" + " sessionHandles : [ "
                 + sessionInfo.get("session").getAsJsonObject().get("handle").getAsString() + " ] " + "}";
@@ -270,7 +271,7 @@ public class VerifySessionAPITest2_9 {
 
         HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/remove", deleteRequest, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         JsonObject request = new JsonObject();
         request.addProperty("accessToken", sessionInfo.get("accessToken").getAsJsonObject().get("token").getAsString());
@@ -278,7 +279,7 @@ public class VerifySessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
         assertEquals(response.get("message").getAsString(), "Either the session has ended or has been blacklisted");
@@ -305,7 +306,7 @@ public class VerifySessionAPITest2_9 {
         request.addProperty("enableAntiCsrf", false);
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                Utils.getCdiVersion2_9ForTests(), "session");
+                SemVer.v2_9.get(), "session");
 
         assertEquals(response.get("status").getAsString(), "TRY_REFRESH_TOKEN");
         assertEquals(response.get("message").getAsString(), "io.supertokens.session.jwt.JWT$JWTException: Invalid JWT");
@@ -336,14 +337,14 @@ public class VerifySessionAPITest2_9 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("doAntiCsrfCheck", true);
             request.addProperty("enableAntiCsrf", true);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -359,7 +360,7 @@ public class VerifySessionAPITest2_9 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -367,7 +368,7 @@ public class VerifySessionAPITest2_9 {
             request.addProperty("doAntiCsrfCheck", true);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -383,7 +384,7 @@ public class VerifySessionAPITest2_9 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -392,7 +393,7 @@ public class VerifySessionAPITest2_9 {
             request.addProperty("enableAntiCsrf", "true");
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);
@@ -408,7 +409,7 @@ public class VerifySessionAPITest2_9 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -417,7 +418,7 @@ public class VerifySessionAPITest2_9 {
             request.addProperty("enableAntiCsrf", true);
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
 
             assertEquals(response.get("status").getAsString(), "TRY_REFRESH_TOKEN");
             assertEquals(response.get("message").getAsString(), "anti-csrf check failed");
@@ -429,7 +430,7 @@ public class VerifySessionAPITest2_9 {
             request.addProperty("enableAntiCsrf", true);
             response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
             assertEquals(response.get("status").getAsString(), "OK");
         }
 
@@ -441,7 +442,7 @@ public class VerifySessionAPITest2_9 {
             sessionRequest.addProperty("enableAntiCsrf", true);
             JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session", sessionRequest, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
 
             JsonObject request = new JsonObject();
             request.addProperty("accessToken",
@@ -450,7 +451,7 @@ public class VerifySessionAPITest2_9 {
             request.addProperty("enableAntiCsrf", true);
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/verify", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_9ForTests(), "session");
+                    SemVer.v2_9.get(), "session");
             fail();
         } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
             assertEquals(e.statusCode, 400);

--- a/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartyGetUserAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartyGetUserAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.thirdparty.ThirdParty;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -73,7 +74,7 @@ public class ThirdPartyGetUserAPITest2_7 {
         {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user",
-                        new HashMap<>(), 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        new HashMap<>(), 1000, 1000, null, SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -88,7 +89,7 @@ public class ThirdPartyGetUserAPITest2_7 {
             QueryParams.put("thirdPartyId", "testThirdPartId");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -103,7 +104,7 @@ public class ThirdPartyGetUserAPITest2_7 {
             QueryParams.put("thirdPartyUserId", "testThirdPartyUserId");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -142,7 +143,7 @@ public class ThirdPartyGetUserAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", QueryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals("OK", response.get("status").getAsString());
 
             JsonObject userInfo = response.get("user").getAsJsonObject();
@@ -157,7 +158,7 @@ public class ThirdPartyGetUserAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", QueryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals("OK", response.get("status").getAsString());
 
             JsonObject userInfo = response.get("user").getAsJsonObject();
@@ -187,7 +188,7 @@ public class ThirdPartyGetUserAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", QueryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals("UNKNOWN_USER_ID_ERROR", response.get("status").getAsString());
         }
 
@@ -199,7 +200,7 @@ public class ThirdPartyGetUserAPITest2_7 {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", QueryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals("UNKNOWN_THIRD_PARTY_USER_ERROR", response.get("status").getAsString());
         }
     }

--- a/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartySignInUpAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartySignInUpAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -129,7 +130,7 @@ public class ThirdPartySignInUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -150,7 +151,7 @@ public class ThirdPartySignInUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -166,7 +167,7 @@ public class ThirdPartySignInUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -202,7 +203,7 @@ public class ThirdPartySignInUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -217,7 +218,7 @@ public class ThirdPartySignInUpAPITest2_7 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400

--- a/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartySignInUpAPITest2_8.java
+++ b/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartySignInUpAPITest2_8.java
@@ -24,6 +24,7 @@ import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -129,7 +130,7 @@ public class ThirdPartySignInUpAPITest2_8 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", null, 1000, 1000, null,
-                        Utils.getCdiVersion2_8ForTests(), "thirdparty");
+                        SemVer.v2_8.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -150,7 +151,7 @@ public class ThirdPartySignInUpAPITest2_8 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_8ForTests(), "thirdparty");
+                        SemVer.v2_8.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -166,7 +167,7 @@ public class ThirdPartySignInUpAPITest2_8 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_8ForTests(), "thirdparty");
+                        SemVer.v2_8.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -202,7 +203,7 @@ public class ThirdPartySignInUpAPITest2_8 {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/signinup", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_8ForTests(), "thirdparty");
+                        SemVer.v2_8.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400

--- a/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartyUsersAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartyUsersAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.thirdparty.ThirdParty;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -75,7 +76,7 @@ public class ThirdPartyUsersAPITest2_7 {
             QueryParams.put("paginationToken", "randomValue");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400
@@ -87,7 +88,7 @@ public class ThirdPartyUsersAPITest2_7 {
             QueryParams.put("limit", "randomValue");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage()
@@ -100,7 +101,7 @@ public class ThirdPartyUsersAPITest2_7 {
             QueryParams.put("timeJoinedOrder", "randomValue");
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/users",
-                        QueryParams, 1000, 1000, null, Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                        QueryParams, 1000, 1000, null, SemVer.v2_7.get(), "thirdparty");
                 throw new Exception("Should not come here");
             } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -145,7 +146,7 @@ public class ThirdPartyUsersAPITest2_7 {
             queryParams.put("limit", "1");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users", queryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
 
             assertEquals("OK", response.get("status").getAsString());
             assertNotNull(response.get("nextPaginationToken"));
@@ -165,7 +166,7 @@ public class ThirdPartyUsersAPITest2_7 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users", new HashMap<>(), 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals(5, response.getAsJsonArray("users").size());
         }
 
@@ -175,7 +176,7 @@ public class ThirdPartyUsersAPITest2_7 {
             queryParams.put("limit", "2");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users", queryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals(2, response.getAsJsonArray("users").size());
 
             JsonObject user_1 = response.getAsJsonArray("users").get(0).getAsJsonObject();
@@ -195,7 +196,7 @@ public class ThirdPartyUsersAPITest2_7 {
             queryParams.put("timeJoinedOrder", "DESC");
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users", queryParams, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals(2, response.getAsJsonArray("users").size());
 
             JsonObject user_1 = response.getAsJsonArray("users").get(0).getAsJsonObject();

--- a/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartyUsersCountAPITest2_7.java
+++ b/src/test/java/io/supertokens/test/thirdparty/api/ThirdPartyUsersCountAPITest2_7.java
@@ -24,6 +24,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.thirdparty.ThirdParty;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,7 +70,7 @@ public class ThirdPartyUsersCountAPITest2_7 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/count", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 0);
         }
@@ -83,7 +84,7 @@ public class ThirdPartyUsersCountAPITest2_7 {
         {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/count", null, 1000, 1000, null,
-                    Utils.getCdiVersion2_7ForTests(), "thirdparty");
+                    SemVer.v2_7.get(), "thirdparty");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("count").getAsLong(), 5);
         }

--- a/src/test/java/io/supertokens/test/userIdMapping/api/CreateUserIdMappingAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/api/CreateUserIdMappingAPITest.java
@@ -33,6 +33,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.usermetadata.UserMetadata;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.WebserverAPI;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -74,7 +75,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -89,7 +90,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -106,7 +107,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -121,7 +122,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -136,7 +137,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -153,7 +154,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -169,7 +170,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -185,7 +186,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -203,7 +204,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -245,7 +246,7 @@ public class CreateUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertEquals(e.statusCode, 400);
@@ -263,7 +264,7 @@ public class CreateUserIdMappingAPITest {
             requestBody.addProperty("force", true);
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(response.get("status").getAsString(), "OK");
         }
         process.kill();
@@ -297,7 +298,7 @@ public class CreateUserIdMappingAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                SemVer.v2_15.get(), "useridmapping");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -335,7 +336,7 @@ public class CreateUserIdMappingAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                SemVer.v2_15.get(), "useridmapping");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("UNKNOWN_SUPERTOKENS_USER_ID_ERROR", response.get("status").getAsString());
@@ -364,7 +365,7 @@ public class CreateUserIdMappingAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                SemVer.v2_15.get(), "useridmapping");
 
         UserIdMappingStorage storage = StorageLayer.getUserIdMappingStorage(process.main);
 
@@ -409,7 +410,7 @@ public class CreateUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
 
             assertEquals(3, response.entrySet().size());
             assertEquals("USER_ID_MAPPING_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
@@ -426,7 +427,7 @@ public class CreateUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
 
             assertEquals(3, response.entrySet().size());
             assertEquals("USER_ID_MAPPING_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
@@ -446,7 +447,7 @@ public class CreateUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
 
             assertEquals(3, response.entrySet().size());
             assertEquals("USER_ID_MAPPING_ALREADY_EXISTS_ERROR", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userIdMapping/api/GetUserIdMappingAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/api/GetUserIdMappingAPITest.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.useridmapping.UserIdMapping;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class GetUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                        SemVer.v2_14.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -83,7 +84,7 @@ public class GetUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                        SemVer.v2_14.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -100,7 +101,7 @@ public class GetUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                        SemVer.v2_14.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -117,7 +118,7 @@ public class GetUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                        SemVer.v2_14.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -148,7 +149,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -161,7 +162,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -174,7 +175,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -210,7 +211,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
 
             assertEquals(4, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -227,7 +228,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
 
             assertEquals(4, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -246,7 +247,7 @@ public class GetUserIdMappingAPITest {
 
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                        SemVer.v2_14.get(), "useridmapping");
 
                 assertEquals(4, response.entrySet().size());
                 assertEquals("OK", response.get("status").getAsString());
@@ -263,7 +264,7 @@ public class GetUserIdMappingAPITest {
 
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                        SemVer.v2_14.get(), "useridmapping");
 
                 assertEquals(4, response.entrySet().size());
                 assertEquals("OK", response.get("status").getAsString());
@@ -303,7 +304,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
 
             assertEquals(4, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -319,7 +320,7 @@ public class GetUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                    SemVer.v2_14.get(), "useridmapping");
 
             assertEquals(4, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -356,7 +357,7 @@ public class GetUserIdMappingAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/userid/map", QUERY_PARAM, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "useridmapping");
+                SemVer.v2_14.get(), "useridmapping");
         assertEquals(3, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertEquals(superTokensUserId, response.get("superTokensUserId").getAsString());

--- a/src/test/java/io/supertokens/test/userIdMapping/api/RemoveUserIdMappingAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/api/RemoveUserIdMappingAPITest.java
@@ -31,6 +31,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.useridmapping.UserIdType;
 import io.supertokens.usermetadata.UserMetadata;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,7 +73,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -88,7 +89,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -103,7 +104,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -119,7 +120,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -135,7 +136,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -152,7 +153,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -183,7 +184,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didMappingExist").getAsBoolean());
@@ -197,7 +198,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didMappingExist").getAsBoolean());
@@ -211,7 +212,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("didMappingExist").getAsBoolean());
@@ -245,7 +246,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("didMappingExist").getAsBoolean());
@@ -267,7 +268,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("didMappingExist").getAsBoolean());
@@ -288,7 +289,7 @@ public class RemoveUserIdMappingAPITest {
 
                 JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 assertEquals(2, response.entrySet().size());
                 assertEquals("OK", response.get("status").getAsString());
                 assertTrue(response.get("didMappingExist").getAsBoolean());
@@ -308,7 +309,7 @@ public class RemoveUserIdMappingAPITest {
 
                 JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 assertEquals(2, response.entrySet().size());
                 assertEquals("OK", response.get("status").getAsString());
                 assertTrue(response.get("didMappingExist").getAsBoolean());
@@ -346,7 +347,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("didMappingExist").getAsBoolean());
@@ -367,7 +368,7 @@ public class RemoveUserIdMappingAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("didMappingExist").getAsBoolean());
@@ -410,7 +411,7 @@ public class RemoveUserIdMappingAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("Should not come here");
             } catch (HttpResponseException e) {
                 assertEquals(e.statusCode, 400);
@@ -426,7 +427,7 @@ public class RemoveUserIdMappingAPITest {
             request.addProperty("force", true);
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/map/remove", request, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(response.get("status").getAsString(), "OK");
         }
 

--- a/src/test/java/io/supertokens/test/userIdMapping/api/UpdateExternalUserIdInfoTest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/api/UpdateExternalUserIdInfoTest.java
@@ -28,6 +28,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -84,7 +85,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -102,7 +103,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -120,7 +121,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -138,7 +139,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -155,7 +156,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", response, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -173,7 +174,7 @@ public class UpdateExternalUserIdInfoTest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/userid/external-user-id-info", response, 1000, 1000, null,
-                        Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                        SemVer.v2_15.get(), "useridmapping");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -205,7 +206,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -219,7 +220,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -233,7 +234,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -246,7 +247,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
         }
@@ -287,7 +288,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
 
@@ -311,7 +312,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
 
@@ -358,7 +359,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
 
@@ -382,7 +383,7 @@ public class UpdateExternalUserIdInfoTest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                    SemVer.v2_15.get(), "useridmapping");
             assertEquals(1, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
 
@@ -423,7 +424,7 @@ public class UpdateExternalUserIdInfoTest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/userid/external-user-id-info", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_15ForTests(), "useridmapping");
+                SemVer.v2_15.get(), "useridmapping");
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/userIdMapping/recipe/EmailPasswordAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/recipe/EmailPasswordAPITest.java
@@ -30,6 +30,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -92,7 +93,7 @@ public class EmailPasswordAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signin", signUpRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalUserId, response.get("user").getAsJsonObject().get("id").getAsString());
         }
@@ -139,7 +140,7 @@ public class EmailPasswordAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/password/reset/token", passwordResetTokenBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
 
             passwordResetToken = response.get("token").getAsString();
@@ -155,7 +156,7 @@ public class EmailPasswordAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/password/reset", resetPasswordBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalUserId, response.get("userId").getAsString());
         }
@@ -195,7 +196,7 @@ public class EmailPasswordAPITest {
             queryParam.put("userId", externalUserId);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", queryParam, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalUserId, response.get("user").getAsJsonObject().get("id").getAsString());
         }
@@ -206,7 +207,7 @@ public class EmailPasswordAPITest {
             queryParam.put("email", email);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", queryParam, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalUserId, response.get("user").getAsJsonObject().get("id").getAsString());
         }
@@ -244,7 +245,7 @@ public class EmailPasswordAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "emailpassword");
+                    SemVer.v2_15.get(), "emailpassword");
             assertEquals("OK", response.get("status").getAsString());
         }
 

--- a/src/test/java/io/supertokens/test/userIdMapping/recipe/PasswordlessAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/recipe/PasswordlessAPITest.java
@@ -30,6 +30,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -100,7 +101,7 @@ public class PasswordlessAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup/code/consume", consumeCodeRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "passwordless");
+                    SemVer.v2_15.get(), "passwordless");
             assertEquals(response.get("status").getAsString(), "OK");
             assertEquals(response.get("user").getAsJsonObject().get("id").getAsString(), externalId);
 
@@ -161,7 +162,7 @@ public class PasswordlessAPITest {
             query.put("email", email);
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, SemVer.v2_15.get(),
                     "passwordless");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalId, response.get("user").getAsJsonObject().get("id").getAsString());
@@ -175,7 +176,7 @@ public class PasswordlessAPITest {
                 query.put("userId", superTokensUserId);
 
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                        "http://localhost:3567/recipe/user", query, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                        "http://localhost:3567/recipe/user", query, 1000, 1000, null, SemVer.v2_15.get(),
                         "passwordless");
                 assertEquals("OK", response.get("status").getAsString());
                 assertEquals(externalId, response.get("user").getAsJsonObject().get("id").getAsString());
@@ -187,7 +188,7 @@ public class PasswordlessAPITest {
                 query.put("userId", externalId);
 
                 JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                        "http://localhost:3567/recipe/user", query, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                        "http://localhost:3567/recipe/user", query, 1000, 1000, null, SemVer.v2_15.get(),
                         "passwordless");
                 assertEquals("OK", response.get("status").getAsString());
                 assertEquals(externalId, response.get("user").getAsJsonObject().get("id").getAsString());
@@ -239,7 +240,7 @@ public class PasswordlessAPITest {
             query.put("phoneNumber", phoneNumber);
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, SemVer.v2_15.get(),
                     "passwordless");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalId, response.get("user").getAsJsonObject().get("id").getAsString());
@@ -282,7 +283,7 @@ public class PasswordlessAPITest {
 
             JsonObject updateUserResponse = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user", updateUserRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "passwordless");
+                    SemVer.v2_15.get(), "passwordless");
             assertEquals(updateUserResponse.get("status").getAsString(), "OK");
 
             // check that user got updated

--- a/src/test/java/io/supertokens/test/userIdMapping/recipe/ThirdPartyAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/recipe/ThirdPartyAPITest.java
@@ -30,6 +30,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.thirdparty.ThirdParty;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -97,7 +98,7 @@ public class ThirdPartyAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/signinup", signInRequestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "thirdparty");
+                    SemVer.v2_15.get(), "thirdparty");
             assertEquals("OK", response.get("status").getAsString());
             assertEquals(externalUserId, response.get("user").getAsJsonObject().get("id").getAsString());
         }
@@ -144,7 +145,7 @@ public class ThirdPartyAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/users/by-email", query, 1000, 1000, null,
-                    Utils.getCdiVersion2_15ForTests(), "thirdparty");
+                    SemVer.v2_15.get(), "thirdparty");
             assertEquals("OK", response.get("status").getAsString());
 
             JsonArray users = response.get("users").getAsJsonArray();
@@ -185,7 +186,7 @@ public class ThirdPartyAPITest {
             query.put("userId", superTokensUserId);
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, SemVer.v2_15.get(),
                     "thirdparty");
 
             assertEquals("OK", response.get("status").getAsString());
@@ -227,7 +228,7 @@ public class ThirdPartyAPITest {
             query.put("thirdPartyUserId", thirdPartyUserId);
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, Utils.getCdiVersion2_15ForTests(),
+                    "http://localhost:3567/recipe/user", query, 1000, 1000, null, SemVer.v2_15.get(),
                     "thirdparty");
 
             assertEquals("OK", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userMetadata/api/GetUserMetadataAPITest2_13.java
+++ b/src/test/java/io/supertokens/test/userMetadata/api/GetUserMetadataAPITest2_13.java
@@ -33,6 +33,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.usermetadata.UserMetadata;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,7 +75,7 @@ public class GetUserMetadataAPITest2_13 {
         QueryParams.put("userId", userId);
         JsonObject resp = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata", QueryParams, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         assertEquals(2, resp.entrySet().size());
         assertEquals("OK", resp.get("status").getAsString());
@@ -114,7 +115,7 @@ public class GetUserMetadataAPITest2_13 {
         QueryParams.put("userId", userId);
         JsonObject resp = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata", QueryParams, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         assertEquals(2, resp.entrySet().size());
         assertEquals("OK", resp.get("status").getAsString());
@@ -155,7 +156,7 @@ public class GetUserMetadataAPITest2_13 {
         QueryParams.put("userId", userId);
         JsonObject resp = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata", QueryParams, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         assertEquals(2, resp.entrySet().size());
         assertEquals("OK", resp.get("status").getAsString());
@@ -183,7 +184,7 @@ public class GetUserMetadataAPITest2_13 {
         HttpResponseException error = null;
         try {
             HttpRequestForTesting.sendGETRequest(process.getProcess(), "", "http://localhost:3567/recipe/user/metadata",
-                    QueryParams, 1000, 1000, null, Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                    QueryParams, 1000, 1000, null, SemVer.v2_13.get(), "usermetadata");
         } catch (HttpResponseException ex) {
             error = ex;
         }

--- a/src/test/java/io/supertokens/test/userMetadata/api/RemoveUserMetadataAPITest2_13.java
+++ b/src/test/java/io/supertokens/test/userMetadata/api/RemoveUserMetadataAPITest2_13.java
@@ -33,6 +33,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.usermetadata.UserMetadata;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -72,7 +73,7 @@ public class RemoveUserMetadataAPITest2_13 {
         requestBody.addProperty("userId", userId);
         JsonObject resp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata/remove", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         // It should not throw
         assertEquals(1, resp.entrySet().size());
@@ -113,7 +114,7 @@ public class RemoveUserMetadataAPITest2_13 {
         requestBody.addProperty("userId", userId);
         JsonObject resp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata/remove", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         // It should not throw
         assertEquals(1, resp.entrySet().size());
@@ -155,7 +156,7 @@ public class RemoveUserMetadataAPITest2_13 {
         requestBody.addProperty("userId", userId);
         JsonObject resp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata/remove", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         // It should not throw
         assertEquals(1, resp.entrySet().size());
@@ -188,7 +189,7 @@ public class RemoveUserMetadataAPITest2_13 {
         try {
             HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/metadata/remove", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                    SemVer.v2_13.get(), "usermetadata");
         } catch (HttpResponseException ex) {
             error = ex;
         }

--- a/src/test/java/io/supertokens/test/userMetadata/api/SetUserMetadataAPITest2_13.java
+++ b/src/test/java/io/supertokens/test/userMetadata/api/SetUserMetadataAPITest2_13.java
@@ -27,6 +27,7 @@ import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.usermetadata.UserMetadata;
 
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -78,7 +79,7 @@ public class SetUserMetadataAPITest2_13 {
         requestBody.add("metadataUpdate", testMetadata);
         JsonObject resp = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         assertEquals(2, resp.entrySet().size());
         assertEquals("OK", resp.get("status").getAsString());
@@ -128,7 +129,7 @@ public class SetUserMetadataAPITest2_13 {
         requestBody.add("metadataUpdate", update);
         JsonObject resp = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/metadata", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                SemVer.v2_13.get(), "usermetadata");
 
         assertEquals(2, resp.entrySet().size());
         assertEquals("OK", resp.get("status").getAsString());
@@ -173,7 +174,7 @@ public class SetUserMetadataAPITest2_13 {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/metadata", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                    SemVer.v2_13.get(), "usermetadata");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -209,7 +210,7 @@ public class SetUserMetadataAPITest2_13 {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/metadata", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                    SemVer.v2_13.get(), "usermetadata");
         } catch (HttpResponseException ex) {
             error = ex;
         }
@@ -243,7 +244,7 @@ public class SetUserMetadataAPITest2_13 {
         try {
             HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/metadata", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_13ForTests(), "usermetadata");
+                    SemVer.v2_13.get(), "usermetadata");
         } catch (HttpResponseException ex) {
             error = ex;
         }

--- a/src/test/java/io/supertokens/test/userRoles/api/AddUserRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/AddUserRoleAPITest.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class AddUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -81,7 +82,7 @@ public class AddUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -97,7 +98,7 @@ public class AddUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -111,7 +112,7 @@ public class AddUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -126,7 +127,7 @@ public class AddUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -141,7 +142,7 @@ public class AddUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -179,7 +180,7 @@ public class AddUserRoleAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
 
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -199,7 +200,7 @@ public class AddUserRoleAPITest {
 
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
 
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -239,7 +240,7 @@ public class AddUserRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -272,7 +273,7 @@ public class AddUserRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/role", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals("UNKNOWN_ROLE_ERROR", response.get("status").getAsString());
         assertEquals(1, response.entrySet().size());

--- a/src/test/java/io/supertokens/test/userRoles/api/CreateRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/CreateRoleAPITest.java
@@ -26,6 +26,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,7 +66,7 @@ public class CreateRoleAPITest {
             // request body is empty
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/role",
-                        new JsonObject(), 1000, 1000, null, Utils.getCdiVersion2_14ForTests(), "userroles");
+                        new JsonObject(), 1000, 1000, null, SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -82,7 +83,7 @@ public class CreateRoleAPITest {
 
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/role",
-                        requestBody, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(), "userroles");
+                        requestBody, 1000, 1000, null, SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -98,7 +99,7 @@ public class CreateRoleAPITest {
 
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/role",
-                        requestBody, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(), "userroles");
+                        requestBody, 1000, 1000, null, SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -116,7 +117,7 @@ public class CreateRoleAPITest {
             requestBody.addProperty("role", 1);
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/role",
-                        requestBody, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(), "userroles");
+                        requestBody, 1000, 1000, null, SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -132,7 +133,7 @@ public class CreateRoleAPITest {
             requestBody.addProperty("role", "testRole");
             try {
                 HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "", "http://localhost:3567/recipe/role",
-                        requestBody, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(), "userroles");
+                        requestBody, 1000, 1000, null, SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -162,7 +163,7 @@ public class CreateRoleAPITest {
             requestBody.addProperty("role", role);
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/role", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertTrue(response.get("createdNewRole").getAsBoolean());
@@ -182,7 +183,7 @@ public class CreateRoleAPITest {
             requestBody.addProperty("role", role);
             JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/role", requestBody, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
             assertFalse(response.get("createdNewRole").getAsBoolean());
@@ -215,7 +216,7 @@ public class CreateRoleAPITest {
         String role = "testRole";
         requestBody.addProperty("role", role);
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/role", requestBody, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(),
+                "http://localhost:3567/recipe/role", requestBody, 1000, 1000, null, SemVer.v2_14.get(),
                 "userroles");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -250,7 +251,7 @@ public class CreateRoleAPITest {
         requestBody.addProperty("role", role);
 
         JsonObject response = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/role", requestBody, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(),
+                "http://localhost:3567/recipe/role", requestBody, 1000, 1000, null, SemVer.v2_14.get(),
                 "userroles");
 
         assertEquals(2, response.entrySet().size());

--- a/src/test/java/io/supertokens/test/userRoles/api/GetPermissionsForRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/GetPermissionsForRoleAPITest.java
@@ -26,6 +26,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class GetPermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -81,7 +82,7 @@ public class GetPermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -96,7 +97,7 @@ public class GetPermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -130,7 +131,7 @@ public class GetPermissionsForRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/permissions", QUERY_PARAM, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -161,7 +162,7 @@ public class GetPermissionsForRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/permissions", QUERY_PARAM, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("UNKNOWN_ROLE_ERROR", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userRoles/api/GetRolesAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/GetRolesAPITest.java
@@ -24,6 +24,7 @@ import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class GetRolesAPITest {
         // retrieve all created roles
 
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
-                "http://localhost:3567/recipe/roles", null, 1000, 1000, null, Utils.getCdiVersion2_14ForTests(),
+                "http://localhost:3567/recipe/roles", null, 1000, 1000, null, SemVer.v2_14.get(),
                 "userroles");
 
         assertEquals(2, response.entrySet().size());

--- a/src/test/java/io/supertokens/test/userRoles/api/GetRolesForPermissionAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/GetRolesForPermissionAPITest.java
@@ -26,6 +26,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class GetRolesForPermissionAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/permission/roles", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -82,7 +83,7 @@ public class GetRolesForPermissionAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/permission/roles", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -97,7 +98,7 @@ public class GetRolesForPermissionAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/permission/roles", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -137,7 +138,7 @@ public class GetRolesForPermissionAPITest {
             QUERY_PARAMS.put("permission", permission1);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/permission/roles", QUERY_PARAMS, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
 
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -153,7 +154,7 @@ public class GetRolesForPermissionAPITest {
             QUERY_PARAMS.put("permission", permission2);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/permission/roles", QUERY_PARAMS, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
 
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userRoles/api/GetUserRolesAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/GetUserRolesAPITest.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -69,7 +70,7 @@ public class GetUserRolesAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/roles", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -84,7 +85,7 @@ public class GetUserRolesAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/roles", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -124,7 +125,7 @@ public class GetUserRolesAPITest {
             QUERY_PARAMS.put("userId", userId);
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/roles", QUERY_PARAMS, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
 
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());
@@ -142,7 +143,7 @@ public class GetUserRolesAPITest {
 
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/user/roles", QUERY_PARAMS, 1000, 1000, null,
-                    Utils.getCdiVersion2_14ForTests(), "userroles");
+                    SemVer.v2_14.get(), "userroles");
 
             assertEquals(2, response.entrySet().size());
             assertEquals("OK", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userRoles/api/GetUsersForRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/GetUsersForRoleAPITest.java
@@ -26,6 +26,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,7 +68,7 @@ public class GetUsersForRoleAPITest {
             try {
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/users", new HashMap<>(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -82,7 +83,7 @@ public class GetUsersForRoleAPITest {
                 QUERY_PARAM.put("role", " ");
                 HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/users", QUERY_PARAM, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -119,7 +120,7 @@ public class GetUsersForRoleAPITest {
         QUERY_PARAM.put("role", role);
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/users", QUERY_PARAM, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
 
@@ -147,7 +148,7 @@ public class GetUsersForRoleAPITest {
         QUERY_PARAM.put("role", "unknownRole");
         JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/users", QUERY_PARAM, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
         assertEquals(1, response.entrySet().size());
         assertEquals("UNKNOWN_ROLE_ERROR", response.get("status").getAsString());
 

--- a/src/test/java/io/supertokens/test/userRoles/api/RemovePermissionsForRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/RemovePermissionsForRoleAPITest.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -68,7 +69,7 @@ public class RemovePermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions/remove", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -86,7 +87,7 @@ public class RemovePermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -104,7 +105,7 @@ public class RemovePermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -119,7 +120,7 @@ public class RemovePermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -135,7 +136,7 @@ public class RemovePermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -150,7 +151,7 @@ public class RemovePermissionsForRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals("Http error. Status Code: 400. Message:"
@@ -188,7 +189,7 @@ public class RemovePermissionsForRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -226,7 +227,7 @@ public class RemovePermissionsForRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
@@ -259,7 +260,7 @@ public class RemovePermissionsForRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/permissions/remove", requestBody, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("UNKNOWN_ROLE_ERROR", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userRoles/api/RemoveRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/RemoveRoleAPITest.java
@@ -27,6 +27,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,7 +67,7 @@ public class RemoveRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/remove", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -82,7 +83,7 @@ public class RemoveRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -98,7 +99,7 @@ public class RemoveRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -113,7 +114,7 @@ public class RemoveRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/role/remove", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -152,7 +153,7 @@ public class RemoveRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/remove", request, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertTrue(response.get("didRoleExist").getAsBoolean());
@@ -198,7 +199,7 @@ public class RemoveRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/role/remove", request, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());

--- a/src/test/java/io/supertokens/test/userRoles/api/RemoveUserRoleAPITest.java
+++ b/src/test/java/io/supertokens/test/userRoles/api/RemoveUserRoleAPITest.java
@@ -26,6 +26,7 @@ import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.userroles.UserRoles;
+import io.supertokens.utils.SemVer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -64,7 +65,7 @@ public class RemoveUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role/remove", new JsonObject(), 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -80,7 +81,7 @@ public class RemoveUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -97,7 +98,7 @@ public class RemoveUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -112,7 +113,7 @@ public class RemoveUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -128,7 +129,7 @@ public class RemoveUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -143,7 +144,7 @@ public class RemoveUserRoleAPITest {
             try {
                 HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                         "http://localhost:3567/recipe/user/role/remove", requestBody, 1000, 1000, null,
-                        Utils.getCdiVersion2_14ForTests(), "userroles");
+                        SemVer.v2_14.get(), "userroles");
                 throw new Exception("should not come here");
             } catch (HttpResponseException e) {
                 assertTrue(e.statusCode == 400 && e.getMessage().equals(
@@ -189,7 +190,7 @@ public class RemoveUserRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertTrue(response.get("didUserHaveRole").getAsBoolean());
@@ -227,7 +228,7 @@ public class RemoveUserRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
         assertEquals(2, response.entrySet().size());
         assertEquals("OK", response.get("status").getAsString());
         assertFalse(response.get("didUserHaveRole").getAsBoolean());
@@ -253,7 +254,7 @@ public class RemoveUserRoleAPITest {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/user/role/remove", request, 1000, 1000, null,
-                Utils.getCdiVersion2_14ForTests(), "userroles");
+                SemVer.v2_14.get(), "userroles");
 
         assertEquals(1, response.entrySet().size());
         assertEquals("UNKNOWN_ROLE_ERROR", response.get("status").getAsString());


### PR DESCRIPTION
## Summary of change

Adding/using a SemVer class instead of version strings. This will used in #566 to enable version ranges instead of equality checks for CDI versions

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

Existing tests should cover everything

## Documentation changes

N/A

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
