### PR TITLE
test: disable jwt signing key generation if testing to test legacy key migration in mongo

### DIFF
--- a/src/main/java/io/supertokens/signingkeys/JWTSigningKey.java
+++ b/src/main/java/io/supertokens/signingkeys/JWTSigningKey.java
@@ -200,8 +200,6 @@ public class JWTSigningKey extends ResourceDistributor.SingletonResource {
 
             // If no key was found create a new one
             if (keyInfo == null) {
-                new Error().printStackTrace();
-
                 while (true) {
                     try {
                         keyInfo = generateKeyForAlgorithm(algorithm);

--- a/src/main/java/io/supertokens/signingkeys/JWTSigningKey.java
+++ b/src/main/java/io/supertokens/signingkeys/JWTSigningKey.java
@@ -41,20 +41,23 @@ public class JWTSigningKey extends ResourceDistributor.SingletonResource {
     private final Main main;
 
     public static void init(Main main) {
-        // init JWT signing keys, we create one key for each supported algorithm type
-        for (int i = 0; i < JWTSigningKey.SupportedAlgorithms.values().length; i++) {
-            JWTSigningKey.SupportedAlgorithms currentAlgorithm = JWTSigningKey.SupportedAlgorithms.values()[i];
-            try {
-                JWTSigningKey.getInstance(main).getOrCreateAndGetKeyForAlgorithm(currentAlgorithm);
-            } catch (StorageQueryException | StorageTransactionLogicException e) {
-                // Do nothing, when a call to /recipe/jwt POST is made the core will attempt to create a new key
-            } catch (UnsupportedJWTSigningAlgorithmException e) {
-                /*
-                 * In this case UnsupportedJWTSigningAlgorithmException should never be thrown because we use
-                 * the enum to iterate all the supported algorithm values. If this does get thrown this should be
-                 * considered a failure.
-                 */
-                throw new QuitProgramException("Trying to create signing key for unsupported JWT signing algorithm");
+        // We want to control when/which key is generated during testing to test migration scenarios with exact DB setups.
+        if (!Main.isTesting) {
+            // init JWT signing keys, we create one key for each supported algorithm type
+            for (int i = 0; i < JWTSigningKey.SupportedAlgorithms.values().length; i++) {
+                JWTSigningKey.SupportedAlgorithms currentAlgorithm = JWTSigningKey.SupportedAlgorithms.values()[i];
+                try {
+                    JWTSigningKey.getInstance(main).getOrCreateAndGetKeyForAlgorithm(currentAlgorithm);
+                } catch (StorageQueryException | StorageTransactionLogicException e) {
+                    // Do nothing, when a call to /recipe/jwt POST is made the core will attempt to create a new key
+                } catch (UnsupportedJWTSigningAlgorithmException e) {
+                    /*
+                     * In this case UnsupportedJWTSigningAlgorithmException should never be thrown because we use
+                     * the enum to iterate all the supported algorithm values. If this does get thrown this should be
+                     * considered a failure.
+                     */
+                    throw new QuitProgramException("Trying to create signing key for unsupported JWT signing algorithm");
+                }
             }
         }
     }
@@ -197,6 +200,8 @@ public class JWTSigningKey extends ResourceDistributor.SingletonResource {
 
             // If no key was found create a new one
             if (keyInfo == null) {
+                new Error().printStackTrace();
+
                 while (true) {
                     try {
                         keyInfo = generateKeyForAlgorithm(algorithm);

--- a/src/test/java/io/supertokens/test/session/AccessTokenSigningKeyTest.java
+++ b/src/test/java/io/supertokens/test/session/AccessTokenSigningKeyTest.java
@@ -164,9 +164,7 @@ public class AccessTokenSigningKeyTest {
     }
 
     @Test
-    public void migratingStaticSigningKeys()
-            throws IOException, InterruptedException, InvalidKeyException, NoSuchAlgorithmException,
-            StorageQueryException, StorageTransactionLogicException, InvalidKeySpecException, SignatureException {
+    public void migratingStaticSigningKeys() throws Exception {
         Utils.setValueInConfig("access_token_signing_key_dynamic", "false");
 
         String[] args = { "../" };
@@ -187,10 +185,11 @@ public class AccessTokenSigningKeyTest {
 
         accessTokenSigningKeyInstance.cleanExpiredAccessTokenSigningKeys();
         List<JWTSigningKeyInfo> keys = SigningKeys.getInstance(process.getProcess()).getStaticKeys();
-        assertEquals(keys.size(), 2);
 
-        assertEquals(legacyKey.value, keys.get(1).keyString);
-        assertEquals(keys.get(1).keyId.substring(0, 2), "s-");
+        assertEquals(keys.size(), 1);
+
+        assertEquals(legacyKey.value, keys.get(0).keyString);
+        assertEquals(keys.get(0).keyId.substring(0, 2), "s-");
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
     }


### PR DESCRIPTION
## Summary of change

disable jwt signing key generation if testing to test legacy key migration in mongo

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
