### PR TITLE
fix: bulk migration to actually use the input value for the email verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [10.1.4]
+
+- Bulk migration now actually uses the `isVerified` field's value in the loginMethod input
+
+
 ## [10.1.3]
 
 - Version bumped for re-release

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileTestJava { options.encoding = "UTF-8" }
 //    }
 //}
 
-version = "10.1.3"
+version = "10.1.4"
 
 repositories {
     mavenCentral()

--- a/src/test/java/io/supertokens/test/bulkimport/BulkImportTestUtils.java
+++ b/src/test/java/io/supertokens/test/bulkimport/BulkImportTestUtils.java
@@ -45,6 +45,7 @@ import io.supertokens.utils.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 
 import static org.junit.Assert.*;
 
@@ -79,13 +80,14 @@ public class BulkImportTestUtils {
 
             List<LoginMethod> loginMethods = new ArrayList<>();
             long currentTimeMillis = System.currentTimeMillis();
-            loginMethods.add(new LoginMethod(tenants, "emailpassword", true, true, currentTimeMillis, email, "$2a",
+            Random random = new Random();
+            loginMethods.add(new LoginMethod(tenants, "emailpassword", random.nextBoolean(), true, currentTimeMillis, email, "$2a",
                     "BCRYPT", null, null, null, null, io.supertokens.utils.Utils.getUUID()));
             loginMethods
-                    .add(new LoginMethod(tenants, "thirdparty", true, false, currentTimeMillis, email, null, null, null,
+                    .add(new LoginMethod(tenants, "thirdparty", random.nextBoolean(), false, currentTimeMillis, email, null, null, null,
                             "thirdPartyId" + i, "thirdPartyUserId" + i, null, io.supertokens.utils.Utils.getUUID()));
             loginMethods.add(
-                    new LoginMethod(tenants, "passwordless", true, false, currentTimeMillis, email, null, null, null,
+                    new LoginMethod(tenants, "passwordless", random.nextBoolean(), false, currentTimeMillis, email, null, null, null,
                             null, null, null, io.supertokens.utils.Utils.getUUID()));
             id = loginMethods.get(0).superTokensUserId;
             users.add(new BulkImportUser(id, externalId, userMetadata, userRoles, totpDevices, loginMethods));


### PR DESCRIPTION
## Summary of change

This changes the Bulk Migraitons behavior by actually using the `isVerified` field's value from the input when doing the email verification.

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core
  config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting
  the user as well if `deleteUserIdMappingToo` is false.
- [ ] If added a new recipe, then make sure to update the bulk import API to include the new recipe.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
