### PR TITLE
fix: error logs should be printed to StdErr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.17] - 2024-02-06
+
+- Fixes issue where error logs were printed to StdOut instead of StdErr.
+
 ## [7.0.16] - 2023-12-04
 
 - Returns 400, instead of 500, for badly typed core config while creating CUD, App or Tenant

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "7.0.16"
+version = "7.0.17"
 
 
 repositories {

--- a/src/main/java/io/supertokens/output/Logging.java
+++ b/src/main/java/io/supertokens/output/Logging.java
@@ -51,11 +51,11 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logging(Main main) {
         this.infoLogger = Config.getBaseConfig(main).getInfoLogPath(main).equals("null")
-                ? createLoggerForConsole(main, "io.supertokens.Info")
+                ? createLoggerForConsole(main, "io.supertokens.Info", LOG_LEVEL.INFO)
                 : createLoggerForFile(main, Config.getBaseConfig(main).getInfoLogPath(main),
                 "io.supertokens.Info");
         this.errorLogger = Config.getBaseConfig(main).getErrorLogPath(main).equals("null")
-                ? createLoggerForConsole(main, "io.supertokens.Error")
+                ? createLoggerForConsole(main, "io.supertokens.Error", LOG_LEVEL.ERROR)
                 : createLoggerForFile(main, Config.getBaseConfig(main).getErrorLogPath(main),
                 "io.supertokens.Error");
         Storage storage = StorageLayer.getBaseStorage(main);
@@ -250,12 +250,13 @@ public class Logging extends ResourceDistributor.SingletonResource {
         return logger;
     }
 
-    private Logger createLoggerForConsole(Main main, String name) {
+    private Logger createLoggerForConsole(Main main, String name, LOG_LEVEL logLevel) {
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
         LayoutWrappingEncoder ple = new LayoutWrappingEncoder(main.getProcessId());
         ple.setContext(lc);
         ple.start();
         ConsoleAppender<ILoggingEvent> logConsoleAppender = new ConsoleAppender<>();
+        logConsoleAppender.setTarget(logLevel == LOG_LEVEL.ERROR ? "System.err" : "System.out");
         logConsoleAppender.setEncoder(ple);
         logConsoleAppender.setContext(lc);
         logConsoleAppender.start();


### PR DESCRIPTION
## Summary of change

Fixes issue where error logs were printed to StdOut instead of StdErr.

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [x] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting the user as well if `deleteUserIdMappingToo` is false.

## TODO

- [ ] Test Docker logs