### PR TITLE
feat: make refresh sync signing key setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `VerifyTotpDeviceAPI` changes
   - Adds `currentNumberOfFailedAttempts` and `maxNumberOfFailedAttempts` in response when status is
     `INVALID_TOTP_ERROR` or `LIMIT_REACHED_ERROR`
+- Adds a new required `useDynamicSigningKey` into the request body of `RefreshSessionAPI`
+  - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to 
+    change the signing key type of a session
 
 ### Migration
 

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -520,11 +520,11 @@ public class Start
     @Override
     public void updateSessionInfo_Transaction(TenantIdentifier tenantIdentifier, TransactionConnection con,
                                               String sessionHandle, String refreshTokenHash2,
-                                              long expiry) throws StorageQueryException {
+                                              long expiry, boolean useStaticKey) throws StorageQueryException {
         Connection sqlCon = (Connection) con.getConnection();
         try {
             SessionQueries.updateSessionInfo_Transaction(this, sqlCon, tenantIdentifier, sessionHandle,
-                    refreshTokenHash2, expiry);
+                    refreshTokenHash2, expiry, useStaticKey);
         } catch (SQLException e) {
             throw new StorageQueryException(e);
         }

--- a/src/main/java/io/supertokens/inmemorydb/queries/SessionQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/SessionQueries.java
@@ -147,18 +147,19 @@ public class SessionQueries {
 
     public static void updateSessionInfo_Transaction(Start start, Connection con, TenantIdentifier tenantIdentifier,
                                                      String sessionHandle,
-                                                     String refreshTokenHash2, long expiry)
+                                                     String refreshTokenHash2, long expiry, boolean useStaticKey)
             throws SQLException, StorageQueryException {
         String QUERY = "UPDATE " + getConfig(start).getSessionInfoTable()
-                + " SET refresh_token_hash_2 = ?, expires_at = ?"
+                + " SET refresh_token_hash_2 = ?, expires_at = ?, use_static_key= ?"
                 + " WHERE app_id = ? AND tenant_id = ? AND session_handle = ?";
 
         update(con, QUERY, pst -> {
             pst.setString(1, refreshTokenHash2);
             pst.setLong(2, expiry);
-            pst.setString(3, tenantIdentifier.getAppId());
-            pst.setString(4, tenantIdentifier.getTenantId());
-            pst.setString(5, sessionHandle);
+            pst.setBoolean(3, useStaticKey);
+            pst.setString(4, tenantIdentifier.getAppId());
+            pst.setString(5, tenantIdentifier.getTenantId());
+            pst.setString(6, sessionHandle);
         });
     }
 

--- a/src/main/java/io/supertokens/session/Session.java
+++ b/src/main/java/io/supertokens/session/Session.java
@@ -377,7 +377,7 @@ public class Session {
                                         accessToken.sessionHandle,
                                         Utils.hashSHA256(accessToken.refreshTokenHash1),
                                         System.currentTimeMillis() +
-                                                config.getRefreshTokenValidity());
+                                                config.getRefreshTokenValidity(), sessionInfo.useStaticKey);
                             }
                             storage.commitTransaction(con);
 
@@ -454,7 +454,7 @@ public class Session {
                                     Utils.hashSHA256(accessToken.refreshTokenHash1),
                                     System.currentTimeMillis() + Config.getConfig(tenantIdentifierWithStorage, main)
                                             .getRefreshTokenValidity(),
-                                    sessionInfo.lastUpdatedSign);
+                                    sessionInfo.lastUpdatedSign, sessionInfo.useStaticKey);
                             if (!success) {
                                 continue;
                             }
