### PR TITLE
fix: user object in link accounts api

### DIFF
--- a/src/main/java/io/supertokens/authRecipe/AuthRecipe.java
+++ b/src/main/java/io/supertokens/authRecipe/AuthRecipe.java
@@ -234,7 +234,7 @@ public class AuthRecipe {
             if (recipeUser.getSupertokensUserId().equals(primaryUser.getSupertokensUserId())) {
                 return new CanLinkAccountsResult(recipeUser.getSupertokensUserId(), primaryUser.getSupertokensUserId(), true);
             } else {
-                throw new RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException(recipeUser.getSupertokensUserId(),
+                throw new RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException(recipeUser,
                         "The input recipe user ID is already linked to another user ID");
             }
         }
@@ -308,7 +308,7 @@ public class AuthRecipe {
     }
 
     @TestOnly
-    public static boolean linkAccounts(Main main, String recipeUserId, String primaryUserId)
+    public static LinkAccountsResult linkAccounts(Main main, String recipeUserId, String primaryUserId)
             throws StorageQueryException, AccountInfoAlreadyAssociatedWithAnotherPrimaryUserIdException,
             UnknownUserIdException,
             FeatureNotEnabledException, InputUserIdIsNotAPrimaryUserException,
@@ -322,7 +322,7 @@ public class AuthRecipe {
         }
     }
 
