### PR TITLE
feat: backport useDynamicSigningKey in refresh api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     `INVALID_TOTP_ERROR` or `LIMIT_REACHED_ERROR`
 - Adds `consumedDevice` in the success response of the `ConsumeCodeAPI`
 - Adds `preAuthSessionId` input to `DeleteCodeAPI` to be able to delete codes for a device
-- Adds a new required `useDynamicSigningKey` into the request body of `RefreshSessionAPI`
+- Adds a new `useDynamicSigningKey` into the request body of `RefreshSessionAPI`
   - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to change the signing key type of a session
+  - This is available after CDI3.0
+  - This is required in&after CDI5.0 and optional before
 - Adds optional `firstFactors` and `requiredSecondaryFactors` to the create or update connectionUriDomain, app and tenant APIs
 - Updates Last active while linking accounts
 - Marks fake email in email password sign up as verified

--- a/src/main/java/io/supertokens/webserver/api/session/RefreshSessionAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/session/RefreshSessionAPI.java
@@ -69,8 +69,10 @@ public class RefreshSessionAPI extends WebserverAPI {
         String refreshToken = InputParser.parseStringOrThrowError(input, "refreshToken", false);
         String antiCsrfToken = InputParser.parseStringOrThrowError(input, "antiCsrfToken", true);
         Boolean enableAntiCsrf = InputParser.parseBooleanOrThrowError(input, "enableAntiCsrf", false);
-        Boolean useDynamicSigningKey = version.greaterThanOrEqualTo(SemVer.v5_0) ?
-                InputParser.parseBooleanOrThrowError(input, "useDynamicSigningKey", false) : null;
+        Boolean useDynamicSigningKey = version.greaterThanOrEqualTo(SemVer.v3_0)
+                ? InputParser.parseBooleanOrThrowError(input, "useDynamicSigningKey", version.lesserThan(SemVer.v5_0))
+                : null;
+
         assert enableAntiCsrf != null;
         assert refreshToken != null;
 

--- a/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest3_0.java
+++ b/src/test/java/io/supertokens/test/session/api/RefreshSessionAPITest3_0.java
@@ -1,0 +1,207 @@
+/*
+ *    Copyright (c) 2021, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.session.api;
+
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.session.jwt.JWT;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.utils.SemVer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertNotNull;
+
+public class RefreshSessionAPITest3_0 {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void successOutputWithValidRefreshTokenTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v3_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, false);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+
+    }
+
+    @Test
+    public void successOutputUpgradeWithNonStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", true);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v3_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, false);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    @Test
+    public void successOutputUpgradeWithStaticKeySessionTest() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String userId = "userId";
+        JsonObject userDataInJWT = new JsonObject();
+        userDataInJWT.add("nullProp", JsonNull.INSTANCE);
+        userDataInJWT.addProperty("key", "value");
+        JsonObject userDataInDatabase = new JsonObject();
+        userDataInDatabase.addProperty("key", "value");
+
+        JsonObject request = new JsonObject();
+        request.addProperty("userId", userId);
+        request.add("userDataInJWT", userDataInJWT);
+        request.add("userDataInDatabase", userDataInDatabase);
+        request.addProperty("enableAntiCsrf", false);
+
+        JsonObject sessionInfo = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session", request, 1000, 1000, null, SemVer.v2_7.get(),
+                "session");
+        assertEquals(sessionInfo.get("status").getAsString(), "OK");
+
+        JsonObject sessionRefreshBody = new JsonObject();
+
+        sessionRefreshBody.addProperty("refreshToken",
+                sessionInfo.get("refreshToken").getAsJsonObject().get("token").getAsString());
+        sessionRefreshBody.addProperty("enableAntiCsrf", false);
+        sessionRefreshBody.addProperty("useDynamicSigningKey", false);
+
+        JsonObject sessionRefreshResponse = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/session/refresh", sessionRefreshBody, 1000, 1000, null,
+                SemVer.v3_0.get(), "session");
+
+        checkRefreshSessionResponse(sessionRefreshResponse, process, userId, userDataInJWT, false, true);
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    private static void checkRefreshSessionResponse(JsonObject response, TestingProcessManager.TestingProcess process,
+                                                    String userId, JsonObject userDataInJWT, boolean hasAntiCsrf, boolean useStaticKey) throws
+            JWT.JWTException {
+
+        assertNotNull(response.get("session").getAsJsonObject().get("handle").getAsString());
+        assertEquals(response.get("session").getAsJsonObject().get("userId").getAsString(), userId);
+        assertEquals(response.get("session").getAsJsonObject().get("tenantId").getAsString(), "public");
+        assertEquals(response.get("session").getAsJsonObject().get("userDataInJWT").getAsJsonObject().toString(),
+                userDataInJWT.toString());
+        assertEquals(response.get("session").getAsJsonObject().entrySet().size(), 4);
+
+        assertTrue(response.get("accessToken").getAsJsonObject().has("token"));
+        assertTrue(response.get("accessToken").getAsJsonObject().has("expiry"));
+        assertTrue(response.get("accessToken").getAsJsonObject().has("createdTime"));
+        assertEquals(response.get("accessToken").getAsJsonObject().entrySet().size(), 3);
+
+        JWT.JWTPreParseInfo tokenInfo = JWT.preParseJWTInfo(response.get("accessToken").getAsJsonObject().get("token").getAsString());
+
+        if (useStaticKey) {
+            assert(tokenInfo.kid.startsWith("s-"));
+        } else {
+            assert(tokenInfo.kid.startsWith("d-"));
+        }
+
+        assertTrue(response.get("refreshToken").getAsJsonObject().has("token"));
+        assertTrue(response.get("refreshToken").getAsJsonObject().has("expiry"));
+        assertTrue(response.get("refreshToken").getAsJsonObject().has("createdTime"));
+        assertEquals(response.get("refreshToken").getAsJsonObject().entrySet().size(), 3);
+
+        assertEquals(response.has("antiCsrfToken"), hasAntiCsrf);
+
+        assertEquals(response.entrySet().size(), hasAntiCsrf ? 5 : 4);
+    }
+}


### PR DESCRIPTION
## Summary of change

feat: backport useDynamicSigningKey in refresh api

## Related issues

- 

## Test Plan

Added tests:
- with and without the new prop in V3
- without new prop in V5

## Documentation changes

- 

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core config (similar to the `access_token_signing_key_update_interval` config alias).
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [x] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting the user as well if `deleteUserIdMappingToo` is false.