@@ -509,7 +509,7 @@ public class Session {
             UnsupportedJWTSigningAlgorithmException, AccessTokenPayloadError {
         try {
             return refreshSession(new AppIdentifier(null, null), main, refreshToken, antiCsrfToken,
-                    enableAntiCsrf, accessTokenVersion);
+                    enableAntiCsrf, accessTokenVersion, null);
         } catch (TenantOrAppNotFoundException e) {
             throw new IllegalStateException(e);
         }
@@ -518,7 +518,7 @@ public class Session {
     public static SessionInformationHolder refreshSession(AppIdentifier appIdentifier, Main main,
                                                           @Nonnull String refreshToken,
                                                           @Nullable String antiCsrfToken, boolean enableAntiCsrf,
-                                                          AccessToken.VERSION accessTokenVersion)
+                                                          AccessToken.VERSION accessTokenVersion, Boolean shouldUseStaticKey)
             throws StorageTransactionLogicException,
             UnauthorisedException, StorageQueryException, TokenTheftDetectedException,
             UnsupportedJWTSigningAlgorithmException, AccessTokenPayloadError, TenantOrAppNotFoundException {
@@ -534,14 +534,14 @@ public class Session {
 
         return refreshSessionHelper(refreshTokenInfo.tenantIdentifier.withStorage(
                         StorageLayer.getStorage(refreshTokenInfo.tenantIdentifier, main)),
-                main, refreshToken, refreshTokenInfo, enableAntiCsrf, accessTokenVersion);
+                main, refreshToken, refreshTokenInfo, enableAntiCsrf, accessTokenVersion, shouldUseStaticKey);
     }
 
     private static SessionInformationHolder refreshSessionHelper(
             TenantIdentifierWithStorage tenantIdentifierWithStorage, Main main, String refreshToken,
             RefreshToken.RefreshTokenInfo refreshTokenInfo,
             boolean enableAntiCsrf,
-            AccessToken.VERSION accessTokenVersion)
+            AccessToken.VERSION accessTokenVersion, Boolean shouldUseStaticKey)
             throws StorageTransactionLogicException, UnauthorisedException, StorageQueryException,
             TokenTheftDetectedException, UnsupportedJWTSigningAlgorithmException, AccessTokenPayloadError,
             TenantOrAppNotFoundException {
@@ -565,8 +565,16 @@ public class Session {
                             storage.commitTransaction(con);
                             throw new UnauthorisedException("Session missing in db or has expired");
                         }
+                        boolean useStaticKey = shouldUseStaticKey != null ? shouldUseStaticKey : sessionInfo.useStaticKey;
 
                         if (sessionInfo.refreshTokenHash2.equals(Utils.hashSHA256(Utils.hashSHA256(refreshToken)))) {
+                            if (useStaticKey != sessionInfo.useStaticKey) {
+                                // We do not update anything except the static key status
+                                storage.updateSessionInfo_Transaction(tenantIdentifierWithStorage, con, sessionHandle,
+                                        sessionInfo.refreshTokenHash2, sessionInfo.expiry,
+                                        useStaticKey);
+                            }
+
                             // at this point, the input refresh token is the parent one.
                             storage.commitTransaction(con);
 
@@ -580,7 +588,8 @@ public class Session {
                                     sessionInfo.recipeUserId, sessionInfo.userId,
                                     Utils.hashSHA256(newRefreshToken.token),
                                     Utils.hashSHA256(refreshToken), sessionInfo.userDataInJWT, antiCsrfToken,
-                                    null, accessTokenVersion, sessionInfo.useStaticKey);
+                                    null, accessTokenVersion,
+                                    useStaticKey);
 
                             TokenInfo idRefreshToken = new TokenInfo(UUID.randomUUID().toString(),
                                     newRefreshToken.expiry, newRefreshToken.createdTime);
@@ -600,13 +609,13 @@ public class Session {
                                 .equals(sessionInfo.refreshTokenHash2))) {
                             storage.updateSessionInfo_Transaction(tenantIdentifierWithStorage, con, sessionHandle,
                                     Utils.hashSHA256(Utils.hashSHA256(refreshToken)),
-                                    System.currentTimeMillis() + config.getRefreshTokenValidity());
+                                    System.currentTimeMillis() + config.getRefreshTokenValidity(), useStaticKey);
 
                             storage.commitTransaction(con);
 
                             return refreshSessionHelper(tenantIdentifierWithStorage, main, refreshToken,
                                     refreshTokenInfo, enableAntiCsrf,
-                                    accessTokenVersion);
+                                    accessTokenVersion, shouldUseStaticKey);
                         }
 
                         storage.commitTransaction(con);
@@ -655,7 +664,18 @@ public class Session {
                         throw new UnauthorisedException("Session missing in db or has expired");
                     }
 
