### PR TITLE
fix: prevent duplicate access token signing keys on concurrent rotation

### DIFF
--- a/src/main/java/io/supertokens/signingkeys/AccessTokenSigningKey.java
+++ b/src/main/java/io/supertokens/signingkeys/AccessTokenSigningKey.java
@@ -39,6 +39,7 @@ import io.supertokens.pluginInterface.multitenancy.exceptions.TenantOrAppNotFoun
 import io.supertokens.pluginInterface.session.SessionStorage;
 import io.supertokens.pluginInterface.session.noSqlStorage.SessionNoSQLStorage_1;
 import io.supertokens.pluginInterface.session.sqlStorage.SessionSQLStorage;
+import io.supertokens.pluginInterface.sqlStorage.SQLStorage.TransactionIsolationLevel;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.utils.Utils;
 import org.jetbrains.annotations.TestOnly;
@@ -226,7 +227,10 @@ public class AccessTokenSigningKey extends ResourceDistributor.SingletonResource
         if (storage.getType() == STORAGE_TYPE.SQL) {
             SessionSQLStorage sqlStorage = (SessionSQLStorage) storage;
             try {
-                // start transaction
+                // SERIALIZABLE (not the default READ_COMMITTED): on a concurrent rotation, READ COMMITTED lets
+                // each instance's SELECT snapshot predate the other's INSERT, so both create a key. SERIALIZABLE
+                // aborts the loser with serialization_failure (SQLSTATE 40); the plugin's startTransaction retry
+                // re-runs it, by which time the other's key is visible, so no duplicate is created.
                 validKeys = sqlStorage.startTransaction(con -> {
                     List<SigningKeys.KeyInfo> validKeysFromSQL = new ArrayList<>();
 
@@ -269,7 +273,7 @@ public class AccessTokenSigningKey extends ResourceDistributor.SingletonResource
 
                     sqlStorage.commitTransaction(con);
                     return validKeysFromSQL;
-                });
+                }, TransactionIsolationLevel.SERIALIZABLE);
             } catch (StorageTransactionLogicException e) {
                 if (e.actualException instanceof TenantOrAppNotFoundException) {
                     throw (TenantOrAppNotFoundException) e.actualException;


### PR DESCRIPTION
## The problem

When multiple core instances run behind a load balancer and the dynamic access token signing key comes up for rotation, each instance races to create the new key and more than one can succeed. Each instance then caches and signs tokens with its own key while serving a JWKS that only contains that key. Consumers validating against the JWKS (Envoy's `jwt_authn`, for example) intermittently reject valid tokens with `Jwks_doesn't_have_key_to_match_kid_or_alg_from_Jwt` until the next rotation happens to reconverge the caches.

The root cause is in `AccessTokenSigningKey.getOrCreateAndGetSigningKeys()`, which does a check-then-act (`SELECT ... FOR UPDATE`, then `INSERT` if no fresh key exists) at the default `READ COMMITTED` isolation level. `FOR UPDATE` only locks rows that already exist, and under `READ COMMITTED` a blocked `SELECT` re-reads only the rows it was blocked on — not rows inserted by the transaction it was waiting for. So a second instance that blocks on the first instance's lock still doesn't see the first instance's newly committed key when it unblocks. Both instances conclude that no fresh key exists and both insert one. Since the primary key includes `created_at_time` and the two inserts land on different milliseconds, there's no unique violation and both commits succeed silently. The existing `startTransaction` retry wrapper never kicks in because nothing fails — there's no deadlock, no constraint violation, and no serialization error at this isolation level.

## Reproducing with two psql sessions

You can demonstrate the race directly against the `session_access_token_signing_keys` table (assuming at least one existing key row so there's something to lock):

```sql
-- Session A                                    -- Session B
BEGIN;
SELECT * FROM session_access_token_signing_keys
  WHERE app_id = 'public' FOR UPDATE;
-- sees only the old, stale key
                                                BEGIN;
                                                SELECT * FROM session_access_token_signing_keys
                                                  WHERE app_id = 'public' FOR UPDATE;
                                                -- blocks on A's row locks...

INSERT INTO session_access_token_signing_keys
  VALUES ('public', 1700000000001, 'keyA...');
COMMIT;
                                                -- ...unblocks, but the result set
                                                -- still does NOT include A's new key,
                                                -- so B also decides to create one
                                                INSERT INTO session_access_token_signing_keys
                                                  VALUES ('public', 1700000000002, 'keyB...');
                                                COMMIT;  -- succeeds silently
```

The table now has two keys for a single rotation. If you repeat the same steps but start both sessions with `BEGIN ISOLATION LEVEL SERIALIZABLE`, session B's commit instead fails with `serialization_failure` (SQLSTATE `40001`) — which is exactly what this fix relies on.

## The fix

Run that one transaction at `SERIALIZABLE` isolation:

```java
validKeys = sqlStorage.startTransaction(con -> { ... }, TransactionIsolationLevel.SERIALIZABLE);
```

Under serializable snapshot isolation the two concurrent creators form a read/write conflict, so the second one to commit aborts with SQLSTATE `40001`. The PostgreSQL plugin's existing `startTransaction` retry loop already catches class-40 errors and re-runs the transaction; on retry the aborted instance takes a fresh snapshot, sees the other instance's committed key, and skips its own insert. Exactly one key is created per rotation. This mirrors the approach taken in #1257 for the analogous OAuth refresh-token race.

The change is core-only and uses the existing `startTransaction(logic, isolationLevel)` overload, so no plugin interface changes are needed. The PostgreSQL plugin already honours the requested isolation level and retries serialization failures. The in-memory (SQLite) plugin ignores the isolation level, but it is already protected by its per-app connection locking, so passing `SERIALIZABLE` is a harmless no-op there. The NoSQL path is already safe through its optimistic-concurrency retry loop.

## Notes

The static JWT-recipe key path (`JWTSigningKey.getOrCreateAndGetKeyForAlgorithm`) has the same check-then-act pattern, but since it isn't involved in access-token/JWKS validation it is intentionally left out to keep this PR focused; happy to follow up separately. Deployments already affected by this race may also want to clean up duplicate rows (keep the newest `created_at_time` per `app_id`), since instance caches will keep diverging on the stale duplicates until the next rotation.

## Changelog

```markdown
## [Unreleased]

- Fixes a race that could create duplicate access token signing keys when multiple
  core instances rotated the key concurrently (SQL/PostgreSQL storage). Key creation
  now runs at SERIALIZABLE isolation, so a concurrent creator aborts with a
  serialization failure and is retried by the existing transaction-retry logic
  instead of inserting a second key. Duplicate keys caused JWKS `kid` mismatches
  during rotation (e.g. Envoy `Jwks_doesn't_have_key_to_match_kid_or_alg_from_Jwt`).
```