### PR TITLE
fix: email verification fix with user id mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.11] - 2023-11-10
+
+- Fixes email verification behaviour with user id mapping
+
 ## [7.0.10] - 2023-11-03
 
 - Collects requests stats per app

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "7.0.10"
+version = "7.0.11"
 
 
 repositories {

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -1059,6 +1059,11 @@ public class Start
     }
 
     @Override
+    public void updateIsEmailVerifiedToExternalUserId(AppIdentifier appIdentifier, String supertokensUserId, String externalUserId) throws StorageQueryException {
+        EmailVerificationQueries.updateIsEmailVerifiedToExternalUserId(this, appIdentifier, supertokensUserId, externalUserId);
+    }
+
+    @Override
     public void deleteExpiredPasswordResetTokens() throws StorageQueryException {
         try {
             EmailPasswordQueries.deleteExpiredPasswordResetTokens(this);

--- a/src/main/java/io/supertokens/passwordless/Passwordless.java
+++ b/src/main/java/io/supertokens/passwordless/Passwordless.java
@@ -257,6 +257,23 @@ public class Passwordless {
     }
 
     @TestOnly
+    public static ConsumeCodeResponse consumeCode(Main main,
+                                                  String deviceId, String deviceIdHashFromUser,
+                                                  String userInputCode, String linkCode, boolean setEmailVerified)
+            throws RestartFlowException, ExpiredUserInputCodeException,
+            IncorrectUserInputCodeException, DeviceIdHashMismatchException, StorageTransactionLogicException,
+            StorageQueryException, NoSuchAlgorithmException, InvalidKeyException, IOException, Base64EncodingException {
+        try {
+            Storage storage = StorageLayer.getStorage(main);
+            return consumeCode(
+                    new TenantIdentifierWithStorage(null, null, null, storage),
+                    main, deviceId, deviceIdHashFromUser, userInputCode, linkCode, setEmailVerified);
+        } catch (TenantOrAppNotFoundException | BadPermissionException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @TestOnly
     public static ConsumeCodeResponse consumeCode(TenantIdentifierWithStorage tenantIdentifierWithStorage, Main main,
                                                   String deviceId, String deviceIdHashFromUser,
                                                   String userInputCode, String linkCode)

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -415,8 +415,8 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
         }
         if (userIdType != UserIdType.SUPERTOKENS) {
             try {
-                io.supertokens.useridmapping.UserIdMapping.assertThatUserIdIsNotBeingUsedInNonAuthRecipes(
-                        tenantIdentifierWithStorage.toAppIdentifierWithStorage(), userId);
+                io.supertokens.useridmapping.UserIdMapping.findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed(
+                        tenantIdentifierWithStorage.toAppIdentifierWithStorage(), userId, true);
             } catch (ServletException e) {
                 // this means that the userId is being used for a non auth recipe.
                 return new TenantIdentifierWithStorageAndUserIdMapping(
@@ -457,8 +457,8 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
             if (userIdType != UserIdType.SUPERTOKENS) {
                 AppIdentifierWithStorage appIdentifierWithStorage = appIdentifier.withStorage(priorityStorage);
                 try {
-                    io.supertokens.useridmapping.UserIdMapping.assertThatUserIdIsNotBeingUsedInNonAuthRecipes(
-                            appIdentifierWithStorage, userId);
+                    io.supertokens.useridmapping.UserIdMapping.findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed(
+                            appIdentifierWithStorage, userId, true);
                 } catch (ServletException e) {
                     // this means that the userId is being used for a non auth recipe.
                     return new AppIdentifierWithStorageAndUserIdMapping(appIdentifierWithStorage, null);
@@ -488,8 +488,8 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
             if (userIdType != UserIdType.SUPERTOKENS) {
                 AppIdentifierWithStorage appIdentifierWithStorage = appIdentifier.withStorage(storage);
                 try {
-                    io.supertokens.useridmapping.UserIdMapping.assertThatUserIdIsNotBeingUsedInNonAuthRecipes(
-                            appIdentifierWithStorage, userId);
+                    io.supertokens.useridmapping.UserIdMapping.findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed(
+                            appIdentifierWithStorage, userId, true);
                 } catch (ServletException e) {
                     // this means that the userId is being used for a non auth recipe.
                     return new AppIdentifierWithStorageAndUserIdMapping(appIdentifierWithStorage, null);

--- a/src/main/java/io/supertokens/thirdparty/ThirdParty.java
+++ b/src/main/java/io/supertokens/thirdparty/ThirdParty.java
@@ -127,6 +127,19 @@ public class ThirdParty {
     }
 
     @TestOnly
+    public static SignInUpResponse signInUp(Main main, String thirdPartyId, String thirdPartyUserId, String email, boolean isEmailVerified)
+            throws StorageQueryException, EmailChangeNotAllowedException {
+        try {
+            Storage storage = StorageLayer.getStorage(main);
+            return signInUp(
+                    new TenantIdentifierWithStorage(null, null, null, storage), main,
+                    thirdPartyId, thirdPartyUserId, email, isEmailVerified);
+        } catch (TenantOrAppNotFoundException | BadPermissionException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @TestOnly
     public static SignInUpResponse signInUp(TenantIdentifierWithStorage tenantIdentifierWithStorage, Main main,
                                             String thirdPartyId,
                                             String thirdPartyUserId, String email)

--- a/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/useridmapping/UserIdMappingAPI.java
@@ -27,6 +27,7 @@ import io.supertokens.pluginInterface.useridmapping.exception.UserIdMappingAlrea
 import io.supertokens.AppIdentifierWithStorageAndUserIdMapping;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
+import io.supertokens.utils.SemVer;
 import io.supertokens.webserver.InputParser;
 import io.supertokens.webserver.WebserverAPI;
 import jakarta.servlet.ServletException;
@@ -97,7 +98,8 @@ public class UserIdMappingAPI extends WebserverAPI {
                     this.getAppIdentifierWithStorageAndUserIdMappingFromRequest(req, superTokensUserId, UserIdType.SUPERTOKENS);
 
             UserIdMapping.createUserIdMapping(main, appIdentifierWithStorageAndUserIdMapping.appIdentifierWithStorage,
-                    superTokensUserId, externalUserId, externalUserIdInfo, force);
+                    superTokensUserId, externalUserId, externalUserIdInfo, force, getVersionFromRequest(req).greaterThanOrEqualTo(
+                            SemVer.v4_0));
 
             JsonObject response = new JsonObject();
             response.addProperty("status", "OK");

--- a/src/test/java/io/supertokens/test/emailverification/EmailVerificationWithUserIdMappingTest.java
+++ b/src/test/java/io/supertokens/test/emailverification/EmailVerificationWithUserIdMappingTest.java
@@ -1,0 +1,178 @@
+/*
+ *    Copyright (c) 2023, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.emailverification;
+
+import io.supertokens.ProcessState;
+import io.supertokens.authRecipe.AuthRecipe;
+import io.supertokens.emailpassword.EmailPassword;
+import io.supertokens.emailverification.EmailVerification;
+import io.supertokens.emailverification.exception.EmailAlreadyVerifiedException;
+import io.supertokens.passwordless.Passwordless;
+import io.supertokens.pluginInterface.STORAGE_TYPE;
+import io.supertokens.pluginInterface.authRecipe.AuthRecipeUserInfo;
+import io.supertokens.storageLayer.StorageLayer;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import io.supertokens.thirdparty.ThirdParty;
+import io.supertokens.useridmapping.UserIdMapping;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import static org.junit.Assert.*;
+
+public class EmailVerificationWithUserIdMappingTest {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void testUserIdMappingCreationAfterEmailVerificationForEmailPasswordUser() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        AuthRecipeUserInfo user = EmailPassword.signUp(process.getProcess(), "test@example.com", "password");
+        String token = EmailVerification.generateEmailVerificationToken(process.getProcess(),
+                user.getSupertokensUserId(), "test@example.com");
+        EmailVerification.verifyEmail(process.getProcess(), token);
+
+        // create mapping
+        // should be allowed although used in non-auth recipe
+        UserIdMapping.createUserIdMapping(process.getProcess(), user.getSupertokensUserId(), "euid", null, false, true);
+
+        // email for the user should remain verified
+        AuthRecipeUserInfo userInfo = AuthRecipe.getUserById(process.getProcess(), user.getSupertokensUserId());
+        assertTrue(userInfo.loginMethods[0].verified);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void testUserIdMappingCreationAfterEmailVerificationForThirdPartyUser() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        AuthRecipeUserInfo user = ThirdParty.signInUp(process.getProcess(), "google", "googleid1", "test@example.com", true).user;
+        try {
+            String token = EmailVerification.generateEmailVerificationToken(process.getProcess(),
+                    user.getSupertokensUserId(), "test@example.com");
+            EmailVerification.verifyEmail(process.getProcess(), token);
+            fail();
+        } catch (EmailAlreadyVerifiedException e) {
+            // email should already be verified
+        }
+
+        // create mapping
+        // should be allowed although used in non-auth recipe
+        UserIdMapping.createUserIdMapping(process.getProcess(), user.getSupertokensUserId(), "euid", null, false, true);
+
+        // email for the user should remain verified
+        AuthRecipeUserInfo userInfo = AuthRecipe.getUserById(process.getProcess(), user.getSupertokensUserId());
+        assertTrue(userInfo.loginMethods[0].verified);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void testUserIdMappingCreationAfterEmailVerificationForPasswordlessUser() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        Passwordless.CreateCodeResponse code = Passwordless.createCode(process.getProcess(), "test@example.com", null,
+                null, null);
+        AuthRecipeUserInfo user = Passwordless.consumeCode(process.getProcess(), code.deviceId, code.deviceIdHash, code.userInputCode, null, true).user;
+
+        try {
+            String token = EmailVerification.generateEmailVerificationToken(process.getProcess(),
+                    user.getSupertokensUserId(), "test@example.com");
+            EmailVerification.verifyEmail(process.getProcess(), token);
+            fail();
+        } catch (EmailAlreadyVerifiedException e) {
+            // email should already be verified
+        }
+
+        // create mapping
+        // should be allowed although used in non-auth recipe
+        UserIdMapping.createUserIdMapping(process.getProcess(), user.getSupertokensUserId(), "euid", null, false, true);
+
+        // email for the user should remain verified
+        AuthRecipeUserInfo userInfo = AuthRecipe.getUserById(process.getProcess(), user.getSupertokensUserId());
+        assertTrue(userInfo.loginMethods[0].verified);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void testEmailVerificationWithTokenAfterWithUserIdMapping() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        AuthRecipeUserInfo user = EmailPassword.signUp(process.getProcess(), "test@example.com", "password");
+        String token = EmailVerification.generateEmailVerificationToken(process.getProcess(),
+                user.getSupertokensUserId(), "test@example.com");
+        // create mapping before verifying token
+        // should be allowed although used in non-auth recipe
+        UserIdMapping.createUserIdMapping(process.getProcess(), user.getSupertokensUserId(), "euid", null, false, true);
+
+        EmailVerification.verifyEmail(process.getProcess(), token);
+
+        // email for the user should be verified
+        AuthRecipeUserInfo userInfo = AuthRecipe.getUserById(process.getProcess(), user.getSupertokensUserId());
+        assertTrue(userInfo.loginMethods[0].verified);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+}

--- a/src/test/java/io/supertokens/test/multitenant/AppTenantUserTest.java
+++ b/src/test/java/io/supertokens/test/multitenant/AppTenantUserTest.java
@@ -128,8 +128,8 @@ public class AppTenantUserTest {
                 StorageLayer.getStorage(process.main).addInfoToNonAuthRecipesBasedOnUserId(app, className, userId);
 
                 try {
-                    UserIdMapping.assertThatUserIdIsNotBeingUsedInNonAuthRecipes(
-                            tWithStorage.toAppIdentifierWithStorage(), userId);
+                    UserIdMapping.findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed(
+                            tWithStorage.toAppIdentifierWithStorage(), userId, true);
                     fail(className);
                 } catch (Exception ignored) {
                     assertTrue(ignored.getMessage().contains("UserId is already in use"));
@@ -156,8 +156,8 @@ public class AppTenantUserTest {
                         new JsonObject()
                 ), false);
 
-                UserIdMapping.assertThatUserIdIsNotBeingUsedInNonAuthRecipes(tWithStorage.toAppIdentifierWithStorage(),
-                        userId);
+                UserIdMapping.findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed(tWithStorage.toAppIdentifierWithStorage(),
+                        userId, true);
             }
         }
 
@@ -232,8 +232,8 @@ public class AppTenantUserTest {
             tenantWithStorage.getStorage().addInfoToNonAuthRecipesBasedOnUserId(tenant, className, userId);
 
             try {
-                UserIdMapping.assertThatUserIdIsNotBeingUsedInNonAuthRecipes(
-                        tenantWithStorage.toAppIdentifierWithStorage(), userId);
+                UserIdMapping.findNonAuthStoragesWhereUserIdIsUsedOrAssertIfUsed(
+                        tenantWithStorage.toAppIdentifierWithStorage(), userId, true);
                 fail(className);
             } catch (Exception ignored) {
                 assertTrue(ignored.getMessage().contains("UserId is already in use"));


### PR DESCRIPTION
## Summary of change

We automatically set email as verified for passwordless users and thirdparty user when the user info from provider has isVerified set to true. This blocks us from creating useridmapping. So we allow creating of useridmapping and update the userid for email verification to the external user id.

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting the user as well if `deleteUserIdMappingToo` is false.
## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
