### PR TITLE
Add Dockerfile for ubuntu 22.04

### DIFF
--- a/.circleci/Dockerfile-ubuntu22
+++ b/.circleci/Dockerfile-ubuntu22
@@ -1,0 +1,57 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get upgrade -y
+
+RUN apt-get install build-essential -y
+
+RUN echo "mysql-server mysql-server/root_password password root" | debconf-set-selections
+
+RUN echo "mysql-server mysql-server/root_password_again password root" | debconf-set-selections
+
+RUN apt install mysql-server -y
+
+RUN usermod -d /var/lib/mysql/ mysql
+
+RUN [ -d /var/run/mysqld ] || mkdir -p /var/run/mysqld
+
+ADD ./runMySQL.sh /runMySQL.sh
+
+RUN chmod +x /runMySQL.sh
+
+RUN apt-get install -y git-core
+
+RUN apt-get install -y wget
+
+# Install OpenJDK 12
+RUN wget https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz
+
+RUN mkdir /usr/java
+
+RUN mv openjdk-12.0.2_linux-x64_bin.tar.gz /usr/java
+
+RUN cd /usr/java && tar -xzvf openjdk-12.0.2_linux-x64_bin.tar.gz
+
+RUN echo 'JAVA_HOME=/usr/java/jdk-12.0.2' >> /etc/profile
+RUN echo 'PATH=$PATH:$HOME/bin:$JAVA_HOME/bin' >> /etc/profile
+
+RUN apt-get install jq -y
+
+RUN apt-get install curl -y
+
+RUN apt-get install unzip -y
+
+# Install OpenJDK 15.0.1
+RUN wget https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz
+
+RUN mv openjdk-15.0.1_linux-x64_bin.tar.gz /usr/java
+
+RUN cd /usr/java && tar -xzvf openjdk-15.0.1_linux-x64_bin.tar.gz
+
+RUN echo 'JAVA_HOME=/usr/java/jdk-15.0.1' >> /etc/profile
+RUN echo 'PATH=$PATH:$HOME/bin:$JAVA_HOME/bin' >> /etc/profile
+RUN echo 'export JAVA_HOME' >> /etc/profile
+RUN echo 'export JRE_HOME' >> /etc/profile
+RUN echo 'export PATH' >> /etc/profile
+
+RUN update-alternatives --install "/usr/bin/java" "java" "/usr/java/jdk-12.0.2/bin/java" 1
+RUN update-alternatives --install "/usr/bin/javac" "javac" "/usr/java/jdk-12.0.2/bin/javac" 1


### PR DESCRIPTION
## Summary of change

This PR adds a Dockerfile to create new test image with Ubuntu 22.04. This was done as we were unable to install Node 18 or higher on Ubuntu 18.04 (or lower).


## Test Plan

Tested the image locally.

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting the user as well if `deleteUserIdMappingToo` is false.

