### PR TITLE
fix: Multitenant user id mapping tests

### DIFF
--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -551,7 +551,12 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
             Main main, AppIdentifier appIdentifier, String userId,
             UserIdType userIdType) throws StorageQueryException, TenantOrAppNotFoundException, UnknownUserIdException {
 
-        Storage[] storages = getStoragesForApp(main, appIdentifier);
+        Storage[] storages;
+        if (appIdentifier instanceof AppIdentifierWithStorage) {
+            storages = ((AppIdentifierWithStorage) appIdentifier).getStorages();
+        } else {
+            storages = getStoragesForApp(main, appIdentifier);
+        }
 
         if (storages.length == 0) {
             throw new TenantOrAppNotFoundException(appIdentifier);

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -543,7 +543,7 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
         throw new UnknownUserIdException();
     }
 
-    public static AppIdentifierWithStorageAndUserIdMapping getAppIdentifierWithStorageAndUserIdMappingForUser(
+    public static AppIdentifierWithStorageAndUserIdMapping getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
             Main main, AppIdentifier appIdentifier, Storage priorityStorage, String userId,
             UserIdType userIdType) throws StorageQueryException, TenantOrAppNotFoundException, UnknownUserIdException {
 
@@ -552,7 +552,10 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
         if (storages.length == 0) {
             throw new TenantOrAppNotFoundException(appIdentifier);
         }
-        if (priorityStorage != null) {
+
+        // We look for userId in the priorityStorage first just in case multiple storages have the mapping, we
+        // return the mapping from the storage of the tenant from which the request came from.
+        {
             UserIdMapping mapping = io.supertokens.useridmapping.UserIdMapping.getUserIdMapping(
                     appIdentifier.withStorage(priorityStorage),
                     userId, userIdType);

--- a/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
+++ b/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
@@ -57,7 +57,7 @@ public class UserIdMapping {
         try { // with supertokens id
             AppIdentifierWithStorageAndUserIdMapping mappingAndStorage =
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                    main, appIdentifierWithStorage, superTokensUserId, UserIdType.ANY);
+                    main, appIdentifierWithStorage, superTokensUserId, UserIdType.SUPERTOKENS);
             if (mappingAndStorage.userIdMapping != null) {
                 throw new UserIdMappingAlreadyExistsException(
                         superTokensUserId == mappingAndStorage.userIdMapping.superTokensUserId,

--- a/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
+++ b/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
@@ -62,8 +62,8 @@ public class UserIdMapping {
         // race condition is fixed.
         try { // with external id
             AppIdentifierWithStorageAndUserIdMapping mappingAndStorage =
-                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            main, appIdentifierWithStorage, null, externalUserId, UserIdType.EXTERNAL);
+                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                            main, appIdentifierWithStorage, appIdentifierWithStorage.getStorage(), externalUserId, UserIdType.EXTERNAL);
 
             assert(mappingAndStorage.userIdMapping != null); // externalUserId can exist only through an userIdMapping
             throw new UserIdMappingAlreadyExistsException(

--- a/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
+++ b/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
@@ -24,9 +24,7 @@ import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdExce
 import io.supertokens.pluginInterface.emailverification.EmailVerificationStorage;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.jwt.JWTRecipeStorage;
-import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifierWithStorage;
-import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifierWithStorage;
 import io.supertokens.pluginInterface.multitenancy.exceptions.TenantOrAppNotFoundException;
 import io.supertokens.pluginInterface.session.SessionStorage;
@@ -63,9 +61,13 @@ public class UserIdMapping {
         try { // with external id
             AppIdentifierWithStorageAndUserIdMapping mappingAndStorage =
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
-                            main, appIdentifierWithStorage, appIdentifierWithStorage.getStorage(), externalUserId, UserIdType.EXTERNAL);
+                            main, appIdentifierWithStorage, appIdentifierWithStorage.getStorage(), externalUserId,
+                            UserIdType.EXTERNAL);
 
-            assert(mappingAndStorage.userIdMapping != null); // externalUserId can exist only through an userIdMapping
+            // externalUserId can exist only through an userIdMapping. the above method will raise an
+            // UnknownUserIdException if the external user was not found. we won't have a case where the user is found
+            // and the mapping is null. Hence, the following assert.
+            assert(mappingAndStorage.userIdMapping != null);
             throw new UserIdMappingAlreadyExistsException(
                     superTokensUserId.equals(mappingAndStorage.userIdMapping.superTokensUserId),
                     externalUserId.equals(mappingAndStorage.userIdMapping.externalUserId)

--- a/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
+++ b/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
@@ -59,17 +59,10 @@ public class UserIdMapping {
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
                             main, appIdentifierWithStorage, externalUserId, UserIdType.EXTERNAL);
             if (mappingAndStorage.userIdMapping != null) {
-                if (superTokensUserId.equals(mappingAndStorage.userIdMapping.superTokensUserId)) {
-                    throw new UserIdMappingAlreadyExistsException(
-                            superTokensUserId.equals(mappingAndStorage.userIdMapping.superTokensUserId),
-                            externalUserId.equals(mappingAndStorage.userIdMapping.externalUserId)
-                    );
-                } else {
-                    throw new UserIdMappingAlreadyExistsException(
-                            externalUserId.equals(mappingAndStorage.userIdMapping.superTokensUserId),
-                            superTokensUserId.equals(mappingAndStorage.userIdMapping.externalUserId)
-                    );
-                }
+                throw new UserIdMappingAlreadyExistsException(
+                        superTokensUserId.equals(mappingAndStorage.userIdMapping.superTokensUserId),
+                        externalUserId.equals(mappingAndStorage.userIdMapping.externalUserId)
+                );
             }
         } catch (UnknownUserIdException e) {
             // ignore

--- a/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
+++ b/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
@@ -50,11 +50,11 @@ public class UserIdMapping {
                                            String superTokensUserId, String externalUserId,
                                            String externalUserIdInfo, boolean force)
             throws UnknownSuperTokensUserIdException,
-            UserIdMappingAlreadyExistsException, StorageQueryException, ServletException, TenantOrAppNotFoundException,
-            UnknownUserIdException {
+            UserIdMappingAlreadyExistsException, StorageQueryException, ServletException,
+            TenantOrAppNotFoundException {
 
         // Check if mapping already exists app wide
-        { // with supertokens id
+        try { // with supertokens id
             AppIdentifierWithStorageAndUserIdMapping mappingAndStorage =
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
                     main, appIdentifierWithStorage, superTokensUserId, UserIdType.ANY);
@@ -64,6 +64,8 @@ public class UserIdMapping {
                         externalUserId == mappingAndStorage.userIdMapping.externalUserId
                 );
             }
+        } catch (UnknownUserIdException e) {
+            throw new UnknownSuperTokensUserIdException();
         }
         try { // with external id
             AppIdentifierWithStorageAndUserIdMapping mappingAndStorage =

--- a/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
+++ b/src/main/java/io/supertokens/useridmapping/UserIdMapping.java
@@ -78,8 +78,9 @@ public class UserIdMapping {
                 );
             }
 
-            // Update `appIdentifierWithStorage` from `mappingAndStorage` so that mapping is created on the
-            // right storage and not on the storage of tenant of interest
+            // Update `appIdentifierWithStorage` with the one from `mappingAndStorage` so that mapping is created
+            // on the right storage for the `supertokensUserId` and not on the storage of tenant from where the
+            // query came from
             appIdentifierWithStorage = mappingAndStorage.appIdentifierWithStorage;
         } catch (UnknownUserIdException e) {
             throw new UnknownSuperTokensUserIdException();

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -256,14 +256,6 @@ public abstract class WebserverAPI extends HttpServlet {
         Storage storage = StorageLayer.getStorage(tenantIdentifier, main);
         Storage[] storages = StorageLayer.getStoragesForApp(main, tenantIdentifier.toAppIdentifier());
 
-        // Make the `storage` is the first item in the `storages` array, to prioritize the tenant of interest
-        for (int i = 1; i < storages.length; i++) {
-            if (storages[i] == storage) {
-                storages[i] = storages[0];
-                storages[0] = storage;
-                break;
-            }
-        }
         return new AppIdentifierWithStorage(tenantIdentifier.getConnectionUriDomain(), tenantIdentifier.getAppId(),
                 storage, storages);
     }
@@ -292,7 +284,7 @@ public abstract class WebserverAPI extends HttpServlet {
     protected AppIdentifierWithStorageAndUserIdMapping getAppIdentifierWithStorageAndUserIdMappingFromRequest(HttpServletRequest req, String userId, UserIdType userIdType)
             throws StorageQueryException, TenantOrAppNotFoundException, UnknownUserIdException {
         AppIdentifierWithStorage appIdentifierWithStorage = getAppIdentifierWithStorage(req);
-        return StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(main, appIdentifierWithStorage, userId, userIdType);
+        return StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(main, appIdentifierWithStorage, appIdentifierWithStorage.getStorage(), userId, userIdType);
     }
 
     @Override

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -26,7 +26,6 @@ import io.supertokens.output.Logging;
 import io.supertokens.pluginInterface.Storage;
 import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdException;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
-import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifierWithStorage;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifierWithStorage;
@@ -283,8 +282,10 @@ public abstract class WebserverAPI extends HttpServlet {
 
     protected AppIdentifierWithStorageAndUserIdMapping getAppIdentifierWithStorageAndUserIdMappingFromRequest(HttpServletRequest req, String userId, UserIdType userIdType)
             throws StorageQueryException, TenantOrAppNotFoundException, UnknownUserIdException {
+        // This function uses storage of the tenent from which the request came from as a priorityStorage
+        // while searching for the user across all storages for the app
         AppIdentifierWithStorage appIdentifierWithStorage = getAppIdentifierWithStorage(req);
-        return StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(main, appIdentifierWithStorage, appIdentifierWithStorage.getStorage(), userId, userIdType);
+        return StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(main, appIdentifierWithStorage, appIdentifierWithStorage.getStorage(), userId, userIdType);
     }
 
     @Override

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -255,6 +255,15 @@ public abstract class WebserverAPI extends HttpServlet {
 
         Storage storage = StorageLayer.getStorage(tenantIdentifier, main);
         Storage[] storages = StorageLayer.getStoragesForApp(main, tenantIdentifier.toAppIdentifier());
+
+        // Make the `storage` is the first item in the `storages` array, to prioritize the tenant of interest
+        for (int i = 1; i < storages.length; i++) {
+            if (storages[i] == storage) {
+                storages[i] = storages[0];
+                storages[0] = storage;
+                break;
+            }
+        }
         return new AppIdentifierWithStorage(tenantIdentifier.getConnectionUriDomain(), tenantIdentifier.getAppId(),
                 storage, storages);
     }
@@ -282,8 +291,8 @@ public abstract class WebserverAPI extends HttpServlet {
 
     protected AppIdentifierWithStorageAndUserIdMapping getAppIdentifierWithStorageAndUserIdMappingFromRequest(HttpServletRequest req, String userId, UserIdType userIdType)
             throws StorageQueryException, TenantOrAppNotFoundException, UnknownUserIdException {
-        AppIdentifier appIdentifier = new AppIdentifier(this.getConnectionUriDomain(req), this.getAppId(req));
-        return StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(main, appIdentifier, userId, userIdType);
+        AppIdentifierWithStorage appIdentifierWithStorage = getAppIdentifierWithStorage(req);
+        return StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(main, appIdentifierWithStorage, userId, userIdType);
     }
 
     @Override

--- a/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
@@ -19,6 +19,7 @@ package io.supertokens.webserver.api.useridmapping;
 import com.google.gson.JsonObject;
 import io.supertokens.Main;
 import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdException;
+import io.supertokens.pluginInterface.multitenancy.AppIdentifierWithStorage;
 import io.supertokens.pluginInterface.multitenancy.exceptions.TenantOrAppNotFoundException;
 import io.supertokens.pluginInterface.RECIPE_ID;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
@@ -93,17 +94,16 @@ public class UserIdMappingAPI extends WebserverAPI {
         }
 
         try {
-            AppIdentifierWithStorageAndUserIdMapping appIdentifierWithStorageAndUserIdMapping =
-                    this.getAppIdentifierWithStorageAndUserIdMappingFromRequest(req, superTokensUserId, UserIdType.SUPERTOKENS);
+            AppIdentifierWithStorage appIdentifierWithStorage = this.getAppIdentifierWithStorage(req);
 
-            UserIdMapping.createUserIdMapping(main, appIdentifierWithStorageAndUserIdMapping.appIdentifierWithStorage,
-                    superTokensUserId, externalUserId, externalUserIdInfo, force);
+            UserIdMapping.createUserIdMapping(main, appIdentifierWithStorage, superTokensUserId, externalUserId,
+                    externalUserIdInfo, force);
 
             JsonObject response = new JsonObject();
             response.addProperty("status", "OK");
             super.sendJsonResponse(200, response, resp);
 
-        } catch (UnknownSuperTokensUserIdException | UnknownUserIdException e) {
+        } catch (UnknownSuperTokensUserIdException e) {
             JsonObject response = new JsonObject();
             response.addProperty("status", "UNKNOWN_SUPERTOKENS_USER_ID_ERROR");
             super.sendJsonResponse(200, response, resp);

--- a/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
@@ -19,7 +19,6 @@ package io.supertokens.webserver.api.useridmapping;
 import com.google.gson.JsonObject;
 import io.supertokens.Main;
 import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdException;
-import io.supertokens.pluginInterface.multitenancy.AppIdentifierWithStorage;
 import io.supertokens.pluginInterface.multitenancy.exceptions.TenantOrAppNotFoundException;
 import io.supertokens.pluginInterface.RECIPE_ID;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
@@ -94,16 +93,17 @@ public class UserIdMappingAPI extends WebserverAPI {
         }
 
         try {
-            AppIdentifierWithStorage appIdentifierWithStorage = this.getAppIdentifierWithStorage(req);
+            AppIdentifierWithStorageAndUserIdMapping appIdentifierWithStorageAndUserIdMapping =
+                    this.getAppIdentifierWithStorageAndUserIdMappingFromRequest(req, superTokensUserId, UserIdType.SUPERTOKENS);
 
-            UserIdMapping.createUserIdMapping(main, appIdentifierWithStorage, superTokensUserId, externalUserId,
-                    externalUserIdInfo, force);
+            UserIdMapping.createUserIdMapping(main, appIdentifierWithStorageAndUserIdMapping.appIdentifierWithStorage,
+                    superTokensUserId, externalUserId, externalUserIdInfo, force);
 
             JsonObject response = new JsonObject();
             response.addProperty("status", "OK");
             super.sendJsonResponse(200, response, resp);
 
-        } catch (UnknownSuperTokensUserIdException e) {
+        } catch (UnknownSuperTokensUserIdException | UnknownUserIdException e) {
             JsonObject response = new JsonObject();
             response.addProperty("status", "UNKNOWN_SUPERTOKENS_USER_ID_ERROR");
             super.sendJsonResponse(200, response, resp);

--- a/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
@@ -151,6 +151,16 @@ public class UserIdMappingAPI extends WebserverAPI {
         }
 
         try {
+            // If there exists a situation where 2 users on different user pools point to same external user id,
+            // this API tries to be deterministic by considering the storage for the tenant on which this request was
+            // made. if the user does not exist on the storage for the tenant on which this request was made,
+            // this API will just return the first mapping it can find. It won't be deterministic
+
+            // Example
+            // (app1, tenant1, user1) -> externaluserid and (app1, tenant2, user2) -> externaluserid
+            // Request from (app1, tenant1) will return user1 and request from (app1, tenant2) will return user2
+            // Request from (app1, tenant3) may result in either user1 or user2
+
             AppIdentifierWithStorageAndUserIdMapping appIdentifierWithStorageAndUserIdMapping =
                     this.getAppIdentifierWithStorageAndUserIdMappingFromRequest(req, userId, userIdType);
 

--- a/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
@@ -96,7 +96,7 @@ public class UserIdMappingAPI extends WebserverAPI {
             AppIdentifierWithStorageAndUserIdMapping appIdentifierWithStorageAndUserIdMapping =
                     this.getAppIdentifierWithStorageAndUserIdMappingFromRequest(req, superTokensUserId, UserIdType.SUPERTOKENS);
 
-            UserIdMapping.createUserIdMapping(appIdentifierWithStorageAndUserIdMapping.appIdentifierWithStorage,
+            UserIdMapping.createUserIdMapping(main, appIdentifierWithStorageAndUserIdMapping.appIdentifierWithStorage,
                     superTokensUserId, externalUserId, externalUserIdInfo, force);
 
             JsonObject response = new JsonObject();

--- a/src/test/java/io/supertokens/test/emailpassword/MultitenantEmailPasswordTest.java
+++ b/src/test/java/io/supertokens/test/emailpassword/MultitenantEmailPasswordTest.java
@@ -27,6 +27,7 @@ import io.supertokens.multitenancy.Multitenancy;
 import io.supertokens.multitenancy.exception.BadPermissionException;
 import io.supertokens.multitenancy.exception.CannotModifyBaseConfigException;
 import io.supertokens.multitenancy.exception.DeletionInProgressException;
+import io.supertokens.pluginInterface.Storage;
 import io.supertokens.pluginInterface.emailpassword.UserInfo;
 import io.supertokens.pluginInterface.emailpassword.exceptions.DuplicateEmailException;
 import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdException;
@@ -246,26 +247,28 @@ public class MultitenantEmailPasswordTest {
         UserInfo user2 = EmailPassword.signUp(t2storage, process.getProcess(), "user2@example.com", "password2");
         UserInfo user3 = EmailPassword.signUp(t3storage, process.getProcess(), "user3@example.com", "password3");
 
+        Storage storage = StorageLayer.getStorage(process.getProcess());
+
         {
             UserInfo userInfo = EmailPassword.getUserUsingId(
-                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            process.getProcess(), new AppIdentifier(null, "a1"), null, user1.id,
+                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                            process.getProcess(), new AppIdentifier(null, "a1"), storage, user1.id,
                             UserIdType.SUPERTOKENS).appIdentifierWithStorage, user1.id);
             assertEquals(user1, userInfo);
         }
 
         {
             UserInfo userInfo = EmailPassword.getUserUsingId(
-                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            process.getProcess(), new AppIdentifier(null, "a1"), null, user2.id,
+                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                            process.getProcess(), new AppIdentifier(null, "a1"), storage, user2.id,
                             UserIdType.SUPERTOKENS).appIdentifierWithStorage, user2.id);
             assertEquals(user2, userInfo);
         }
 
         {
             UserInfo userInfo = EmailPassword.getUserUsingId(
-                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            process.getProcess(), new AppIdentifier(null, "a1"), null, user3.id,
+                    StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                            process.getProcess(), new AppIdentifier(null, "a1"), storage, user3.id,
                             UserIdType.SUPERTOKENS).appIdentifierWithStorage, user3.id);
             assertEquals(user3, userInfo);
         }
@@ -346,19 +349,21 @@ public class MultitenantEmailPasswordTest {
         UserInfo user2 = EmailPassword.signUp(t2storage, process.getProcess(), "user@example.com", "password2");
         UserInfo user3 = EmailPassword.signUp(t3storage, process.getProcess(), "user@example.com", "password3");
 
+        Storage storage = StorageLayer.getStorage(process.getProcess());
+
         EmailPassword.updateUsersEmailOrPassword(
-                StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                        process.getProcess(), new AppIdentifier(null, "a1"), null, user1.id,
+                StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                        process.getProcess(), new AppIdentifier(null, "a1"), storage, user1.id,
                         UserIdType.SUPERTOKENS).appIdentifierWithStorage,
                 process.getProcess(), user1.id, null, "newpassword1");
         EmailPassword.updateUsersEmailOrPassword(
-                StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                        process.getProcess(), new AppIdentifier(null, "a1"), null, user2.id,
+                StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                        process.getProcess(), new AppIdentifier(null, "a1"), storage, user2.id,
                         UserIdType.SUPERTOKENS).appIdentifierWithStorage,
                 process.getProcess(), user2.id, null, "newpassword2");
         EmailPassword.updateUsersEmailOrPassword(
-                StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                        process.getProcess(), new AppIdentifier(null, "a1"), null, user3.id,
+                StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUserWithPriorityForTenantStorage(
+                        process.getProcess(), new AppIdentifier(null, "a1"), storage, user3.id,
                         UserIdType.SUPERTOKENS).appIdentifierWithStorage,
                 process.getProcess(), user3.id, null, "newpassword3");
 

--- a/src/test/java/io/supertokens/test/emailpassword/MultitenantEmailPasswordTest.java
+++ b/src/test/java/io/supertokens/test/emailpassword/MultitenantEmailPasswordTest.java
@@ -249,7 +249,7 @@ public class MultitenantEmailPasswordTest {
         {
             UserInfo userInfo = EmailPassword.getUserUsingId(
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            process.getProcess(), new AppIdentifier(null, "a1"), user1.id,
+                            process.getProcess(), new AppIdentifier(null, "a1"), null, user1.id,
                             UserIdType.SUPERTOKENS).appIdentifierWithStorage, user1.id);
             assertEquals(user1, userInfo);
         }
@@ -257,7 +257,7 @@ public class MultitenantEmailPasswordTest {
         {
             UserInfo userInfo = EmailPassword.getUserUsingId(
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            process.getProcess(), new AppIdentifier(null, "a1"), user2.id,
+                            process.getProcess(), new AppIdentifier(null, "a1"), null, user2.id,
                             UserIdType.SUPERTOKENS).appIdentifierWithStorage, user2.id);
             assertEquals(user2, userInfo);
         }
@@ -265,7 +265,7 @@ public class MultitenantEmailPasswordTest {
         {
             UserInfo userInfo = EmailPassword.getUserUsingId(
                     StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                            process.getProcess(), new AppIdentifier(null, "a1"), user3.id,
+                            process.getProcess(), new AppIdentifier(null, "a1"), null, user3.id,
                             UserIdType.SUPERTOKENS).appIdentifierWithStorage, user3.id);
             assertEquals(user3, userInfo);
         }
@@ -348,17 +348,17 @@ public class MultitenantEmailPasswordTest {
 
         EmailPassword.updateUsersEmailOrPassword(
                 StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                        process.getProcess(), new AppIdentifier(null, "a1"), user1.id,
+                        process.getProcess(), new AppIdentifier(null, "a1"), null, user1.id,
                         UserIdType.SUPERTOKENS).appIdentifierWithStorage,
                 process.getProcess(), user1.id, null, "newpassword1");
         EmailPassword.updateUsersEmailOrPassword(
                 StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                        process.getProcess(), new AppIdentifier(null, "a1"), user2.id,
+                        process.getProcess(), new AppIdentifier(null, "a1"), null, user2.id,
                         UserIdType.SUPERTOKENS).appIdentifierWithStorage,
                 process.getProcess(), user2.id, null, "newpassword2");
         EmailPassword.updateUsersEmailOrPassword(
                 StorageLayer.getAppIdentifierWithStorageAndUserIdMappingForUser(
-                        process.getProcess(), new AppIdentifier(null, "a1"), user3.id,
+                        process.getProcess(), new AppIdentifier(null, "a1"), null, user3.id,
                         UserIdType.SUPERTOKENS).appIdentifierWithStorage,
                 process.getProcess(), user3.id, null, "newpassword3");
 

--- a/src/test/java/io/supertokens/test/userIdMapping/UserIdMappingTest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/UserIdMappingTest.java
@@ -800,8 +800,10 @@ public class UserIdMappingTest {
             }
         }
 
-        String userId = "testUserId";
         for (String className : classNames) {
+            UserInfo user = EmailPassword.signUp(process.main, "test@example.com", "password");
+            String userId = user.id;
+
             // create entry in nonAuth table
             StorageLayer.getStorage(process.main).addInfoToNonAuthRecipesBasedOnUserId(className, userId);
             // try to create the mapping with superTokensId

--- a/src/test/java/io/supertokens/test/userIdMapping/api/MultitenantAPITest.java
+++ b/src/test/java/io/supertokens/test/userIdMapping/api/MultitenantAPITest.java
@@ -1,0 +1,382 @@
+/*
+ *    Copyright (c) 2023, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.userIdMapping.api;
+
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.featureflag.EE_FEATURES;
+import io.supertokens.featureflag.FeatureFlagTestContent;
+import io.supertokens.featureflag.exceptions.FeatureNotEnabledException;
+import io.supertokens.multitenancy.Multitenancy;
+import io.supertokens.multitenancy.exception.BadPermissionException;
+import io.supertokens.multitenancy.exception.CannotModifyBaseConfigException;
+import io.supertokens.multitenancy.exception.DeletionInProgressException;
+import io.supertokens.pluginInterface.exceptions.InvalidConfigException;
+import io.supertokens.pluginInterface.exceptions.StorageQueryException;
+import io.supertokens.pluginInterface.multitenancy.*;
+import io.supertokens.pluginInterface.multitenancy.exceptions.TenantOrAppNotFoundException;
+import io.supertokens.pluginInterface.useridmapping.UserIdMappingStorage;
+import io.supertokens.storageLayer.StorageLayer;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.thirdparty.InvalidProviderConfigException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+public class MultitenantAPITest {
+    TestingProcessManager.TestingProcess process;
+    TenantIdentifier t1, t2, t3;
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @After
+    public void afterEach() throws InterruptedException {
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Before
+    public void beforeEach() throws InterruptedException, InvalidProviderConfigException, DeletionInProgressException,
+            StorageQueryException, FeatureNotEnabledException, TenantOrAppNotFoundException, IOException,
+            InvalidConfigException, CannotModifyBaseConfigException, BadPermissionException {
+        Utils.reset();
+
+        String[] args = {"../"};
+
+        this.process = TestingProcessManager.start(args);
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[]{EE_FEATURES.MULTI_TENANCY});
+        process.startProcess();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        createTenants();
+    }
+
+
+    private void createTenants()
+            throws StorageQueryException, TenantOrAppNotFoundException, InvalidProviderConfigException,
+            DeletionInProgressException, FeatureNotEnabledException, IOException, InvalidConfigException,
+            CannotModifyBaseConfigException, BadPermissionException {
+        // User pool 1 - (null, a1, null)
+        // User pool 2 - (null, a1, t1), (null, a1, t2)
+
+        { // tenant 1
+            JsonObject config = new JsonObject();
+            TenantIdentifier tenantIdentifier = new TenantIdentifier(null, "a1", null);
+
+            StorageLayer.getStorage(new TenantIdentifier(null, null, null), process.getProcess())
+                    .modifyConfigToAddANewUserPoolForTesting(config, 1);
+
+            Multitenancy.addNewOrUpdateAppOrTenant(
+                    process.getProcess(),
+                    new TenantIdentifier(null, null, null),
+                    new TenantConfig(
+                            tenantIdentifier,
+                            new EmailPasswordConfig(true),
+                            new ThirdPartyConfig(false, null),
+                            new PasswordlessConfig(false),
+                            config
+                    )
+            );
+        }
+
+        { // tenant 2
+            JsonObject config = new JsonObject();
+            TenantIdentifier tenantIdentifier = new TenantIdentifier(null, "a1", "t1");
+
+            StorageLayer.getStorage(new TenantIdentifier(null, null, null), process.getProcess())
+                    .modifyConfigToAddANewUserPoolForTesting(config, 2);
+
+            Multitenancy.addNewOrUpdateAppOrTenant(
+                    process.getProcess(),
+                    new TenantIdentifier(null, "a1", null),
+                    new TenantConfig(
+                            tenantIdentifier,
+                            new EmailPasswordConfig(true),
+                            new ThirdPartyConfig(false, null),
+                            new PasswordlessConfig(false),
+                            config
+                    )
+            );
+        }
+
+        { // tenant 3
+            JsonObject config = new JsonObject();
+            TenantIdentifier tenantIdentifier = new TenantIdentifier(null, "a1", "t2");
+
+            StorageLayer.getStorage(new TenantIdentifier(null, null, null), process.getProcess())
+                    .modifyConfigToAddANewUserPoolForTesting(config, 2);
+
+            Multitenancy.addNewOrUpdateAppOrTenant(
+                    process.getProcess(),
+                    new TenantIdentifier(null, "a1", null),
+                    new TenantConfig(
+                            tenantIdentifier,
+                            new EmailPasswordConfig(true),
+                            new ThirdPartyConfig(false, null),
+                            new PasswordlessConfig(false),
+                            config
+                    )
+            );
+        }
+
+        t1 = new TenantIdentifier(null, "a1", null);
+        t2 = new TenantIdentifier(null, "a1", "t1");
+        t3 = new TenantIdentifier(null, "a1", "t2");
+    }
+
+    private JsonObject emailPasswordSignUp(TenantIdentifier tenantIdentifier, String email, String password)
+            throws HttpResponseException, IOException {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("email", email);
+        requestBody.addProperty("password", password);
+        JsonObject signUpResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                HttpRequestForTesting.getMultitenantUrl(tenantIdentifier, "/recipe/signup"),
+                requestBody, 1000, 1000, null,
+                Utils.getCdiVersionLatestForTests(), "emailpassword");
+        assertEquals("OK", signUpResponse.getAsJsonPrimitive("status").getAsString());
+        return signUpResponse.getAsJsonObject("user");
+    }
+
+    private void successfulCreateUserIdMapping(TenantIdentifier tenantIdentifier, String supertokensUserId, String externalUserId)
+            throws HttpResponseException, IOException {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("superTokensUserId", supertokensUserId);
+        requestBody.addProperty("externalUserId", externalUserId);
+
+        JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                HttpRequestForTesting.getMultitenantUrl(tenantIdentifier, "/recipe/userid/map"), requestBody,
+                1000, 1000, null,
+                Utils.getCdiVersionLatestForTests(), "useridmapping");
+        assertEquals("OK", response.get("status").getAsString());
+    }
+
+    private void mappingAlreadyExistsWithCreateUserIdMapping(TenantIdentifier tenantIdentifier, String supertokensUserId, String externalUserId)
+            throws HttpResponseException, IOException {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("superTokensUserId", supertokensUserId);
+        requestBody.addProperty("externalUserId", externalUserId);
+
+        JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                HttpRequestForTesting.getMultitenantUrl(tenantIdentifier, "/recipe/userid/map"), requestBody,
+                1000, 1000, null,
+                Utils.getCdiVersionLatestForTests(), "useridmapping");
+        assertEquals("USER_ID_MAPPING_ALREADY_EXISTS_ERROR", response.get("status").getAsString());
+    }
+
+    private JsonObject getUserIdMapping(TenantIdentifier tenantIdentifier, String userId, String userIdType)
+            throws HttpResponseException, IOException {
+        HashMap<String, String> QUERY_PARAM = new HashMap<>();
+        QUERY_PARAM.put("userId", userId);
+        QUERY_PARAM.put("userIdType", userIdType);
+
+        JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                HttpRequestForTesting.getMultitenantUrl(tenantIdentifier, "/recipe/userid/map"), QUERY_PARAM, 1000, 1000, null,
+                Utils.getCdiVersionLatestForTests(), "useridmapping");
+        assertEquals("OK", response.get("status").getAsString());
+        return response;
+    }
+
+    private void getUnknownUserIdMapping(TenantIdentifier tenantIdentifier, String userId, String userIdType)
+            throws HttpResponseException, IOException {
+        HashMap<String, String> QUERY_PARAM = new HashMap<>();
+        QUERY_PARAM.put("userId", userId);
+        QUERY_PARAM.put("userIdType", userIdType);
+
+        JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                HttpRequestForTesting.getMultitenantUrl(tenantIdentifier, "/recipe/userid/map"), QUERY_PARAM, 1000, 1000, null,
+                Utils.getCdiVersionLatestForTests(), "useridmapping");
+        assertEquals("UNKNOWN_MAPPING_ERROR", response.get("status").getAsString());
+    }
+
+    private void successfulRemoveUserIdMapping(TenantIdentifier tenantIdentifier, String userId, String userIdType)
+            throws HttpResponseException, IOException {
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.addProperty("userIdType", userIdType);
+
+        JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                HttpRequestForTesting.getMultitenantUrl(tenantIdentifier, "/recipe/userid/map/remove"), request,
+                1000, 1000, null,
+                Utils.getCdiVersionLatestForTests(), "useridmapping");
+        assertEquals(2, response.entrySet().size());
+        assertEquals("OK", response.get("status").getAsString());
+        assertTrue(response.get("didMappingExist").getAsBoolean());
+    }
+
+    @Test
+    public void testUserIdMappingWorksCorrectlyAcrossTenants() throws Exception {
+        JsonObject user1 = emailPasswordSignUp(t1, "user@example.com", "password1");
+        JsonObject user2 = emailPasswordSignUp(t2, "user@example.com", "password2");
+        JsonObject user3 = emailPasswordSignUp(t3, "user@example.com", "password3");
+
+        user1.addProperty("externalUserId", "euserid1");
+        user2.addProperty("externalUserId", "euserid2");
+        user3.addProperty("externalUserId", "euserid3");
+
+
+        for (TenantIdentifier createTenant: new TenantIdentifier[]{t1, t2, t3}) {
+            successfulCreateUserIdMapping(createTenant, user1.get("id").getAsString(), "euserid1");
+            successfulCreateUserIdMapping(createTenant, user2.get("id").getAsString(), "euserid2");
+            successfulCreateUserIdMapping(createTenant, user3.get("id").getAsString(), "euserid3");
+
+            for (TenantIdentifier queryTenant : new TenantIdentifier[]{t1, t2, t3}) {
+                for (JsonObject user : new JsonObject[]{user1, user2, user3}) {
+                    {
+                        JsonObject mapping = getUserIdMapping(queryTenant, user.get("id").getAsString(), "SUPERTOKENS");
+                        assertEquals(user.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+                        assertEquals(user.get("externalUserId").getAsString(),
+                                mapping.get("externalUserId").getAsString());
+                    }
+                    {
+                        JsonObject mapping = getUserIdMapping(queryTenant, user.get("id").getAsString(), "ANY");
+                        assertEquals(user.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+                        assertEquals(user.get("externalUserId").getAsString(),
+                                mapping.get("externalUserId").getAsString());
+                    }
+                    {
+                        JsonObject mapping = getUserIdMapping(queryTenant, user.get("externalUserId").getAsString(), "EXTERNAL");
+                        assertEquals(user.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+                        assertEquals(user.get("externalUserId").getAsString(),
+                                mapping.get("externalUserId").getAsString());
+                    }
+                    {
+                        JsonObject mapping = getUserIdMapping(queryTenant, user.get("externalUserId").getAsString(), "ANY");
+                        assertEquals(user.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+                        assertEquals(user.get("externalUserId").getAsString(),
+                                mapping.get("externalUserId").getAsString());
+                    }
+                }
+            }
+
+            successfulRemoveUserIdMapping(createTenant, user1.get("id").getAsString(), "SUPERTOKENS");
+            successfulRemoveUserIdMapping(createTenant, user2.get("id").getAsString(), "SUPERTOKENS");
+            successfulRemoveUserIdMapping(createTenant, user3.get("id").getAsString(), "SUPERTOKENS");
+        }
+    }
+
+    @Test
+    public void testSameExternalIdIsDisallowedIrrespectiveOfUserPool() throws Exception {
+        TenantIdentifier[] tenants = new TenantIdentifier[]{t1, t2, t3};
+        int userCount = 0;
+        int testcase = 0;
+
+        for (TenantIdentifier tx : tenants) {
+            for (TenantIdentifier ty : tenants) {
+                JsonObject user1 = emailPasswordSignUp(tx, "user" + (userCount++) + "@example.com", "password");
+                JsonObject user2 = emailPasswordSignUp(ty, "user" + (userCount++) + "@example.com", "password");
+
+                String externalUserId = "euserid" + (testcase++);
+
+                successfulCreateUserIdMapping(tx, user1.get("id").getAsString(), externalUserId);
+                mappingAlreadyExistsWithCreateUserIdMapping(ty, user2.get("id").getAsString(), externalUserId);
+            }
+        }
+    }
+
+    @Test
+    public void testRemoveMappingWorksAppWide() throws Exception {
+        TenantIdentifier[] tenants = new TenantIdentifier[]{t1, t2, t3};
+        int userCount = 0;
+
+        for (TenantIdentifier userTenant : tenants) {
+            JsonObject user = emailPasswordSignUp(userTenant, "user" + (userCount++) + "@example.com", "password");
+            String externalUserId = "euserid" + userCount;
+            user.addProperty("externalUserId", externalUserId);
+
+            for (TenantIdentifier tx : tenants) {
+                for (TenantIdentifier ty : tenants) {
+                    {
+                        successfulCreateUserIdMapping(tx, user.get("id").getAsString(), externalUserId);
+                        getUserIdMapping(ty, user.get("id").getAsString(), "SUPERTOKENS");
+                        successfulRemoveUserIdMapping(ty, user.get("id").getAsString(), "SUPERTOKENS");
+                        getUnknownUserIdMapping(ty, user.get("id").getAsString(), "SUPERTOKENS");
+                    }
+                    {
+                        successfulCreateUserIdMapping(tx, user.get("id").getAsString(), externalUserId);
+                        getUserIdMapping(ty, user.get("id").getAsString(), "ANY");
+                        successfulRemoveUserIdMapping(ty, user.get("id").getAsString(), "ANY");
+                        getUnknownUserIdMapping(ty, user.get("id").getAsString(), "ANY");
+                    }
+                    {
+                        successfulCreateUserIdMapping(tx, user.get("id").getAsString(), externalUserId);
+                        getUserIdMapping(ty, user.get("externalUserId").getAsString(), "EXTERNAL");
+                        successfulRemoveUserIdMapping(ty, user.get("externalUserId").getAsString(), "EXTERNAL");
+                        getUnknownUserIdMapping(ty, user.get("externalUserId").getAsString(), "EXTERNAL");
+                    }
+                    {
+                        successfulCreateUserIdMapping(tx, user.get("id").getAsString(), externalUserId);
+                        getUserIdMapping(ty, user.get("externalUserId").getAsString(), "ANY");
+                        successfulRemoveUserIdMapping(ty, user.get("externalUserId").getAsString(), "ANY");
+                        getUnknownUserIdMapping(ty, user.get("externalUserId").getAsString(), "ANY");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testSameExternalIdAcrossUserPoolPrioritizesTenantOfInterest() throws Exception {
+        JsonObject user1 = emailPasswordSignUp(t1, "user@example.com", "password1");
+        JsonObject user2 = emailPasswordSignUp(t2, "user@example.com", "password2");
+
+        ((UserIdMappingStorage)StorageLayer.getStorage(t1, process.getProcess())).createUserIdMapping(
+                t1.toAppIdentifier(), user1.get("id").getAsString(), "euserid", null);
+
+        ((UserIdMappingStorage)StorageLayer.getStorage(t2, process.getProcess())).createUserIdMapping(
+                t2.toAppIdentifier(), user2.get("id").getAsString(), "euserid", null);
+
+        {
+            JsonObject mapping = getUserIdMapping(t1, "euserid", "EXTERNAL");
+            assertEquals(user1.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+        }
+        {
+            JsonObject mapping = getUserIdMapping(t1, "euserid", "ANY");
+            assertEquals(user1.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+        }
+
+        {
+            JsonObject mapping = getUserIdMapping(t2, "euserid", "EXTERNAL");
+            assertEquals(user2.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+        }
+        {
+            JsonObject mapping = getUserIdMapping(t2, "euserid", "ANY");
+            assertEquals(user2.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+        }
+
+        {
+            JsonObject mapping = getUserIdMapping(t3, "euserid", "EXTERNAL");
+            assertEquals(user2.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+        }
+        {
+            JsonObject mapping = getUserIdMapping(t3, "euserid", "ANY");
+            assertEquals(user2.get("id").getAsString(), mapping.get("superTokensUserId").getAsString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary of change

- Disallow same external userid across all storages
- Prioritize tenant of interest while working with appIdentifierWithStorage

## Related issues

- https://github.com/supertokens/supertokens-core/issues/610 (not addressed)

## Test Plan


## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
