### PR TITLE
chore: update get-core-dependencies action references

### DIFF
--- a/.github/workflows/_release-resolve-deps.yml
+++ b/.github/workflows/_release-resolve-deps.yml
@@ -31,7 +31,7 @@ jobs:
       postgresql-sha: ${{ steps.shas.outputs.postgresql }}
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         id: result
         with:
           run-for: add-dev-tag

--- a/.github/workflows/add-dev-tag.yml
+++ b/.github/workflows/add-dev-tag.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         id: result
         with:
           run-for: add-dev-tag

--- a/.github/workflows/dev-tag.yml
+++ b/.github/workflows/dev-tag.yml
@@ -16,7 +16,7 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         with:
           run-for: PR
         id: result

--- a/.github/workflows/do-release-java15.yml
+++ b/.github/workflows/do-release-java15.yml
@@ -57,7 +57,7 @@ jobs:
       postgresql-sha: ${{ steps.shas.outputs.postgresql }}
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         id: result
         with:
           run-for: add-dev-tag

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         id: result
         with:
           run-for: PR

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -20,7 +20,7 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         id: result
         with:
           run-for: PR

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/actions/get-core-dependencies-action@main
         id: result
         with:
           run-for: PR


### PR DESCRIPTION
## Summary of change
- update workflow references from `supertokens/get-core-dependencies-action@main` to `supertokens/actions/get-core-dependencies-action@main`
- update all current usages in this repo

## Related issue
- Closes #1239

## Files updated
- `.github/workflows/dev-tag.yml`
- `.github/workflows/add-dev-tag.yml`
- `.github/workflows/publish-dev-docker.yml`
- `.github/workflows/unit-test.yml`
- `.github/workflows/_release-resolve-deps.yml`
- `.github/workflows/release-tests.yml`
- `.github/workflows/do-release-java15.yml`

## Test plan
- verified there are no remaining `supertokens/get-core-dependencies-action@main` references in workflow files
- verified the updated workflow YAML files parse successfully locally