+                    boolean useStaticKey = shouldUseStaticKey != null ? shouldUseStaticKey : sessionInfo.useStaticKey;
+
                     if (sessionInfo.refreshTokenHash2.equals(Utils.hashSHA256(Utils.hashSHA256(refreshToken)))) {
+                        if (sessionInfo.useStaticKey != useStaticKey) {
+                            // We do not update anything except the static key status
+                            boolean success = storage.updateSessionInfo_Transaction(sessionHandle,
+                                    sessionInfo.refreshTokenHash2, sessionInfo.expiry,
+                                    sessionInfo.lastUpdatedSign, useStaticKey);
+                            if (!success) {
+                                continue;
+                            }
+                        }
                         // at this point, the input refresh token is the parent one.
                         String antiCsrfToken = enableAntiCsrf ? UUID.randomUUID().toString() : null;
 
@@ -666,7 +686,8 @@ public class Session {
                                 sessionHandle,
                                 sessionInfo.recipeUserId, sessionInfo.userId, Utils.hashSHA256(newRefreshToken.token),
                                 Utils.hashSHA256(refreshToken), sessionInfo.userDataInJWT, antiCsrfToken,
-                                null, accessTokenVersion, sessionInfo.useStaticKey);
+                                null, accessTokenVersion,
+                                useStaticKey);
 
                         TokenInfo idRefreshToken = new TokenInfo(UUID.randomUUID().toString(), newRefreshToken.expiry,
                                 newRefreshToken.createdTime);
@@ -688,13 +709,12 @@ public class Session {
                                 Utils.hashSHA256(Utils.hashSHA256(refreshToken)),
                                 System.currentTimeMillis() +
                                         Config.getConfig(tenantIdentifierWithStorage, main).getRefreshTokenValidity(),
-                                sessionInfo.lastUpdatedSign);
+                                sessionInfo.lastUpdatedSign, useStaticKey);
                         if (!success) {
                             continue;
                         }
                         return refreshSessionHelper(tenantIdentifierWithStorage, main, refreshToken, refreshTokenInfo,
-                                enableAntiCsrf,
-                                accessTokenVersion);
+                                enableAntiCsrf, accessTokenVersion, shouldUseStaticKey);
                     }
 
                     throw new TokenTheftDetectedException(sessionHandle, sessionInfo.recipeUserId, sessionInfo.userId);

