### PR TITLE
fix: validate licenseKey field to reject misspelled or malformed input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [11.4.4]
 
 - Fix: adds the otel-javaagent to the installed distribution
+- Fix: validate licenseKey field to reject misspelled or malformed input
 
 ## [11.4.3]
 

--- a/src/main/java/io/supertokens/webserver/api/core/LicenseKeyAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/core/LicenseKeyAPI.java
@@ -50,6 +50,10 @@ public class LicenseKeyAPI extends WebserverAPI {
         // API is app specific and can be queried only from public tenant
         JsonObject input = InputParser.parseJsonObjectOrThrowError(req);
         String licenseKey = InputParser.parseStringOrThrowError(input, "licenseKey", true);
+        if (licenseKey == null && input.size() > 0) {
+            throw new ServletException(
+                    new WebserverAPI.BadRequestException("Field name 'licenseKey' is missing in JSON input"));
+        }
         try {
             AppIdentifier appIdentifier = this.getAppIdentifier(req);
             this.enforcePublicTenantAndGetPublicTenantStorage(req); // enforce public tenant


### PR DESCRIPTION
## Summary
The `PUT /ee/license` endpoint silently accepts requests with misspelled field names (e.g., `licenceKey` instead of `licenseKey`) or missing required fields, returning `OK` without actually setting the license key. This causes silent misconfiguration.

## Changes
Added validation in `LicenseKeyAPI.doPut()` to reject requests where the JSON body is non-empty but the `licenseKey` field is missing. This catches misspelled field names while preserving the existing re-sync behavior when called with an empty body `{}`.

## Test Plan
- `PUT /ee/license` with `{"licenseKey": "valid"}` → sets key (existing behavior)
- `PUT /ee/license` with `{}` → re-syncs existing key (existing behavior preserved)
- `PUT /ee/license` with `{"licenceKey": "abc"}` → now returns 400 error (fixed)

Closes #1152

Assisted-by: GLM 5.1