### PR TITLE
fix: exp and iat should not use exponential format in the access token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ local.properties
 addDevTag
 addReleaseTag
 *.iml
+ee/bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [5.0.0] - 2023-04-05
 
+### Changes
+
+- Updated the `java-jwt` dependency version 
+
 ### Fixes
 
 - Fixed creating JWTs using MongoDB if a key already exists

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation group: 'de.mkammerer', name: 'argon2-jvm', version: '2.11'
 
     // https://mvnrepository.com/artifact/com.auth0/java-jwt
-    implementation 'com.auth0:java-jwt:4.0.0'
+    implementation 'com.auth0:java-jwt:4.4.0'
 
     // https://mvnrepository.com/artifact/com.lambdaworks/scrypt
     implementation group: 'com.lambdaworks', name: 'scrypt', version: '1.4.0'

--- a/implementationDependencies.json
+++ b/implementationDependencies.json
@@ -7,9 +7,9 @@
       "src": "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.3.1/gson-2.3.1-sources.jar"
     },
     {
-      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.14.0/jackson-dataformat-yaml-2.14.0.jar",
-      "name": "Jackson Dataformat 2.14.0",
-      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.14.0/jackson-dataformat-yaml-2.14.0-sources.jar"
+      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.14.2/jackson-dataformat-yaml-2.14.2.jar",
+      "name": "Jackson Dataformat 2.14.2",
+      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.14.2/jackson-dataformat-yaml-2.14.2-sources.jar"
     },
     {
       "jar": "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.33/snakeyaml-1.33.jar",
@@ -17,19 +17,19 @@
       "src": "https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.33/snakeyaml-1.33-sources.jar"
     },
     {
-      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.0/jackson-core-2.14.0.jar",
-      "name": "Jackson core 2.14.0",
-      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.0/jackson-core-2.14.0-sources.jar"
+      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar",
+      "name": "Jackson core 2.14.2",
+      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2-sources.jar"
     },
     {
-      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.0/jackson-databind-2.14.0.jar",
-      "name": "Jackson databind 2.14.0",
-      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.0/jackson-databind-2.14.0-sources.jar"
+      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar",
+      "name": "Jackson databind 2.14.2",
+      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2-sources.jar"
     },
     {
-      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.0/jackson-annotations-2.14.0.jar",
-      "name": "Jackson annotation 2.14.0",
-      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.0/jackson-annotations-2.14.0-sources.jar"
+      "jar": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar",
+      "name": "Jackson annotation 2.14.2",
+      "src": "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2-sources.jar"
     },
     {
       "jar": "https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.2.3/logback-classic-1.2.3.jar",
@@ -77,9 +77,9 @@
       "src": "https://repo1.maven.org/maven2/org/mindrot/jbcrypt/0.4/jbcrypt-0.4-sources.jar"
     },
     {
-      "jar": "https://repo1.maven.org/maven2/com/auth0/java-jwt/4.0.0/java-jwt-4.0.0.jar",
+      "jar": "https://repo1.maven.org/maven2/com/auth0/java-jwt/4.4.0/java-jwt-4.4.0.jar",
       "name": "Auth0 Java JWT",
-      "src": "https://repo1.maven.org/maven2/com/auth0/java-jwt/4.0.0/java-jwt-4.0.0-sources.jar"
+      "src": "https://repo1.maven.org/maven2/com/auth0/java-jwt/4.4.0/java-jwt-4.4.0-sources.jar"
     },
     {
       "jar": "https://repo1.maven.org/maven2/de/mkammerer/argon2-jvm/2.11/argon2-jvm-2.11.jar",

--- a/src/main/java/io/supertokens/jwt/JWTSigningFunctions.java
+++ b/src/main/java/io/supertokens/jwt/JWTSigningFunctions.java
@@ -20,6 +20,7 @@ import com.auth0.jwt.JWTCreator;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import io.supertokens.Main;
 import io.supertokens.jwt.exceptions.UnsupportedJWTSigningAlgorithmException;
@@ -99,21 +100,18 @@ public class JWTSigningFunctions {
         headerClaims.put("kid", keyToUse.keyId);
 
         // Add relevant claims to the payload, note we only add/override ones that we absolutely need to.
-        Map<String, Object> jwtPayload = new Gson().fromJson(payload, HashMap.class);
-        if (jwksDomain != null ) {
-            jwtPayload.putIfAbsent("iss", jwksDomain);
-        }
 
         JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
-        builder.withKeyId(keyToUse.keyId);
         builder.withHeader(headerClaims);
+        builder.withKeyId(keyToUse.keyId);
+
+        builder.withPayload(payload.toString());
         builder.withIssuedAt(new Date(jwtIssuedAtInMs));
         builder.withExpiresAt(new Date(jwtExpiryInMs));
 
-        if (jwksDomain != null) {
+        if (jwksDomain != null && !payload.has("iss")) {
             builder.withIssuer(jwksDomain);
         }
-        builder.withPayload(jwtPayload);
 
         return builder.sign(signingAlgorithm);
     }

--- a/src/test/java/io/supertokens/test/session/api/SessionAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionAPITest2_21.java
@@ -78,6 +78,11 @@ public class SessionAPITest2_21 {
         checkSessionResponse(response, process, userId, userDataInJWT, false);
         assertFalse(response.has("antiCsrfToken"));
 
+        String iat = JWT.getPayloadWithoutVerifying(response.get("accessToken").getAsJsonObject().get("token").getAsString()).payload.get("iat").toString();
+        assertEquals(10, iat.length());
+        //noinspection ResultOfMethodCallIgnored
+        Long.parseLong(iat); // We are checking that this doesn't throw, it would if it was in exponential form
+
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
 


### PR DESCRIPTION
## Summary of change

- updated dependency version for java-jwt
- fixed an issue during access token serialization

## Related issues

- 

## Test Plan

Extended existing test

## Documentation changes

N/A

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