--- a/src/main/java/io/supertokens/webserver/api/session/RefreshSessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/RefreshSessionAPI.java
@@ -67,8 +67,8 @@ public class RefreshSessionAPI extends WebserverAPI {
         String refreshToken = InputParser.parseStringOrThrowError(input, "refreshToken", false);
         String antiCsrfToken = InputParser.parseStringOrThrowError(input, "antiCsrfToken", true);
         Boolean enableAntiCsrf = InputParser.parseBooleanOrThrowError(input, "enableAntiCsrf", false);
-        Boolean useStaticKey = version.greaterThanOrEqualTo(SemVer.v5_0) ?
-                InputParser.parseBooleanOrThrowError(input, "useStaticKey", false) : null;
+        Boolean useDynamicSigningKey = version.greaterThanOrEqualTo(SemVer.v5_0) ?
+                InputParser.parseBooleanOrThrowError(input, "useDynamicSigningKey", false) : null;
         assert enableAntiCsrf != null;
         assert refreshToken != null;
 
@@ -84,7 +84,9 @@ public class RefreshSessionAPI extends WebserverAPI {
 
             SessionInformationHolder sessionInfo = Session.refreshSession(appIdentifierWithStorage, main,
                     refreshToken, antiCsrfToken,
-                    enableAntiCsrf, accessTokenVersion, useStaticKey);
+                    enableAntiCsrf, accessTokenVersion,
+                    useDynamicSigningKey == null ? null : Boolean.FALSE.equals(useDynamicSigningKey)
+            );
 
             if (StorageLayer.getStorage(this.getTenantIdentifierWithStorageFromRequest(req), main).getType() ==
                     STORAGE_TYPE.SQL) {

--- a/src/test/java/io/supertokens/test/StorageTest.java
+++ b/src/test/java/io/supertokens/test/StorageTest.java
@@ -751,6 +751,7 @@ public class StorageTest {
         jsonBody.addProperty("refreshToken",
                 sessionCreated.get("refreshToken").getAsJsonObject().get("token").getAsString());
         jsonBody.addProperty("enableAntiCsrf", false);
+        jsonBody.addProperty("useDynamicSigningKey", true);
 
         storage.setStorageLayerEnabled(false);
 

--- a/src/test/java/io/supertokens/test/session/SessionTest6.java
+++ b/src/test/java/io/supertokens/test/session/SessionTest6.java
@@ -1,0 +1,203 @@
+/*
+ *    Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.session;
+
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.exceptions.TryRefreshTokenException;
+import io.supertokens.exceptions.UnauthorisedException;
+import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
+import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
+import io.supertokens.pluginInterface.session.SessionStorage;
+import io.supertokens.session.Session;
+import io.supertokens.session.accessToken.AccessToken;
+import io.supertokens.session.info.SessionInformationHolder;
+import io.supertokens.session.jwt.JWT;
+import io.supertokens.storageLayer.StorageLayer;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import org.junit.*;
+import org.junit.rules.TestRule;
+
+import static junit.framework.TestCase.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+public class SessionTest6 {
+
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void createRefreshSwitchVerify() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        SessionInformationHolder sessionInfo = Session.createNewSession(process.getProcess(), userId, userDataInJWT,
+                userDataInDatabase, false, AccessToken.getLatestVersion(), false);
+        checkIfUsingStaticKey(sessionInfo, false);
+
+        sessionInfo = Session.refreshSession(new AppIdentifier(null, null), process.getProcess(), sessionInfo.refreshToken.token,
+                sessionInfo.antiCsrfToken, false, AccessToken.getLatestVersion(), true);
+        assert sessionInfo.refreshToken != null;
+        assert sessionInfo.accessToken != null;
+
+        checkIfUsingStaticKey(sessionInfo, true);
+
+        SessionInformationHolder verifiedSession = Session.getSession(process.getProcess(), sessionInfo.accessToken.token,
+                sessionInfo.antiCsrfToken, false, true, false);
+
+        checkIfUsingStaticKey(verifiedSession, true);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+    @Test
+    public void createRefreshSwitchRegen() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        SessionInformationHolder sessionInfo = Session.createNewSession(process.getProcess(), userId, userDataInJWT,
+                userDataInDatabase, false, AccessToken.getLatestVersion(), false);
+        checkIfUsingStaticKey(sessionInfo, false);
+
+        sessionInfo = Session.refreshSession(new AppIdentifier(null, null), process.getProcess(), sessionInfo.refreshToken.token,
+                sessionInfo.antiCsrfToken, false, AccessToken.getLatestVersion(), true);
+        assert sessionInfo.refreshToken != null;
+        assert sessionInfo.accessToken != null;
+        checkIfUsingStaticKey(sessionInfo, true);
+
+        SessionInformationHolder newSessionInfo = Session.regenerateToken(process.getProcess(),
+                sessionInfo.accessToken.token, userDataInJWT);
+        checkIfUsingStaticKey(newSessionInfo, true);
+
+        SessionInformationHolder getSessionResponse = Session.getSession(process.getProcess(),
+                newSessionInfo.accessToken.token, sessionInfo.antiCsrfToken, false, true, false);
+        checkIfUsingStaticKey(getSessionResponse, true);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void createRefreshRefreshSwitchVerify() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        SessionInformationHolder sessionInfo = Session.createNewSession(process.getProcess(), userId, userDataInJWT,
+                userDataInDatabase, false, AccessToken.getLatestVersion(), false);
+        checkIfUsingStaticKey(sessionInfo, false);
+
+        sessionInfo = Session.refreshSession(new AppIdentifier(null, null), process.getProcess(), sessionInfo.refreshToken.token,
+                sessionInfo.antiCsrfToken, false, AccessToken.getLatestVersion(), false);
+
+        sessionInfo = Session.refreshSession(new AppIdentifier(null, null), process.getProcess(), sessionInfo.refreshToken.token,
+                sessionInfo.antiCsrfToken, false, AccessToken.getLatestVersion(), true);
+        assert sessionInfo.refreshToken != null;
+        assert sessionInfo.accessToken != null;
+
+        checkIfUsingStaticKey(sessionInfo, true);
+
+        SessionInformationHolder verifiedSession = Session.getSession(process.getProcess(), sessionInfo.accessToken.token,
+                sessionInfo.antiCsrfToken, false, true, false);
+
+        checkIfUsingStaticKey(verifiedSession, true);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+    @Test
+    public void createRefreshRefreshSwitchRegen() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        SessionInformationHolder sessionInfo = Session.createNewSession(process.getProcess(), userId, userDataInJWT,
+                userDataInDatabase, false, AccessToken.getLatestVersion(), false);
+        checkIfUsingStaticKey(sessionInfo, false);
+
+        sessionInfo = Session.refreshSession(new AppIdentifier(null, null), process.getProcess(), sessionInfo.refreshToken.token,
+                sessionInfo.antiCsrfToken, false, AccessToken.getLatestVersion(), false);
+
+        sessionInfo = Session.refreshSession(new AppIdentifier(null, null), process.getProcess(), sessionInfo.refreshToken.token,
+                sessionInfo.antiCsrfToken, false, AccessToken.getLatestVersion(), true);
+        assert sessionInfo.refreshToken != null;
+        assert sessionInfo.accessToken != null;
+        checkIfUsingStaticKey(sessionInfo, true);
+
+        SessionInformationHolder newSessionInfo = Session.regenerateToken(process.getProcess(),
+                sessionInfo.accessToken.token, userDataInJWT);
+        checkIfUsingStaticKey(newSessionInfo, true);
+
+        SessionInformationHolder getSessionResponse = Session.getSession(process.getProcess(),
+                newSessionInfo.accessToken.token, sessionInfo.antiCsrfToken, false, true, false);
+        checkIfUsingStaticKey(getSessionResponse, true);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    private static void checkIfUsingStaticKey(SessionInformationHolder info, boolean shouldBeStatic) throws JWT.JWTException {
+        assert info.accessToken != null;
+        JWT.JWTPreParseInfo tokenInfo = JWT.preParseJWTInfo(info.accessToken.token);
+        assert tokenInfo.kid != null;
+        if (shouldBeStatic) {
+            assert tokenInfo.kid.startsWith("s-");
+        } else {
+            assert tokenInfo.kid.startsWith("d-");
+        }
+    }
+
+}
+

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest2_21.java
@@ -76,7 +76,7 @@ public class RefreshSessionAPITest2_21 {
 
         JsonObject response = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                     "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
-                    Utils.getCdiVersionStringLatestForTests(), "session");
+                    SemVer.v2_21.get(), "session");
 
         assertEquals(response.entrySet().size(), 2);
         assertEquals(response.get("status").getAsString(), "UNAUTHORISED");

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest5_0.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest5_0.java
@@ -314,9 +314,7 @@ public class RefreshSessionAPITest5_0 {
         assertEquals(response.get("accessToken").getAsJsonObject().entrySet().size(), 3);
 
         JWT.JWTPreParseInfo tokenInfo = JWT.preParseJWTInfo(response.get("accessToken").getAsJsonObject().get("token").getAsString());
-
-        System.out.println(tokenInfo.kid);
-
+        
         if (useStaticKey) {
             assert(tokenInfo.kid.startsWith("s-"));
         } else {

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest5_0.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest5_0.java
@@ -79,7 +79,7 @@ public class RefreshSessionAPITest5_0 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
-        sessionRefreshBody.addProperty("useStaticKey", false);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", true);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
@@ -120,7 +120,7 @@ public class RefreshSessionAPITest5_0 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
-        sessionRefreshBody.addProperty("useStaticKey", true);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", false);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
@@ -161,7 +161,7 @@ public class RefreshSessionAPITest5_0 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
-        sessionRefreshBody.addProperty("useStaticKey", true);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", false);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
@@ -202,7 +202,7 @@ public class RefreshSessionAPITest5_0 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
-        sessionRefreshBody.addProperty("useStaticKey", true);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", false);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
@@ -244,7 +244,7 @@ public class RefreshSessionAPITest5_0 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
-        sessionRefreshBody.addProperty("useStaticKey", true);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", false);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
@@ -286,7 +286,7 @@ public class RefreshSessionAPITest5_0 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
-        sessionRefreshBody.addProperty("useStaticKey", true);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", false);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest5_0.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest5_0.java
@@ -1,0 +1,336 @@
+/*
+ *    Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.session.api;
+
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.session.jwt.JWT;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class RefreshSessionAPITest5_0 {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void successOutputUpgradeWithNonStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useStaticKey", false);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v5_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, false);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void successOutputUpgradeWithStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useStaticKey", true);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v5_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, true);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void successOutputWithStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v5_0.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useStaticKey", true);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v5_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, true);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void successOutputWithNonStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v5_0.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useStaticKey", true);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v5_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, true);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void successOutputSwitchingWithStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+        request.addProperty("useDynamicSigningKey", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v5_0.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useStaticKey", true);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v5_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, true);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void successOutputSwitchingWithNonStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("useDynamicSigningKey", true);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v5_0.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useStaticKey", true);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v5_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, true);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+    private static void checkRefreshSessionResponse(JsonObject response, TestingProcessManager.TestingProcess process,
+            String userId, JsonObject userDataInJWT, boolean hasAntiCsrf, boolean useStaticKey) throws
+            JWT.JWTException {
+
+        assertNotNull(response.get("session").getAsJsonObject().get("handle").getAsString());
+        assertEquals(response.get("session").getAsJsonObject().get("userId").getAsString(), userId);
+        assertEquals(response.get("session").getAsJsonObject().get("recipeUserId").getAsString(), userId);
+        assertEquals(response.get("session").getAsJsonObject().get("tenantId").getAsString(), "public");
+        assertEquals(response.get("session").getAsJsonObject().get("userDataInJWT").getAsJsonObject().toString(),
+                userDataInJWT.toString());
+        assertEquals(response.get("session").getAsJsonObject().entrySet().size(), 5);
+
+        assertTrue(response.get("accessToken").getAsJsonObject().has("token"));
+        assertTrue(response.get("accessToken").getAsJsonObject().has("expiry"));
+        assertTrue(response.get("accessToken").getAsJsonObject().has("createdTime"));
+        assertEquals(response.get("accessToken").getAsJsonObject().entrySet().size(), 3);
+
+        JWT.JWTPreParseInfo tokenInfo = JWT.preParseJWTInfo(response.get("accessToken").getAsJsonObject().get("token").getAsString());
+
+        System.out.println(tokenInfo.kid);
+
+        if (useStaticKey) {
+            assert(tokenInfo.kid.startsWith("s-"));
+        } else {
+            assert(tokenInfo.kid.startsWith("d-"));
+        }
+
+        assertTrue(response.get("refreshToken").getAsJsonObject().has("token"));
+        assertTrue(response.get("refreshToken").getAsJsonObject().has("expiry"));
+        assertTrue(response.get("refreshToken").getAsJsonObject().has("createdTime"));
+        assertEquals(response.get("refreshToken").getAsJsonObject().entrySet().size(), 3);
+
+        assertEquals(response.has("antiCsrfToken"), hasAntiCsrf);
+
+        assertEquals(response.entrySet().size(), hasAntiCsrf ? 5 : 4);
+    }
+
+}

--- a/src/test/java/io/supertokens/test/session/api/SessionRegenerateAPITest2_21.java
+++ b/src/test/java/io/supertokens/test/session/api/SessionRegenerateAPITest2_21.java
@@ -107,6 +107,7 @@ public class SessionRegenerateAPITest2_21 {
         sessionRefreshBody.addProperty("refreshToken",
                 sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
         sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", true);
 
         JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
                 "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,


### PR DESCRIPTION
## Summary of change

- Add a `useDynamicSigningKey` param to the refresh session api (v5.0+). This matches the parameter name used by the session creation API.
- Use the above param to update the `useStaticSigningKey` of the session during refresh. 

## Related issues

- core: https://github.com/supertokens/supertokens-core/pull/909
- plugin-interface: https://github.com/supertokens/supertokens-plugin-interface/pull/136
- postgresql-plugin: https://github.com/supertokens/supertokens-postgresql-plugin/pull/180
- mysql-plugin: https://github.com/supertokens/supertokens-mysql-plugin/pull/88
- mongodb-plugin: https://github.com/supertokens/supertokens-mongodb-plugin/pull/31
- node: https://github.com/supertokens/supertokens-node/pull/782

## Test Plan

- Added tests to API output while switching  
  - successOutputSwitchingWithStaticKeySessionTest
  - successOutputSwitchingWithNonStaticKeySessionTest
- Added test to check API output while not switching 
  - successOutputWithStaticKeySessionTest
  - successOutputWithNonStaticKeySessionTest
- Added API tests checking how we upgrade from old access tokens (created on v2.7)
  - successOutputUpgradeWithNonStaticKeySessionTest
  - successOutputUpgradeWithStaticKeySessionTest
- Function level test:
  - createRefreshSwitchVerify
  - createRefreshSwitchRegen
  - createRefreshRefreshSwitchVerify
  - createRefreshRefreshSwitchRegen

## Documentation changes

-  [ ] Update the caution sections in `common-customizations/sessions/jwt-signing-key-rotation`, `common-customizations/sessions/with-jwt/jwt-verification`, ` common-customizations/sessions/anonymous-session`
-   [ ] Add a warning about updating the `useDynamicAccessTokenSigningKey`, because it causes a spike in refresh calls

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [x] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting the user as well if `deleteUserIdMappingToo` is false.
