### PR TITLE
feat: make refresh api return unauthorised on AccessTokenPayloadError

### DIFF
--- a/src/main/java/io/supertokens/webserver/api/session/RefreshSessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/RefreshSessionAPI.java
@@ -71,9 +71,7 @@ public class RefreshSessionAPI extends WebserverAPI {
             super.sendJsonResponse(200, result, resp);
         } catch (StorageQueryException | StorageTransactionLogicException | UnsupportedJWTSigningAlgorithmException e) {
             throw new ServletException(e);
-        } catch(AccessTokenPayloadError e) {
-            throw new ServletException(new BadRequestException(e.getMessage()));
-        } catch (UnauthorisedException e) {
+        } catch (AccessTokenPayloadError | UnauthorisedException e) {
             Logging.debug(main, Utils.exceptionStacktraceToString(e));
             JsonObject reply = new JsonObject();
             reply.addProperty("status", "UNAUTHORISED");

--- a/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
@@ -78,7 +78,7 @@ public class SessionAPI extends WebserverAPI {
         JsonObject userDataInDatabase = InputParser.parseJsonObjectOrThrowError(input, "userDataInDatabase", false);
         assert userDataInDatabase != null;
 
-        boolean useStaticSigningKey = Config.getConfig(main).getAccessTokenSigningKeyDynamic();
+        boolean useStaticSigningKey = !Config.getConfig(main).getAccessTokenSigningKeyDynamic();
         if (version.greaterThanOrEqualTo(SemVer.v2_19)) {
             Boolean useDynamicSigningKey = InputParser.parseBooleanOrThrowError(input, "useDynamicSigningKey", true);
 

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_19.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_19.java
@@ -75,18 +75,13 @@ public class RefreshSessionAPITest2_19 {
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
 
-        HttpResponseException caught = null;
-        try {
-            HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+        JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
                     Utils.getCdiVersionStringLatestForTests(), "session");
-        } catch (HttpResponseException e) {
-            caught = e;
-        }
 
-        assertNotNull(caught);
-        Assert.assertEquals(caught.statusCode, 400);
-        Assert.assertEquals(caught.getMessage(), "Http error. Status Code: 400. Message:" + " The user payload contains protected field");
+        assertEquals(response.entrySet().size(), 2);
+        assertEquals(response.get("status").getAsString(), "UNAUTHORISED");
+        assertEquals(response.get("message").getAsString(), "The user payload contains protected field");
     }
 
     @Test


### PR DESCRIPTION
## Summary of change

make refresh api return unauthorised on AccessTokenPayloadError

## Related issues

- 

## Test Plan

Updated existing test

## Documentation changes

N/A

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
