### PR TITLE
fix: add exp and iat to JWT payloads without scientific notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+## [6.0.9] - 2023-08-14
+
+- Now using decimal notation to add numbers into the access token payload (instead of scientific notation) 
+
 ## [6.0.8] - 2023-08-01
 
 - Fixes CUD validation starting with number.

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "6.0.8"
+version = "6.0.9"
 
 
 repositories {

--- a/src/main/java/io/supertokens/jwt/JWTSigningFunctions.java
+++ b/src/main/java/io/supertokens/jwt/JWTSigningFunctions.java
@@ -127,9 +127,8 @@ public class JWTSigningFunctions {
         headerClaims.put("kid", keyToUse.keyId);
 
         // Add relevant claims to the payload, note we only add/override ones that we absolutely need to.
-        Map<String, Object> jwtPayload = new Gson().fromJson(payload, HashMap.class);
-        if (jwksDomain != null) {
-            jwtPayload.putIfAbsent("iss", jwksDomain);
+        if (jwksDomain != null && !payload.has("iss")){
+            payload.addProperty("iss", jwksDomain);
         }
 
         JWTCreator.Builder builder = com.auth0.jwt.JWT.create();
@@ -141,7 +140,7 @@ public class JWTSigningFunctions {
         if (jwksDomain != null) {
             builder.withIssuer(jwksDomain);
         }
-        builder.withPayload(jwtPayload);
+        builder.withPayload(payload.toString());
 
         return builder.sign(signingAlgorithm);
     }

--- a/src/test/java/io/supertokens/test/session/AccessTokenTest.java
+++ b/src/test/java/io/supertokens/test/session/AccessTokenTest.java
@@ -18,6 +18,7 @@ package io.supertokens.test.session;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.supertokens.ProcessState.EventAndException;
 import io.supertokens.ProcessState.PROCESS_STATE;
 import io.supertokens.exceptions.AccessTokenPayloadError;
@@ -272,6 +273,11 @@ public class AccessTokenTest {
         assertEquals("antiCsrfToken", info.antiCsrfToken);
         assertEquals(expiryTime / 1000 * 1000, info.expiryTime);
 
+        JsonObject payload = (JsonObject) new JsonParser()
+                .parse(io.supertokens.utils.Utils.convertFromBase64(newToken.token.split("\\.")[1]));
+        // This throws if the number is in scientific (E) format
+        assertEquals(expiryTime / 1000, Long.parseLong(payload.get("exp").toString()));
+
         JWT.JWTPreParseInfo jwtInfo = JWT.preParseJWTInfo(newToken.token);
         assertNotNull(jwtInfo.kid);
         assertEquals(jwtInfo.version, AccessToken.getLatestVersion());
@@ -302,6 +308,11 @@ public class AccessTokenTest {
         assertEquals("antiCsrfToken", info.antiCsrfToken);
         assertEquals(expiryTime / 1000 * 1000, info.expiryTime);
 
+        JsonObject payload = (JsonObject) new JsonParser()
+                .parse(io.supertokens.utils.Utils.convertFromBase64(newToken.token.split("\\.")[1]));
+        // This throws if the number is in scientific (E) format
+        assertEquals(expiryTime / 1000, Long.parseLong(payload.get("exp").toString()));
+
         JWT.JWTPreParseInfo jwtInfo = JWT.preParseJWTInfo(newToken.token);
         assertNotNull(jwtInfo.kid);
         assertEquals(jwtInfo.version, AccessToken.getLatestVersion());
@@ -330,6 +341,12 @@ public class AccessTokenTest {
         assertEquals("value", info.userData.get("key").getAsString());
         assertEquals("antiCsrfToken", info.antiCsrfToken);
         assertEquals(expiryTime, info.expiryTime);
+
+        JsonObject payload = (JsonObject) new JsonParser()
+                .parse(io.supertokens.utils.Utils.convertFromBase64(newToken.token.split("\\.")[1]));
+        // This throws if the number is in scientific (E) format
+        assertEquals(expiryTime, Long.parseLong(payload.get("expiryTime").toString()));
+
         process.kill();
     }
 
@@ -355,6 +372,12 @@ public class AccessTokenTest {
         assertEquals("parentRefreshTokenHash1", info.parentRefreshTokenHash1);
         assertEquals("value", info.userData.get("key").getAsString());
         assertEquals("antiCsrfToken", info.antiCsrfToken);
+
+        JsonObject payload = (JsonObject) new JsonParser()
+                .parse(io.supertokens.utils.Utils.convertFromBase64(newToken.token.split("\\.")[1]));
+        // This throws if the number is in scientific (E) format
+        Long.parseLong(payload.get("expiryTime").toString());
+
         process.kill();
     }
 


### PR DESCRIPTION
## Summary of change

Now using decimal notation to add numbers into the access token payload (instead of scientific notation)

## Related issues

- 

## Test Plan

Updated inputOutput tests to check the expiration time format

## Documentation changes

N/A

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
