### PR TITLE
fix(cli): keep child process stderr separate from stdout in StartHandler

### DIFF
--- a/cli/src/main/java/io/supertokens/cli/commandHandler/start/StartHandler.java
+++ b/cli/src/main/java/io/supertokens/cli/commandHandler/start/StartHandler.java
@@ -25,6 +25,7 @@ import io.supertokens.cli.logging.Logging;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
@@ -149,14 +150,19 @@ public class StartHandler extends CommandHandler {
             try {
                 ProcessBuilder pb = new ProcessBuilder(commands);
                 Logging.info("Command to be run: " + String.join(" ", pb.command()));
-                pb.redirectErrorStream(true);
                 Process process = pb.start();
+
+                Thread stderrLoggerThread = new Thread(() -> logProcessStream(process.getErrorStream(), true),
+                        "supertokens-cli-stderr-logger");
+                stderrLoggerThread.setDaemon(true);
+                stderrLoggerThread.start();
+
                 try (InputStreamReader in = new InputStreamReader(process.getInputStream());
                      BufferedReader reader = new BufferedReader(in)) {
                     String line;
                     boolean success = false;
                     while ((line = reader.readLine()) != null) {
-                        Logging.info(line); // TODO: make error go to Logging.error and other go to Logging.info - later
+                        Logging.info(line);
                         if (line.startsWith("Started SuperTokens on")) {
                             success = true;
                             break;
@@ -188,6 +194,22 @@ public class StartHandler extends CommandHandler {
             } finally {
                 Main.removeShutdownHook();
             }
+        }
+    }
+
+    private static void logProcessStream(InputStream inputStream, boolean isErrorStream) {
+        try (InputStreamReader in = new InputStreamReader(inputStream);
+             BufferedReader reader = new BufferedReader(in)) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (isErrorStream) {
+                    Logging.error(line);
+                } else {
+                    Logging.info(line);
+                }
+            }
+        } catch (Exception ignored) {
+            // Ignore stream reading errors here, they are handled by startup failure handling in caller.
         }
     }
 


### PR DESCRIPTION
Summary of change
This PR fixes log stream handling when starting SuperTokens via the CLI. Previously, StartHandler merged stderr into stdout using redirectErrorStream(true), which caused error logs to be surfaced as info logs.
Now, stdout and stderr are handled separately: stdout is still used for startup detection, while stderr is read independently and logged via Logging.error, preserving proper error visibility.

Related issues
https://github.com/supertokens/supertokens-core/issues/5

https://github.com/supertokens/supertokens-core/issues/319

Test Plan
Ran CLI unit/integration tests:

mvn -pl cli -DskipTests=false test

Verified that tests pass successfully.

Manual verification:

Start SuperTokens using CLI start command.

Trigger an error condition in core startup/runtime.

Confirm normal startup/info messages appear on stdout.

Confirm error output from the child process appears on stderr and is logged as errors.

Documentation changes
No documentation updates are required for this internal logging/stream-handling fix.

Checklist for important updates
 Changelog has been updated

 If there are any db schema changes, mention those changes clearly

 coreDriverInterfaceSupported.json file has been updated (if needed)

 pluginInterfaceSupported.json file has been updated (if needed)

 Changes to the version if needed

In build.gradle

 If added a new paid feature, edit the getPaidFeatureStats function in FeatureFlag.java file

 Had installed and ran the pre-commit hook

 If there are new dependencies that have been added in build.gradle, please make sure to add them
in implementationDependencies.json.

 Update function getValidFields in io/supertokens/config/CoreConfig.java if new aliases were added for any core
config (similar to the access_token_signing_key_update_interval config alias).

 Issue this PR against the latest non released version branch.

To know which one it is, run find the latest released tag (git tag) in the format vX.Y.Z, and then find the
latest branch (git branch --all) whose X.Y is greater than the latest released tag.

If no such branch exists, then create one from the latest released branch.

 If added a foreign key constraint on app_id_to_user_id table, make sure to delete from this table when deleting
the user as well if deleteUserIdMappingToo is false.

 If added a new recipe, then make sure to update the bulk import API to include the new recipe.