### PR TITLE
fix: make canLinkAccountsHelper check if the login methods of the primary user have conflicts on the tenant of the link target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [9.1.1] -2024-07-24
+
+### Fixes
+
+- Account linking now properly checks if the login methods of the primary user can be shared with the tenants of the 
+  recipe user we are trying to link
+
 ## [9.1.0] - 2024-05-24
 
 ### Changes

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "9.1.0"
+version = "9.1.1"
 
 
 repositories {

--- a/src/main/java/io/supertokens/authRecipe/AuthRecipe.java
+++ b/src/main/java/io/supertokens/authRecipe/AuthRecipe.java
@@ -234,12 +234,25 @@ public class AuthRecipe {
         // now we know that the recipe user ID is not a primary user, so we can focus on it's one
         // login method
         assert (recipeUser.loginMethods.length == 1);
-        LoginMethod recipeUserIdLM = recipeUser.loginMethods[0];
-
+        
         Set<String> tenantIds = new HashSet<>();
         tenantIds.addAll(recipeUser.tenantIds);
         tenantIds.addAll(primaryUser.tenantIds);
 
+        checkIfLoginMethodCanBeLinkedOnTenant(con, appIdentifier, authRecipeStorage, tenantIds, recipeUser.loginMethods[0], primaryUser);
+
+        for (LoginMethod currLoginMethod : primaryUser.loginMethods) {
+            checkIfLoginMethodCanBeLinkedOnTenant(con, appIdentifier, authRecipeStorage, tenantIds, currLoginMethod, primaryUser);
+        }
+
+        return new CanLinkAccountsResult(recipeUser.getSupertokensUserId(), primaryUser.getSupertokensUserId(), false);
+    }
+
+    private static void checkIfLoginMethodCanBeLinkedOnTenant(TransactionConnection con, AppIdentifier appIdentifier,
+                                                              AuthRecipeSQLStorage authRecipeStorage,
+                                                              Set<String> tenantIds, LoginMethod currLoginMethod,
+                                                              AuthRecipeUserInfo primaryUser)
+            throws StorageQueryException, AccountInfoAlreadyAssociatedWithAnotherPrimaryUserIdException {
         // we loop through the union of both the user's tenantIds and check that the criteria for
         // linking accounts is not violated in any of them. We do a union and not an intersection
         // cause if we did an intersection, and that yields that account linking is allowed, it could
@@ -251,17 +264,14 @@ public class AuthRecipe {
         // intersection, we will get an empty set, but if we do a union, we will get both the tenants and
         // do the checks in both.
         for (String tenantId : tenantIds) {
-            TenantIdentifier tenantIdentifier = new TenantIdentifier(
-                    appIdentifier.getConnectionUriDomain(), appIdentifier.getAppId(),
-                    tenantId);
             // we do not bother with getting the storage for each tenant here because
             // we get the tenants from the user itself, and the user can only be shared across
             // tenants of the same storage - therefore, the storage will be the same.
 
-            if (recipeUserIdLM.email != null) {
+            if (currLoginMethod.email != null) {
                 AuthRecipeUserInfo[] usersWithSameEmail = authRecipeStorage
                         .listPrimaryUsersByEmail_Transaction(appIdentifier, con,
-                                recipeUserIdLM.email);
+                                currLoginMethod.email);
                 for (AuthRecipeUserInfo user : usersWithSameEmail) {
                     if (!user.tenantIds.contains(tenantId)) {
                         continue;
@@ -274,10 +284,10 @@ public class AuthRecipe {
                 }
             }
 
-            if (recipeUserIdLM.phoneNumber != null) {
+            if (currLoginMethod.phoneNumber != null) {
                 AuthRecipeUserInfo[] usersWithSamePhoneNumber = authRecipeStorage
                         .listPrimaryUsersByPhoneNumber_Transaction(appIdentifier, con,
-                                recipeUserIdLM.phoneNumber);
+                                currLoginMethod.phoneNumber);
                 for (AuthRecipeUserInfo user : usersWithSamePhoneNumber) {
                     if (!user.tenantIds.contains(tenantId)) {
                         continue;
@@ -291,10 +301,10 @@ public class AuthRecipe {
                 }
             }
 
-            if (recipeUserIdLM.thirdParty != null) {
+            if (currLoginMethod.thirdParty != null) {
                 AuthRecipeUserInfo[] usersWithSameThirdParty = authRecipeStorage
                         .listPrimaryUsersByThirdPartyInfo_Transaction(appIdentifier, con,
-                                recipeUserIdLM.thirdParty.id, recipeUserIdLM.thirdParty.userId);
+                                currLoginMethod.thirdParty.id, currLoginMethod.thirdParty.userId);
                 for (AuthRecipeUserInfo userWithSameThirdParty : usersWithSameThirdParty) {
                     if (!userWithSameThirdParty.tenantIds.contains(tenantId)) {
                         continue;
@@ -310,8 +320,6 @@ public class AuthRecipe {
 
             }
         }
-
-        return new CanLinkAccountsResult(recipeUser.getSupertokensUserId(), primaryUser.getSupertokensUserId(), false);
     }
 
     @TestOnly


### PR DESCRIPTION
## Summary of change

fix: make canLinkAccountsHelper check if the login methods of the primary user have conflicts on the tenant of the link target

## Related issues

- 

## Test Plan

Added an extra test-case

## Documentation changes

N/A

## Checklist for important updates

- [x] Changelog has been updated
    - [x] If there are any db schema changes, mention those changes clearly
- [x] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [x] Changes to the version if needed
    - In `build.gradle`
- [x] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [x] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core
  config (similar to the `access_token_signing_key_update_interval` config alias).
- [x] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [x] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting
  the user as well if `deleteUserIdMappingToo` is false.
