### PR TITLE
fix: docker readonly fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [9.2.3] - 2024-10-09
 
 - Adds support for `--with-temp-dir` in CLI and `tempDirLocation=` in Core
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Adds support for `--with-temp-dir` in CLI and `tempDirLocation=` in Core
+
 ## [9.2.2] - 2024-09-04
 
 - Adds index on `last_active_time` for `user_last_active` table to improve the performance of MAU computation.

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "9.2.2"
+version = "9.2.3"
 
 
 repositories {

--- a/cli/src/main/java/io/supertokens/cli/commandHandler/start/StartHandler.java
+++ b/cli/src/main/java/io/supertokens/cli/commandHandler/start/StartHandler.java
@@ -35,6 +35,7 @@ public class StartHandler extends CommandHandler {
     public void doCommand(String installationDir, boolean viaInstaller, String[] args) {
         String space = CLIOptionsParser.parseOption("--with-space", args);
         String configPath = CLIOptionsParser.parseOption("--with-config", args);
+        String tempDirLocation = CLIOptionsParser.parseOption("--with-temp-dir", args);
         if (configPath != null) {
             configPath = new File(configPath).getAbsolutePath();
         }
@@ -67,6 +68,9 @@ public class StartHandler extends CommandHandler {
             if (forceNoInMemDB) {
                 commands.add("forceNoInMemDB=true");
             }
+            if(tempDirLocation != null && !tempDirLocation.isEmpty()) {
+                commands.add("tempDirLocation=" + tempDirLocation);
+            }
         } else {
             commands.add(installationDir + "jre/bin/java");
             commands.add("-Djava.security.egd=file:/dev/urandom");
@@ -89,6 +93,9 @@ public class StartHandler extends CommandHandler {
             }
             if (forceNoInMemDB) {
                 commands.add("forceNoInMemDB=true");
+            }
+            if(tempDirLocation != null && !tempDirLocation.isEmpty()) {
+                commands.add("tempDirLocation=" + tempDirLocation);
             }
         }
         if (!foreground) {
@@ -172,6 +179,8 @@ public class StartHandler extends CommandHandler {
                 "Sets the host on which this instance of SuperTokens should run. Example: \"--host=192.168.0.1\""));
         options.add(
                 new Option("--foreground", "Runs this instance of SuperTokens in the foreground (not as a daemon)"));
+        options.add(
+                new Option("--with-temp-dir", "Uses the passed dir as temp dir, instead of the internal default."));
         return options;
     }
 

--- a/src/main/java/io/supertokens/Main.java
+++ b/src/main/java/io/supertokens/Main.java
@@ -266,6 +266,7 @@ public class Main {
         Webserver.getInstance(this).start();
 
         // this is a sign to the controlling script that this process has started.
+
         createDotStartedFileForThisProcess();
 
         // NOTE: If the message below is changed, make sure to also change the corresponding check in the CLI program
@@ -345,10 +346,11 @@ public class Main {
 
     private void createDotStartedFileForThisProcess() throws IOException {
         CoreConfig config = Config.getBaseConfig(this);
+        String fileLocation = CLIOptions.get(this).getTempDirLocation() == null ? CLIOptions.get(this).getInstallationPath() : CLIOptions.get(this).getTempDirLocation();
         String fileName = OperatingSystem.getOS() == OperatingSystem.OS.WINDOWS
-                ? CLIOptions.get(this).getInstallationPath() + ".started\\" + config.getHost(this) + "-"
+                ? fileLocation + ".started\\" + config.getHost(this) + "-"
                 + config.getPort(this)
-                : CLIOptions.get(this).getInstallationPath() + ".started/" + config.getHost(this) + "-"
+                : fileLocation + ".started/" + config.getHost(this) + "-"
                 + config.getPort(this);
         File dotStarted = new File(fileName);
         if (!dotStarted.exists()) {

--- a/src/main/java/io/supertokens/cliOptions/CLIOptions.java
+++ b/src/main/java/io/supertokens/cliOptions/CLIOptions.java
@@ -32,10 +32,13 @@ public class CLIOptions extends ResourceDistributor.SingletonResource {
     private static final String HOST_FILE_KEY = "host=";
     private static final String TEST_MODE = "test_mode";
     private static final String FORCE_NO_IN_MEM_DB = "forceNoInMemDB=true";
+    private static final String TEMP_DIR_LOCATION_KEY = "tempDirLocation=";
     private final String installationPath;
     private final String configFilePath;
     private final Integer port;
     private final String host;
+    private final String tempDirLocation;
+
 
     // if this is true, then even in DEV mode, we will not use in memory db, even if there is an error in the plugin
     private final boolean forceNoInMemoryDB;
@@ -44,6 +47,7 @@ public class CLIOptions extends ResourceDistributor.SingletonResource {
         checkIfArgsIsCorrect(args);
         String installationPath = args[0];
         String configFilePathTemp = null;
+        String tempDirLocationPath = null;
         Integer portTemp = null;
         String hostTemp = null;
         boolean forceNoInMemoryDBTemp = false;
@@ -54,7 +58,16 @@ public class CLIOptions extends ResourceDistributor.SingletonResource {
                 if (!new File(configFilePathTemp).isAbsolute()) {
                     throw new QuitProgramException("configPath option must be an absolute path only");
                 }
-            } else if (curr.startsWith(PORT_FILE_KEY)) {
+            } else if (curr.startsWith(TEMP_DIR_LOCATION_KEY)) {
+                tempDirLocationPath = curr.split(TEMP_DIR_LOCATION_KEY)[1];
+                if (!new File(tempDirLocationPath).isAbsolute()) {
+                    throw new QuitProgramException("tempDirLocation option must be an absolute path only");
+                }
+                if(!tempDirLocationPath.isEmpty() && !tempDirLocationPath.endsWith(File.separator)){
+                    tempDirLocationPath = tempDirLocationPath + File.separator;
+                }
+            }
+            else if (curr.startsWith(PORT_FILE_KEY)) {
                 portTemp = Integer.parseInt(curr.split(PORT_FILE_KEY)[1]);
             } else if (curr.startsWith(HOST_FILE_KEY)) {
                 hostTemp = curr.split(HOST_FILE_KEY)[1];
@@ -69,6 +82,7 @@ public class CLIOptions extends ResourceDistributor.SingletonResource {
         this.port = portTemp;
         this.host = hostTemp;
         this.forceNoInMemoryDB = forceNoInMemoryDBTemp;
+        this.tempDirLocation = tempDirLocationPath;
     }
 
     private static CLIOptions getInstance(Main main) {
@@ -122,5 +136,9 @@ public class CLIOptions extends ResourceDistributor.SingletonResource {
 
     public boolean isForceNoInMemoryDB() {
         return this.forceNoInMemoryDB;
+    }
+
+    public String getTempDirLocation() {
+        return tempDirLocation;
     }
 }

--- a/src/main/java/io/supertokens/webserver/Webserver.java
+++ b/src/main/java/io/supertokens/webserver/Webserver.java
@@ -101,10 +101,12 @@ public class Webserver extends ResourceDistributor.SingletonResource {
             return;
         }
 
-        File webserverTemp = new File(CLIOptions.get(main).getInstallationPath() + "webserver-temp");
+        String tempDirLocation = decideTempDirLocation();
+        File webserverTemp = new File(tempDirLocation);
         if (!webserverTemp.exists()) {
-            webserverTemp.mkdir();
+            webserverTemp.mkdirs();
         }
+
 
         CONTEXT_PATH = Config.getBaseConfig(main).getBasePath();
 
@@ -117,7 +119,7 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         setupLogging();
 
         // baseDir is a place for Tomcat to store temporary files..
-        tomcat.setBaseDir(CLIOptions.get(main).getInstallationPath() + TEMP_FOLDER);
+        tomcat.setBaseDir(tempDirLocation);
 
         // set thread pool size and port
         Connector connector = new Connector();
@@ -131,7 +133,7 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         tomcat.getEngine().setName(main.getProcessId());
 
         // create docBase folder and get context
-        new File(CLIOptions.get(main).getInstallationPath() + TEMP_FOLDER + "webapps").mkdirs();
+        new File(decideTempDirLocation() + "webapps").mkdirs();
         StandardContext context = (StandardContext) tomcat.addContext(CONTEXT_PATH, "");
 
         // the amount of time for which we should wait for all requests to finish when
@@ -156,6 +158,15 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         tomcatReference = new TomcatReference(tomcat, context);
 
         setupRoutes();
+    }
+
+    private String decideTempDirLocation(){
+        String userSetTempDir = CLIOptions.get(main).getTempDirLocation();
+        if(userSetTempDir != null && !userSetTempDir.endsWith(File.separator)) {
+            userSetTempDir = userSetTempDir + File.separator;
+        }
+        String defaultTempDir = CLIOptions.get(main).getInstallationPath() + TEMP_FOLDER;
+        return userSetTempDir != null ? userSetTempDir : defaultTempDir;
     }
 
     private void setupRoutes() {
@@ -307,7 +318,7 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         try {
             // we want to clear just this process' folder and not all since other processes
             // might still be running.
-            FileUtils.deleteDirectory(new File(CLIOptions.get(main).getInstallationPath() + TEMP_FOLDER));
+            FileUtils.deleteDirectory(new File(decideTempDirLocation()));
         } catch (Exception ignored) {
         }
 

--- a/src/main/java/io/supertokens/webserver/Webserver.java
+++ b/src/main/java/io/supertokens/webserver/Webserver.java
@@ -56,6 +56,7 @@ import org.apache.catalina.connector.Connector;
 import org.apache.catalina.core.StandardContext;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.tomcat.util.http.fileupload.FileUtils;
+import org.jetbrains.annotations.TestOnly;
 
 import java.io.File;
 import java.util.UUID;
@@ -364,6 +365,11 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         }
     }
 
+    @TestOnly
+    public TomcatReference getTomcatReference(){
+        return tomcatReference;
+    }
+
     public static class TomcatReference {
         private Tomcat tomcat;
         private StandardContext context;
@@ -374,6 +380,11 @@ public class Webserver extends ResourceDistributor.SingletonResource {
         }
 
         Tomcat getTomcat() {
+            return tomcat;
+        }
+
+        @TestOnly
+        public Tomcat getTomcatForTest(){
             return tomcat;
         }
 

--- a/src/test/java/io/supertokens/test/CLIOptionsTest.java
+++ b/src/test/java/io/supertokens/test/CLIOptionsTest.java
@@ -287,4 +287,32 @@ public class CLIOptionsTest {
 
     }
 
+    @Test
+    public void cli2TempLocationTest() throws Exception {
+
+        String[] args = {"../"};
+
+        TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STARTED));
+
+        assertEquals(Config.getConfig(process.getProcess()).getHost(process.getProcess()), "localhost");
+        assertEquals(Config.getConfig(process.getProcess()).getPort(process.getProcess()), 3567);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
+
+        //process starts with tempDirLocation param too.
+        args = new String[]{"../", "tempDirLocation=" + new File("../temp/").getAbsolutePath()};
+
+        process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STARTED));
+
+        assertEquals(Config.getConfig(process.getProcess()).getHost(process.getProcess()), "localhost");
+        assertEquals(Config.getConfig(process.getProcess()).getPort(process.getProcess()), 3567);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
+
+    }
+
 }

--- a/src/test/java/io/supertokens/test/DotStartedFileTest.java
+++ b/src/test/java/io/supertokens/test/DotStartedFileTest.java
@@ -185,4 +185,36 @@ public class DotStartedFileTest {
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
+
+    @Test
+    public void dotStartedFileAtTempDirLocation() throws Exception {
+        String tempDirLocation = new File("../temp/").getAbsolutePath();
+        String[] args = {"../", "tempDirLocation=" + tempDirLocation};
+
+        String host = "localhost";
+        String port = "8081";
+        String hostPortNameCheck = host + "-" + port;
+
+        Utils.setValueInConfig("port", port);
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        File loc = new File(tempDirLocation + "/.started");
+
+        File[] dotStartedNameAndContent = loc.listFiles();
+        assert dotStartedNameAndContent != null;
+        assertEquals(1, dotStartedNameAndContent.length);
+        assertEquals(dotStartedNameAndContent[0].getName(), hostPortNameCheck);
+
+        String[] dotStartedContent = Files.readString(Paths.get(dotStartedNameAndContent[0].getPath())).split("\n");
+        String line = dotStartedContent[0];
+        assertEquals(line, Long.toString(ProcessHandle.current().pid()));
+        line = dotStartedContent.length > 1 ? dotStartedContent[1] : "";
+        assertEquals(line, Config.getConfig(process.main).getBasePath());
+        assertEquals(line, "");
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -35,6 +35,7 @@ import io.supertokens.webserver.WebserverAPI;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.apache.catalina.startup.Tomcat;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,6 +43,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
@@ -961,6 +963,25 @@ public class WebserverTest extends Mockito {
             assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
         }
 
+    }
+
+    @Test
+    public void tempDirLocationWebserverStarts() throws InterruptedException, HttpResponseException, IOException {
+        String tempDirLocation = new File("../temp/").getCanonicalPath();
+        String[] args = {"../", "tempDirLocation=" + tempDirLocation};
+        TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STARTED));
+
+        Webserver.TomcatReference reference = Webserver.getInstance(process.getProcess()).getTomcatReference();
+        File catalinaBase = reference.getTomcatForTest().getServer().getCatalinaBase();
+        assertEquals(tempDirLocation, catalinaBase.getAbsolutePath());
+
+        String response = HttpRequest.sendGETRequest(process.getProcess(), "", "http://localhost:3567/", null,
+                1000, 1000, null);
+        assertEquals("Hello", response);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
     }
 
     @Test


### PR DESCRIPTION
## Summary of change

Adds support in CLI and in Core to specify the temp folder location. It's required for docker when run with readonly root fs.

## Related issues

[1048](https://github.com/supertokens/supertokens-core/issues/1048)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core
  config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting
  the user as well if `deleteUserIdMappingToo` is false.

## Remaining TODOs for this PR
