### PR TITLE
fix: fix handling of b64 and b64url encoded access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+## [6.0.10] - 2023-08-16
+
+- Fixed an encoding/decoding issue for certain access token payloads
+
 ## [6.0.9] - 2023-08-14
 
 - Now using decimal notation to add numbers into the access token payload (instead of scientific notation) 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "6.0.9"
+version = "6.0.10"
 
 
 repositories {

--- a/src/main/java/io/supertokens/utils/Utils.java
+++ b/src/main/java/io/supertokens/utils/Utils.java
@@ -77,8 +77,9 @@ public class Utils {
         return new String(Base64.getEncoder().encode(stringToBytes(str)), StandardCharsets.UTF_8);
     }
 
+    // This function deserializes both B64 and B64URL encodings
     public static String convertFromBase64(String str) {
-        return new String(Base64.getDecoder().decode(stringToBytes(str)), StandardCharsets.UTF_8);
+        return new String(Base64.getDecoder().decode(stringToBytes(str.replace("-", "+").replace("_", "/"))), StandardCharsets.UTF_8);
     }
 
     public static String throwableStacktraceToString(Throwable e) {

--- a/src/test/java/io/supertokens/test/session/AccessTokenTest.java
+++ b/src/test/java/io/supertokens/test/session/AccessTokenTest.java
@@ -257,7 +257,8 @@ public class AccessTokenTest {
         EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
         assertNotNull(e);
         JsonObject jsonObj = new JsonObject();
-        jsonObj.addProperty("key", "value");
+        String testValue = "asdf???123";
+        jsonObj.addProperty("key", testValue);
 
         // db key
         long expiryTime = System.currentTimeMillis() + 1000;
@@ -269,7 +270,7 @@ public class AccessTokenTest {
         assertEquals("userId", info.userId);
         assertEquals("refreshTokenHash1", info.refreshTokenHash1);
         assertEquals("parentRefreshTokenHash1", info.parentRefreshTokenHash1);
-        assertEquals("value", info.userData.get("key").getAsString());
+        assertEquals(testValue, info.userData.get("key").getAsString());
         assertEquals("antiCsrfToken", info.antiCsrfToken);
         assertEquals(expiryTime / 1000 * 1000, info.expiryTime);
 
@@ -292,19 +293,21 @@ public class AccessTokenTest {
         EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
         assertNotNull(e);
         JsonObject jsonObj = new JsonObject();
-        jsonObj.addProperty("key", "value");
+        String testValue = "asdf???123";
+        jsonObj.addProperty("key", testValue);
 
         // db key
         long expiryTime = System.currentTimeMillis() + 1000;
         TokenInfo newToken = AccessToken.createNewAccessToken(process.getProcess(), "sessionHandle", "userId",
                 "refreshTokenHash1", "parentRefreshTokenHash1", jsonObj, "antiCsrfToken", expiryTime,
                 AccessToken.getLatestVersion(), true);
+        System.out.println(newToken.token);
         AccessTokenInfo info = AccessToken.getInfoFromAccessToken(process.getProcess(), newToken.token, true);
         assertEquals("sessionHandle", info.sessionHandle);
         assertEquals("userId", info.userId);
         assertEquals("refreshTokenHash1", info.refreshTokenHash1);
         assertEquals("parentRefreshTokenHash1", info.parentRefreshTokenHash1);
-        assertEquals("value", info.userData.get("key").getAsString());
+        assertEquals(testValue, info.userData.get("key").getAsString());
         assertEquals("antiCsrfToken", info.antiCsrfToken);
         assertEquals(expiryTime / 1000 * 1000, info.expiryTime);
 
@@ -326,7 +329,8 @@ public class AccessTokenTest {
         EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
         assertNotNull(e);
         JsonObject jsonObj = new JsonObject();
-        jsonObj.addProperty("key", "value");
+        String testValue = "asdf???123";
+        jsonObj.addProperty("key", testValue);
 
         // db key
         long expiryTime = System.currentTimeMillis() + 1000;
@@ -338,7 +342,7 @@ public class AccessTokenTest {
         assertEquals("userId", info.userId);
         assertEquals("refreshTokenHash1", info.refreshTokenHash1);
         assertEquals("parentRefreshTokenHash1", info.parentRefreshTokenHash1);
-        assertEquals("value", info.userData.get("key").getAsString());
+        assertEquals(testValue, info.userData.get("key").getAsString());
         assertEquals("antiCsrfToken", info.antiCsrfToken);
         assertEquals(expiryTime, info.expiryTime);
 
@@ -360,7 +364,8 @@ public class AccessTokenTest {
         EventAndException e = process.checkOrWaitForEvent(PROCESS_STATE.STARTED);
         assertNotNull(e);
         JsonObject jsonObj = new JsonObject();
-        jsonObj.addProperty("key", "value");
+        String testValue = "asdf???123";
+        jsonObj.addProperty("key", testValue);
 
         // db key
         TokenInfo newToken = AccessToken.createNewAccessTokenV1(process.getProcess(), "sessionHandle", "userId",
@@ -370,7 +375,7 @@ public class AccessTokenTest {
         assertEquals("userId", info.userId);
         assertEquals("refreshTokenHash1", info.refreshTokenHash1);
         assertEquals("parentRefreshTokenHash1", info.parentRefreshTokenHash1);
-        assertEquals("value", info.userData.get("key").getAsString());
+        assertEquals(testValue, info.userData.get("key").getAsString());
         assertEquals("antiCsrfToken", info.antiCsrfToken);
 
         JsonObject payload = (JsonObject) new JsonParser()


### PR DESCRIPTION
## Summary of change

fix handling of b64 and b64url encoded access tokens

## Related issues

- Issues in prod logs

## Test Plan

Updated existing tests to highlight differences between encodings

## Documentation changes

N/A, bugfix

## Checklist for important updates

- [x] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
