### PR TITLE
fix: hello or not found api should not throw invalid API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+## [6.0.1]
+
+- Fixes `Invalid API key` issue on hello API
+
 ## [6.0.0] - 2023-06-02
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
-## [6.0.1]
-
 - Fixes `Invalid API key` issue on hello API
 
 ## [6.0.0] - 2023-06-02

--- a/src/main/java/io/supertokens/webserver/api/core/NotFoundOrHelloAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/core/NotFoundOrHelloAPI.java
@@ -44,6 +44,11 @@ public class NotFoundOrHelloAPI extends WebserverAPI {
     }
 
     @Override
+    protected boolean checkAPIKey(HttpServletRequest req) {
+        return false;
+    }
+
+    @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException {
         handleRequest(req, resp);
     }

--- a/src/test/java/io/supertokens/test/HelloAPITest.java
+++ b/src/test/java/io/supertokens/test/HelloAPITest.java
@@ -244,6 +244,15 @@ public class HelloAPITest {
             assertEquals(404, e.statusCode);
         }
 
+        try {
+            res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                    "http://localhost:3567", null, 1000, 1000,
+                    null, Utils.getCdiVersionStringLatestForTests(), "");
+            fail();
+        } catch (HttpResponseException e) {
+            assertEquals(404, e.statusCode);
+        }
+
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }

--- a/src/test/java/io/supertokens/test/HelloAPITest.java
+++ b/src/test/java/io/supertokens/test/HelloAPITest.java
@@ -25,14 +25,14 @@ import io.supertokens.pluginInterface.STORAGE_TYPE;
 import io.supertokens.pluginInterface.multitenancy.*;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.test.httpRequest.HttpResponseException;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class HelloAPITest {
     @Rule
@@ -161,6 +161,88 @@ public class HelloAPITest {
                 "http://localhost:3567/hello/appid-hello/hello/hello", null, 1000, 1000,
                 null, Utils.getCdiVersionStringLatestForTests(), "");
         assertEquals("Hello", res);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void testThatHelloAPIDoesNotRequireAPIKeys() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args, false);
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[]{EE_FEATURES.MULTI_TENANCY});
+        Utils.setValueInConfig("api_keys", "asdfasdfasdf123412341234");
+        Utils.setValueInConfig("base_path", "/hello");
+
+        process.startProcess();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        Multitenancy.addNewOrUpdateAppOrTenant(process.getProcess(), new TenantConfig(
+                new TenantIdentifier(null, "hello", null),
+                new EmailPasswordConfig(true),
+                new ThirdPartyConfig(true, null),
+                new PasswordlessConfig(true),
+                new JsonObject()
+        ), false);
+
+        Multitenancy.addNewOrUpdateAppOrTenant(process.getProcess(), new TenantConfig(
+                new TenantIdentifier(null, "hello", "hello"),
+                new EmailPasswordConfig(true),
+                new ThirdPartyConfig(true, null),
+                new PasswordlessConfig(true),
+                new JsonObject()
+        ), false);
+
+        Multitenancy.addNewOrUpdateAppOrTenant(process.getProcess(), new TenantConfig(
+                new TenantIdentifier(null, null, "hello"),
+                new EmailPasswordConfig(true),
+                new ThirdPartyConfig(true, null),
+                new PasswordlessConfig(true),
+                new JsonObject()
+        ), false);
+
+        String res;
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello/hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello/appid-hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello/appid-hello/hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        // Not found
+        try {
+            res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                    "http://localhost:3567/abcd", null, 1000, 1000,
+                    null, Utils.getCdiVersionStringLatestForTests(), "");
+            fail();
+        } catch (HttpResponseException e) {
+            assertEquals(404, e.statusCode);
+        }
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));

--- a/src/test/java/io/supertokens/test/HelloAPITest.java
+++ b/src/test/java/io/supertokens/test/HelloAPITest.java
@@ -167,7 +167,7 @@ public class HelloAPITest {
     }
 
     @Test
-    public void testThatHelloAPIDoesNotRequireAPIKeys() throws Exception {
+    public void testWithBasePathThatHelloAPIDoesNotRequireAPIKeys() throws Exception {
         String[] args = {"../"};
 
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args, false);
@@ -247,6 +247,87 @@ public class HelloAPITest {
         try {
             res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567", null, 1000, 1000,
+                    null, Utils.getCdiVersionStringLatestForTests(), "");
+            fail();
+        } catch (HttpResponseException e) {
+            assertEquals(404, e.statusCode);
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void testThatHelloAPIDoesNotRequireAPIKeys() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args, false);
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[]{EE_FEATURES.MULTI_TENANCY});
+        Utils.setValueInConfig("api_keys", "asdfasdfasdf123412341234");
+
+        process.startProcess();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        Multitenancy.addNewOrUpdateAppOrTenant(process.getProcess(), new TenantConfig(
+                new TenantIdentifier(null, "hello", null),
+                new EmailPasswordConfig(true),
+                new ThirdPartyConfig(true, null),
+                new PasswordlessConfig(true),
+                new JsonObject()
+        ), false);
+
+        Multitenancy.addNewOrUpdateAppOrTenant(process.getProcess(), new TenantConfig(
+                new TenantIdentifier(null, "hello", "hello"),
+                new EmailPasswordConfig(true),
+                new ThirdPartyConfig(true, null),
+                new PasswordlessConfig(true),
+                new JsonObject()
+        ), false);
+
+        Multitenancy.addNewOrUpdateAppOrTenant(process.getProcess(), new TenantConfig(
+                new TenantIdentifier(null, null, "hello"),
+                new EmailPasswordConfig(true),
+                new ThirdPartyConfig(true, null),
+                new PasswordlessConfig(true),
+                new JsonObject()
+        ), false);
+
+        String res;
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/appid-hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        res = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                "http://localhost:3567/appid-hello/hello/hello", null, 1000, 1000,
+                null, Utils.getCdiVersionStringLatestForTests(), "");
+        assertEquals("Hello", res);
+
+        // Not found
+        try {
+            HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                    "http://localhost:3567/abcd", null, 1000, 1000,
                     null, Utils.getCdiVersionStringLatestForTests(), "");
             fail();
         } catch (HttpResponseException e) {


### PR DESCRIPTION
## Summary of change

Hello API / not found should not throw `Invalid API key`

## Related issues

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
