### PR TITLE
fix: fix getting jwt signing keys with mongodb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+### Fixes
+
+- Fixed creating JWTs using MongoDB if a key already exists
+
 ### Breaking changes
 
 - Using an internal `SemVer` class to handle version numbers. This will make handling CDI version ranges easier.

--- a/src/main/java/io/supertokens/signingkeys/JWTSigningKey.java
+++ b/src/main/java/io/supertokens/signingkeys/JWTSigningKey.java
@@ -214,9 +214,9 @@ public class JWTSigningKey extends ResourceDistributor.SingletonResource {
                         // Retry with a new key id
                     }
                 }
-
-                return keyInfo;
             }
+
+            return keyInfo;
         }
 
         throw new QuitProgramException("Unsupported storage type detected");

--- a/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
+++ b/src/test/java/io/supertokens/test/jwt/JWTCreateTest.java
@@ -71,6 +71,28 @@ public class JWTCreateTest {
     }
 
     /**
+     * Call JWTSigningFunctions.createJWTToken with valid params twice and ensure that it does not throw any errors
+     */
+    @Test
+    public void testCreateTokenWithAlreadyExistingKey() throws Exception {
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String algorithm = "RS256";
+        JsonObject payload = new JsonObject();
+        payload.addProperty("customClaim", "customValue");
+        String jwksDomain = "http://localhost";
+        long validity = 3600;
+
+        JWTSigningFunctions.createJWTToken(process.getProcess(), algorithm, payload, jwksDomain, validity, false);
+        JWTSigningFunctions.createJWTToken(process.getProcess(), algorithm, payload, jwksDomain, validity, false);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    /**
      * Call JWTSigningFunctions.createJWTToken with valid params and long validity and ensure that it does not throw any
      * errors
      */


### PR DESCRIPTION
## Summary of change

fix: fix getting jwt signing keys with MongoDB (already existing in master)

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

Added test that creates 2 JWTs, ensuring we have a key created before we sign the second one

## Documentation changes

N/A

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