-    public static boolean linkAccounts(Main main, AppIdentifierWithStorage appIdentifierWithStorage,
+    public static LinkAccountsResult linkAccounts(Main main, AppIdentifierWithStorage appIdentifierWithStorage,
                                        String _recipeUserId, String _primaryUserId)
             throws StorageQueryException,
             AccountInfoAlreadyAssociatedWithAnotherPrimaryUserIdException,
@@ -337,14 +337,14 @@ public class AuthRecipe {
 
         AuthRecipeSQLStorage storage = (AuthRecipeSQLStorage) appIdentifierWithStorage.getAuthRecipeStorage();
         try {
-            boolean wasAlreadyLinked = storage.startTransaction(con -> {
+            LinkAccountsResult result = storage.startTransaction(con -> {
 
                 try {
                     CanLinkAccountsResult canLinkAccounts = canLinkAccountsHelper(con, appIdentifierWithStorage,
                             _recipeUserId, _primaryUserId);
 
                     if (canLinkAccounts.alreadyLinked) {
-                        return true;
+                        return new LinkAccountsResult(getUserById(appIdentifierWithStorage, canLinkAccounts.primaryUserId), true);
                     }
                     // now we can link accounts in the db.
                     storage.linkAccounts_Transaction(appIdentifierWithStorage, con, canLinkAccounts.recipeUserId,
@@ -352,7 +352,7 @@ public class AuthRecipe {
 
                     storage.commitTransaction(con);
 
-                    return false;
+                    return new LinkAccountsResult(getUserById(appIdentifierWithStorage, canLinkAccounts.primaryUserId), true);
                 } catch (UnknownUserIdException | InputUserIdIsNotAPrimaryUserException |
                          RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException |
                          AccountInfoAlreadyAssociatedWithAnotherPrimaryUserIdException e) {
@@ -360,7 +360,7 @@ public class AuthRecipe {
                 }
             });
 
-            if (!wasAlreadyLinked) {
+            if (!result.wasAlreadyLinked) {
                 io.supertokens.pluginInterface.useridmapping.UserIdMapping mappingResult =
                         io.supertokens.useridmapping.UserIdMapping.getUserIdMapping(
                                 appIdentifierWithStorage,
@@ -370,7 +370,7 @@ public class AuthRecipe {
                         mappingResult == null ? _recipeUserId : mappingResult.externalUserId, false);
             }
 
-            return wasAlreadyLinked;
+            return result;
         } catch (StorageTransactionLogicException e) {
             if (e.actualException instanceof UnknownUserIdException) {
                 throw (UnknownUserIdException) e.actualException;
@@ -382,6 +382,16 @@ public class AuthRecipe {
                 throw (AccountInfoAlreadyAssociatedWithAnotherPrimaryUserIdException) e.actualException;
             }
             throw new StorageQueryException(e);
+        }
+    }
+
+    public static class LinkAccountsResult {
+        public final AuthRecipeUserInfo user;
+        public final boolean wasAlreadyLinked;
+
+        public LinkAccountsResult(AuthRecipeUserInfo user, boolean wasAlreadyLinked) {
+            this.user = user;
+            this.wasAlreadyLinked = wasAlreadyLinked;
         }
     }
 

--- a/src/main/java/io/supertokens/authRecipe/AuthRecipe.java
+++ b/src/main/java/io/supertokens/authRecipe/AuthRecipe.java
@@ -352,7 +352,7 @@ public class AuthRecipe {
 
                     storage.commitTransaction(con);
 
-                    return new LinkAccountsResult(getUserById(appIdentifierWithStorage, canLinkAccounts.primaryUserId), true);
+                    return new LinkAccountsResult(getUserById(appIdentifierWithStorage, canLinkAccounts.primaryUserId), false);
                 } catch (UnknownUserIdException | InputUserIdIsNotAPrimaryUserException |
                          RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException |
                          AccountInfoAlreadyAssociatedWithAnotherPrimaryUserIdException e) {

--- a/src/main/java/io/supertokens/authRecipe/exception/RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException.java
+++ b/src/main/java/io/supertokens/authRecipe/exception/RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException.java
@@ -16,11 +16,13 @@
 
 package io.supertokens.authRecipe.exception;
 
-public class RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException extends Exception {
-    public final String primaryUserId;
+import io.supertokens.pluginInterface.authRecipe.AuthRecipeUserInfo;
 
-    public RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException(String primaryUserId, String description) {
+public class RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException extends Exception {
+    public final AuthRecipeUserInfo recipeUser;
+
+    public RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException(AuthRecipeUserInfo recipeUser, String description) {
         super(description);
-        this.primaryUserId = primaryUserId;
+        this.recipeUser = recipeUser;
     }
 }

--- a/src/main/java/io/supertokens/webserver/api/accountlinking/CanLinkAccountsAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/accountlinking/CanLinkAccountsAPI.java
@@ -24,6 +24,7 @@ import io.supertokens.authRecipe.exception.AccountInfoAlreadyAssociatedWithAnoth
 import io.supertokens.authRecipe.exception.InputUserIdIsNotAPrimaryUserException;
 import io.supertokens.authRecipe.exception.RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException;
 import io.supertokens.pluginInterface.RECIPE_ID;
+import io.supertokens.pluginInterface.authRecipe.AuthRecipeUserInfo;
 import io.supertokens.pluginInterface.emailpassword.exceptions.UnknownUserIdException;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifierWithStorage;
@@ -121,14 +122,8 @@ public class CanLinkAccountsAPI extends WebserverAPI {
             try {
                 JsonObject response = new JsonObject();
                 response.addProperty("status", "RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR");
-                io.supertokens.pluginInterface.useridmapping.UserIdMapping result = UserIdMapping.getUserIdMapping(
-                        recipeUserIdAppIdentifierWithStorage, e.primaryUserId,
-                        UserIdType.SUPERTOKENS);
-                if (result != null) {
-                    response.addProperty("primaryUserId", result.externalUserId);
-                } else {
-                    response.addProperty("primaryUserId", e.primaryUserId);
-                }
+                UserIdMapping.populateExternalUserIdForUsers(recipeUserIdAppIdentifierWithStorage, new AuthRecipeUserInfo[]{e.recipeUser});
+                response.addProperty("primaryUserId", e.recipeUser.getSupertokensOrExternalUserId());
                 response.addProperty("description", e.getMessage());
                 super.sendJsonResponse(200, response, resp);
             } catch (StorageQueryException ex) {

--- a/src/main/java/io/supertokens/webserver/api/core/ListUsersByAccountInfoAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/core/ListUsersByAccountInfoAPI.java
@@ -76,18 +76,7 @@ public class ListUsersByAccountInfoAPI extends WebserverAPI {
             AuthRecipeUserInfo[] users = AuthRecipe.getUsersByAccountInfo(
                     this.getTenantIdentifierWithStorageFromRequest(
                             req), doUnionOfAccountInfo, email, phoneNumber, thirdPartyId, thirdPartyUserId);
-
-            for (int i = 0; i < users.length; i++) {
-                // we intentionally do not use the function that accepts an array of user IDs to get the mapping cause
-                // this is simpler to use, and cause there shouldn't be that many userIds per email anyway
-                io.supertokens.pluginInterface.useridmapping.UserIdMapping userIdMapping = UserIdMapping
-                        .getUserIdMapping(appIdentifierWithStorage, users[i].getSupertokensUserId(), UserIdType.SUPERTOKENS);
-                if (userIdMapping != null) {
-                    users[i].setExternalUserId(userIdMapping.externalUserId);
-                } else {
-                    users[i].setExternalUserId(null);
-                }
-            }
+            UserIdMapping.populateExternalUserIdForUsers(appIdentifierWithStorage, users);
 
             JsonObject result = new JsonObject();
             result.addProperty("status", "OK");

--- a/src/test/java/io/supertokens/test/accountlinking/DeleteUserTest.java
+++ b/src/test/java/io/supertokens/test/accountlinking/DeleteUserTest.java
@@ -73,7 +73,7 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r1.getSupertokensUserId(), false);
 
@@ -110,7 +110,7 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r2.getSupertokensUserId(), false);
 
@@ -148,7 +148,7 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r2.getSupertokensUserId());
 
@@ -183,7 +183,7 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r1.getSupertokensUserId());
 
@@ -228,7 +228,7 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r1.getSupertokensUserId(), false);
 
@@ -280,7 +280,7 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r1.getSupertokensUserId());
 
@@ -338,8 +338,8 @@ public class DeleteUserTest {
 
         AuthRecipe.createPrimaryUser(process.main, r2.getSupertokensUserId());
 
-        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()));
-        assert (!AuthRecipe.linkAccounts(process.main, r3.getSupertokensUserId(), r1.getSupertokensUserId()));
+        assert (!AuthRecipe.linkAccounts(process.main, r1.getSupertokensUserId(), r2.getSupertokensUserId()).wasAlreadyLinked);
+        assert (!AuthRecipe.linkAccounts(process.main, r3.getSupertokensUserId(), r1.getSupertokensUserId()).wasAlreadyLinked);
 
         AuthRecipe.deleteUser(process.main, r1.getSupertokensUserId(), false);
 

--- a/src/test/java/io/supertokens/test/accountlinking/LinkAccountsTest.java
+++ b/src/test/java/io/supertokens/test/accountlinking/LinkAccountsTest.java
@@ -88,7 +88,7 @@ public class LinkAccountsTest {
         String[] sessions = Session.getAllNonExpiredSessionHandlesForUser(process.main, user2.getSupertokensUserId());
         assert (sessions.length == 1);
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo refetchUser2 = AuthRecipe.getUserById(process.main, user2.getSupertokensUserId());
@@ -140,7 +140,7 @@ public class LinkAccountsTest {
         String[] sessions = Session.getAllNonExpiredSessionHandlesForUser(process.main, user2.getSupertokensUserId());
         assert (sessions.length == 1);
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo refetchUser2 = AuthRecipe.getUserById(process.main, user2.getSupertokensUserId());
@@ -204,13 +204,13 @@ public class LinkAccountsTest {
 
         AuthRecipe.createPrimaryUser(process.main, user.getSupertokensUserId());
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo user3 = EmailPassword.signUp(process.getProcess(), "test3@example.com", "password");
         assert (!user3.isPrimaryUser);
 
-        wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user3.getSupertokensUserId(), user2.getSupertokensUserId());
+        wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user3.getSupertokensUserId(), user2.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo refetchUser = AuthRecipe.getUserById(process.main, user.getSupertokensUserId());
@@ -256,14 +256,14 @@ public class LinkAccountsTest {
 
         AuthRecipe.createPrimaryUser(process.main, user.getSupertokensUserId());
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         Session.createNewSession(process.main, user2.getSupertokensUserId(), new JsonObject(), new JsonObject());
         String[] sessions = Session.getAllNonExpiredSessionHandlesForUser(process.main, user2.getSupertokensUserId());
         assert (sessions.length == 1);
 
-        wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (wasAlreadyLinked);
 
         // cause linkAccounts revokes sessions for the recipe user ID
@@ -301,7 +301,7 @@ public class LinkAccountsTest {
 
         AuthRecipe.createPrimaryUser(process.main, user.getSupertokensUserId());
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo user3 = EmailPassword.signUp(process.getProcess(), "test3@example.com", "password");
@@ -312,7 +312,7 @@ public class LinkAccountsTest {
             AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user3.getSupertokensUserId());
             assert (false);
         } catch (RecipeUserIdAlreadyLinkedWithAnotherPrimaryUserIdException e) {
-            assert (e.primaryUserId.equals(user.getSupertokensUserId()));
+            assert (e.recipeUser.getSupertokensUserId().equals(user.getSupertokensUserId()));
             assert (e.getMessage().equals("The input recipe user ID is already linked to another user ID"));
         }
 
@@ -533,7 +533,7 @@ public class LinkAccountsTest {
         AuthRecipeUserInfo user2 = signInUpResponse.user;
         assert (!user2.isPrimaryUser);
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo refetchedUser1 = AuthRecipe.getUserById(process.main, user.getSupertokensUserId());
@@ -584,7 +584,7 @@ public class LinkAccountsTest {
         Passwordless.updateUser(process.main, user2.getSupertokensUserId(), null, new Passwordless.FieldUpdate("1234"));
         user2 = AuthRecipe.getUserById(process.main, user2.getSupertokensUserId());
 
-        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId());
+        boolean wasAlreadyLinked = AuthRecipe.linkAccounts(process.main, user2.getSupertokensUserId(), user.getSupertokensUserId()).wasAlreadyLinked;
         assert (!wasAlreadyLinked);
 
         AuthRecipeUserInfo refetchUser2 = AuthRecipe.getUserById(process.main, user2.getSupertokensUserId());

--- a/src/test/java/io/supertokens/test/accountlinking/api/CanLinkAccountsAPITest.java
+++ b/src/test/java/io/supertokens/test/accountlinking/api/CanLinkAccountsAPITest.java
@@ -378,13 +378,12 @@ public class CanLinkAccountsAPITest {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/accountlinking/user/link/check", params, 1000, 1000, null,
                     WebserverAPI.getLatestCDIVersion().get(), "");
-            assertEquals(4, response.entrySet().size());
+            assertEquals(3, response.entrySet().size());
             assertEquals("RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
                     response.get("status").getAsString());
             assertEquals(emailPasswordUser1.getSupertokensUserId(), response.get("primaryUserId").getAsString());
             assertEquals("The input recipe user ID is already linked to another user ID",
                     response.get("description").getAsString());
-            assertTrue(response.has("user"));
         }
 
         process.kill();
@@ -425,13 +424,12 @@ public class CanLinkAccountsAPITest {
             JsonObject response = HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/accountlinking/user/link/check", params, 1000, 1000, null,
                     WebserverAPI.getLatestCDIVersion().get(), "");
-            assertEquals(4, response.entrySet().size());
+            assertEquals(3, response.entrySet().size());
             assertEquals("RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR",
                     response.get("status").getAsString());
             assertEquals("r1", response.get("primaryUserId").getAsString());
             assertEquals("The input recipe user ID is already linked to another user ID",
                     response.get("description").getAsString());
-            assertTrue(response.has("user"));
         }
 
         process.kill();

--- a/src/test/java/io/supertokens/test/accountlinking/api/GetUserByAccountInfoTest.java
+++ b/src/test/java/io/supertokens/test/accountlinking/api/GetUserByAccountInfoTest.java
@@ -435,8 +435,8 @@ public class GetUserByAccountInfoTest {
         JsonObject primaryUserInfo = getUsersByAccountInfo(process.getProcess(), false,
                 "test@example.com", null, null, null).get(0).getAsJsonObject();
         assertEquals("ext1", primaryUserInfo.get("loginMethods").getAsJsonArray().get(0).getAsJsonObject().get("recipeUserId").getAsString());
-        assertNotEquals("ext2", primaryUserInfo.get("loginMethods").getAsJsonArray().get(1).getAsJsonObject().get("recipeUserId").getAsString()); // TODO should be equal once userIdMapping is fixed
-        assertNotEquals("ext3", primaryUserInfo.get("loginMethods").getAsJsonArray().get(2).getAsJsonObject().get("recipeUserId").getAsString()); // TODO should be equal once userIdMapping is fixed
+        assertEquals("ext2", primaryUserInfo.get("loginMethods").getAsJsonArray().get(1).getAsJsonObject().get("recipeUserId").getAsString());
+        assertEquals("ext3", primaryUserInfo.get("loginMethods").getAsJsonArray().get(2).getAsJsonObject().get("recipeUserId").getAsString());
 
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));

--- a/src/test/java/io/supertokens/test/authRecipe/GetUserByIdAPITest.java
+++ b/src/test/java/io/supertokens/test/authRecipe/GetUserByIdAPITest.java
@@ -191,7 +191,7 @@ public class GetUserByIdAPITest {
                 JsonObject lM = jsonUser.get("loginMethods").getAsJsonArray().get(1).getAsJsonObject();
                 assertFalse(lM.get("verified").getAsBoolean());
                 assertEquals(lM.get("timeJoined").getAsLong(), user2.timeJoined);
-                assertEquals(lM.get("recipeUserId").getAsString(), user2.getSupertokensUserId());
+                assertEquals(lM.get("recipeUserId").getAsString(), "e2");
                 assertEquals(lM.get("recipeId").getAsString(), "emailpassword");
                 assertEquals(lM.get("email").getAsString(), "test2@example.com");
                 assert (lM.entrySet().size() == 6);


### PR DESCRIPTION
## Summary of change

- Link account should return the updated user object in status OK
- linkAccount should return the updated user object in status `RECIPE_USER_ID_ALREADY_LINKED_WITH_ANOTHER_PRIMARY_USER_ID_ERROR`

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
