### PR TITLE
feat: linkcodes and preauthsessionids should not use padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+- Remove padding from link codes and pre-auth session ids in passwordless, but keep support for old format that included padding (`=` signs)
+
 ## [7.0.0] - 2023-09-19
 
 - Support for CDI version 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [7.0.1] - 2023-10-04
 
 - Remove padding from link codes and pre-auth session ids in passwordless, but keep support for old format that included padding (`=` signs)
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "7.0.0"
+version = "7.0.1"
 
 
 repositories {

--- a/src/main/java/io/supertokens/passwordless/Passwordless.java
+++ b/src/main/java/io/supertokens/passwordless/Passwordless.java
@@ -316,7 +316,7 @@ public class Passwordless {
             linkCodeHash = parsedDeviceId.getLinkCode(linkCodeSalt, userInputCode).getHash();
         }
 
-        if (!deviceIdHash.encode().equals(deviceIdHashFromUser)) {
+        if (!deviceIdHash.encode().equals(deviceIdHashFromUser.replaceAll("=", ""))) {
             throw new DeviceIdHashMismatchException();
         }
 

--- a/src/main/java/io/supertokens/passwordless/PasswordlessDeviceIdHash.java
+++ b/src/main/java/io/supertokens/passwordless/PasswordlessDeviceIdHash.java
@@ -8,7 +8,7 @@ public class PasswordlessDeviceIdHash {
     public PasswordlessDeviceIdHash(byte[] bytes) {
         // We never do anything further with the bytes, so we can just encode, store and reuse it.
         // If we choose to do storage based on bytes this can change.
-        this.encodedValue = Base64.getUrlEncoder().encodeToString(bytes);
+        this.encodedValue = Base64.getUrlEncoder().encodeToString(bytes).replaceAll("=", "");
     }
 
     public PasswordlessDeviceIdHash(String encodedValue) {

--- a/src/main/java/io/supertokens/passwordless/PasswordlessLinkCode.java
+++ b/src/main/java/io/supertokens/passwordless/PasswordlessLinkCode.java
@@ -23,7 +23,7 @@ public class PasswordlessLinkCode {
     }
 
     public String encode() {
-        return Base64.getUrlEncoder().encodeToString(bytes);
+        return Base64.getUrlEncoder().encodeToString(bytes).replaceAll("=", "");
     }
 
     public PasswordlessLinkCodeHash getHash() throws NoSuchAlgorithmException {

--- a/src/test/java/io/supertokens/test/passwordless/PasswordlessConsumeCodeTest.java
+++ b/src/test/java/io/supertokens/test/passwordless/PasswordlessConsumeCodeTest.java
@@ -118,9 +118,12 @@ public class PasswordlessConsumeCodeTest {
                 null, null);
         assertNotNull(createCodeResponse);
 
+        assert(!createCodeResponse.deviceIdHash.contains("="));
+        assert(!createCodeResponse.linkCode.contains("="));
+
         long consumeStart = System.currentTimeMillis();
         Passwordless.ConsumeCodeResponse consumeCodeResponse = Passwordless.consumeCode(process.getProcess(), null,
-                createCodeResponse.deviceIdHash.replace("=", ""), null, createCodeResponse.linkCode.replace("=", ""));
+                createCodeResponse.deviceIdHash, null, createCodeResponse.linkCode);
         
         assertNotNull(consumeCodeResponse);
         checkUserWithConsumeResponse(storage, consumeCodeResponse, EMAIL, null, consumeStart);

--- a/src/test/java/io/supertokens/test/passwordless/PasswordlessConsumeCodeTest.java
+++ b/src/test/java/io/supertokens/test/passwordless/PasswordlessConsumeCodeTest.java
@@ -97,6 +97,78 @@ public class PasswordlessConsumeCodeTest {
     }
 
     /**
+     * success without existing user - link code with equal signs removed
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConsumeLinkCodeWithoutEqualSigns() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        PasswordlessStorage storage = (PasswordlessStorage) StorageLayer.getStorage(process.getProcess());
+
+        Passwordless.CreateCodeResponse createCodeResponse = Passwordless.createCode(process.getProcess(), EMAIL, null,
+                null, null);
+        assertNotNull(createCodeResponse);
+
+        long consumeStart = System.currentTimeMillis();
+        Passwordless.ConsumeCodeResponse consumeCodeResponse = Passwordless.consumeCode(process.getProcess(), null,
+                createCodeResponse.deviceIdHash.replace("=", ""), null, createCodeResponse.linkCode.replace("=", ""));
+        
+        assertNotNull(consumeCodeResponse);
+        checkUserWithConsumeResponse(storage, consumeCodeResponse, EMAIL, null, consumeStart);
+
+        PasswordlessDevice[] devices = storage.getDevicesByEmail(new TenantIdentifier(null, null, null), EMAIL);
+        assertEquals(0, devices.length);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    /**
+     * success without existing user - link code with equal signs (padding)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConsumeLinkCodeWithEqualSigns() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        PasswordlessStorage storage = (PasswordlessStorage) StorageLayer.getStorage(process.getProcess());
+
+        Passwordless.CreateCodeResponse createCodeResponse = Passwordless.createCode(process.getProcess(), EMAIL, null,
+                null, null);
+        assertNotNull(createCodeResponse);
+
+        long consumeStart = System.currentTimeMillis();
+        Passwordless.ConsumeCodeResponse consumeCodeResponse = Passwordless.consumeCode(process.getProcess(), null,
+                createCodeResponse.deviceIdHash + "=", null, createCodeResponse.linkCode + "=");
+        
+        assertNotNull(consumeCodeResponse);
+        checkUserWithConsumeResponse(storage, consumeCodeResponse, EMAIL, null, consumeStart);
+
+        PasswordlessDevice[] devices = storage.getDevicesByEmail(new TenantIdentifier(null, null, null), EMAIL);
+        assertEquals(0, devices.length);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    /**
      * Success without existing user - input code
      *
      * @throws Exception


### PR DESCRIPTION
## Summary of change

- linkCodes and preAuthSessionIds should not use padding (= signs)
- we should accept them with and without = signs

## Related issues

- Issue reported on discord about some router clearing `=` signs from query params

## Test Plan

- Added new test that removes all '=' signs from linkcodes and preauthsessionids and checks that it remains the same (plus it still works)
- Added new test that adds '=' signs to linkcodes and preauthsessionids and checks that it sign in still works.

## Documentation changes

We can update some example data, but we do not document the format in detail

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [x] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting the user as well if `deleteUserIdMappingToo` is false.
