### PR TITLE
fix: throw if a protected prop is passed to JWTDataAPI

### DIFF
--- a/src/main/java/io/supertokens/session/accessToken/AccessToken.java
+++ b/src/main/java/io/supertokens/session/accessToken/AccessToken.java
@@ -223,7 +223,7 @@ public class AccessToken {
     }
 
     public static class AccessTokenInfo {
-        static String[] protectedPropNames = {
+        public static String[] protectedPropNames = {
                 "sub",
                 "exp",
                 "iat",

--- a/src/main/java/io/supertokens/webserver/api/session/JWTDataAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/JWTDataAPI.java
@@ -34,9 +34,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
-
-import static io.supertokens.session.accessToken.AccessToken.AccessTokenInfo.protectedPropNames;
 
 public class JWTDataAPI extends WebserverAPI {
     private static final long serialVersionUID = -4989144736402314280L;

--- a/src/main/java/io/supertokens/webserver/api/session/JWTDataAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/JWTDataAPI.java
@@ -60,7 +60,7 @@ public class JWTDataAPI extends WebserverAPI {
         assert userDataInJWT != null;
 
         if (getVersionFromRequest(req).greaterThanOrEqualTo(SemVer.v2_21) &&
-                Arrays.stream(protectedPropNames).anyMatch(name -> userDataInJWT.has(name))) {
+                Arrays.stream(protectedPropNames).anyMatch(userDataInJWT::has)) {
             throw new ServletException(new BadRequestException("The user payload contains protected field"));
         }
 

--- a/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
@@ -88,10 +88,6 @@ public class SessionAPI extends WebserverAPI {
 
             // useDynamicSigningKey defaults to true, so we check if it has been explicitly set to true
             useStaticSigningKey = Boolean.FALSE.equals(useDynamicSigningKey);
-
-            if (Arrays.stream(protectedPropNames).anyMatch(userDataInJWT::has)) {
-                throw new ServletException(new BadRequestException("The user payload contains protected field"));
-            }
         }
 
         try {

--- a/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
@@ -52,9 +52,6 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
-import java.util.Arrays;
-
-import static io.supertokens.session.accessToken.AccessToken.AccessTokenInfo.protectedPropNames;
 
 public class SessionAPI extends WebserverAPI {
     private static final long serialVersionUID = 7142317017402226537L;

--- a/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionAPI.java
@@ -52,6 +52,9 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+
+import static io.supertokens.session.accessToken.AccessToken.AccessTokenInfo.protectedPropNames;
 
 public class SessionAPI extends WebserverAPI {
     private static final long serialVersionUID = 7142317017402226537L;
@@ -85,6 +88,10 @@ public class SessionAPI extends WebserverAPI {
 
             // useDynamicSigningKey defaults to true, so we check if it has been explicitly set to true
             useStaticSigningKey = Boolean.FALSE.equals(useDynamicSigningKey);
+
+            if (Arrays.stream(protectedPropNames).anyMatch(userDataInJWT::has)) {
+                throw new ServletException(new BadRequestException("The user payload contains protected field"));
+            }
         }
 
         try {

--- a/src/main/java/io/supertokens/webserver/api/session/SessionRegenerateAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionRegenerateAPI.java
@@ -31,6 +31,7 @@ import io.supertokens.pluginInterface.exceptions.StorageTransactionLogicExceptio
 import io.supertokens.session.Session;
 import io.supertokens.session.info.SessionInformationHolder;
 import io.supertokens.session.jwt.JWT;
+import io.supertokens.utils.SemVer;
 import io.supertokens.utils.Utils;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.WebserverAPI;
@@ -43,6 +44,9 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Arrays;
+
+import static io.supertokens.session.accessToken.AccessToken.AccessTokenInfo.protectedPropNames;
 
 public class SessionRegenerateAPI extends WebserverAPI {
 
@@ -65,6 +69,12 @@ public class SessionRegenerateAPI extends WebserverAPI {
         assert accessToken != null;
 
         JsonObject userDataInJWT = InputParser.parseJsonObjectOrThrowError(input, "userDataInJWT", true);
+
+        if (getVersionFromRequest(req).greaterThanOrEqualTo(SemVer.v2_21) &&
+                userDataInJWT != null &&
+                Arrays.stream(protectedPropNames).anyMatch(userDataInJWT::has)) {
+            throw new ServletException(new BadRequestException("The user payload contains protected field"));
+        }
 
         try {
             SessionInformationHolder sessionInfo = Session.regenerateToken(main, accessToken, userDataInJWT);

--- a/src/main/java/io/supertokens/webserver/api/session/SessionRegenerateAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/SessionRegenerateAPI.java
@@ -46,8 +46,6 @@ import java.security.SignatureException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.Arrays;
 
-import static io.supertokens.session.accessToken.AccessToken.AccessTokenInfo.protectedPropNames;
-
 public class SessionRegenerateAPI extends WebserverAPI {
 
     private static final long serialVersionUID = -6614427303762598143L;
@@ -70,14 +68,10 @@ public class SessionRegenerateAPI extends WebserverAPI {
 
         JsonObject userDataInJWT = InputParser.parseJsonObjectOrThrowError(input, "userDataInJWT", true);
 
-        if (getVersionFromRequest(req).greaterThanOrEqualTo(SemVer.v2_21) &&
-                userDataInJWT != null &&
-                Arrays.stream(protectedPropNames).anyMatch(userDataInJWT::has)) {
-            throw new ServletException(new BadRequestException("The user payload contains protected field"));
-        }
-
         try {
-            SessionInformationHolder sessionInfo = Session.regenerateToken(main, accessToken, userDataInJWT);
+            SessionInformationHolder sessionInfo = getVersionFromRequest(req).greaterThanOrEqualTo(SemVer.v2_21) ?
+                    Session.regenerateToken(main, accessToken, userDataInJWT) :
+                    Session.regenerateTokenBeforeCDI2_21(main, accessToken, userDataInJWT);
 
             JsonObject result = sessionInfo.toJsonObject();
 

--- a/src/test/java/io/supertokens/test/session/SessionGetSessionDataTest.java
+++ b/src/test/java/io/supertokens/test/session/SessionGetSessionDataTest.java
@@ -92,8 +92,7 @@ public class SessionGetSessionDataTest {
     // * Try getting and updating session information for a non-existent session handle -> Verify that both throw
     // * UnauthorisedException for session not existing
     @Test
-    public void gettingAndUpdatingSessionDataForNonExistentSession()
-            throws InterruptedException, StorageQueryException {
+    public void gettingAndUpdatingSessionDataForNonExistentSession() throws Exception {
 
         String[] args = { "../" };
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);

--- a/src/test/java/io/supertokens/test/session/SessionTest4.java
+++ b/src/test/java/io/supertokens/test/session/SessionTest4.java
@@ -120,8 +120,7 @@ public class SessionTest4 {
     }
 
     @Test
-    public void gettingAndUpdatingSessionDataForNonExistantSession()
-            throws InterruptedException, StorageQueryException {
+    public void gettingAndUpdatingSessionDataForNonExistantSession() throws Exception {
 
         String[] args = { "../" };
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);

--- a/src/test/java/io/supertokens/test/session/api/HandshakeAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/HandshakeAPITest2_21.java
@@ -28,7 +28,7 @@ import org.junit.rules.TestRule;
 
 import static org.junit.Assert.*;
 
-public class HandshakeAPITest2_19 {
+public class HandshakeAPITest2_21 {
     @Rule
     public TestRule watchman = Utils.getOnFailure();
 

--- a/src/test/java/io/supertokens/test/session/api/JWTDataAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/JWTDataAPITest2_21.java
@@ -1,0 +1,99 @@
+/*
+ *    Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.session.api;
+
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.*;
+
+public class JWTDataAPITest2_21 {
+
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void testThatAddingProtectedPropsThrow() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        // createSession with JWT payload
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_21.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+        String sessionHandle = sessionInfo.get("session").getAsJsonObject().get("handle").getAsString();
+
+
+        // change JWT payload using API
+        JsonObject newUserDataInJwt = new JsonObject();
+        newUserDataInJwt.addProperty("sub", "value2");
+        request = new JsonObject();
+        request.addProperty("sessionHandle", sessionHandle);
+        request.add("userDataInJWT", newUserDataInJwt);
+        try {
+            HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
+                    "http://localhost:3567/recipe/jwt/data", request, 1000, 1000, null, SemVer.v2_21.get(),
+                    "session");
+            fail();
+        } catch (HttpResponseException e) {
+            assertEquals(e.statusCode, 400);
+            assertEquals(e.getMessage(),
+                    "Http error. Status Code: 400. Message: The user payload contains protected field");
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+
+    }
+}

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_21.java
@@ -22,7 +22,6 @@ import io.supertokens.ProcessState;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
-import io.supertokens.test.httpRequest.HttpResponseException;
 import io.supertokens.utils.SemVer;
 import org.junit.*;
 import org.junit.rules.TestRule;
@@ -32,7 +31,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
-public class RefreshSessionAPITest2_19 {
+public class RefreshSessionAPITest2_21 {
     @Rule
     public TestRule watchman = Utils.getOnFailure();
 

--- a/src/test/java/io/supertokens/test/session/api/SessionRegenerateAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionRegenerateAPITest2_21.java
@@ -154,6 +154,17 @@ public class SessionRegenerateAPITest2_21 {
         assertEquals(caught.statusCode, 400);
         assertEquals(caught.getMessage(), "Http error. Status Code: 400. Message:" + " The user payload contains protected field");
 
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                Utils.getCdiVersionStringLatestForTests(), "session");
+
+        assertEquals("OK", sessionRefreshResponse.get("status").getAsString());
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }


### PR DESCRIPTION
## Summary of change

- Checking for protected props in JWTDataAPI to make sure it can't break a session
- Added the same checks for other endpoints - it's more consistent, and it makes sure that the changes do not get saved in the DB
- We still need the check when serializing the access tokens to ensure. The above checks are mainly for user convenience that is more about security.

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
