### PR TITLE
fix: return 4xx instead of 500 for malformed OAuth/JWT input

### DIFF
--- a/src/main/java/io/supertokens/oauth/OAuth.java
+++ b/src/main/java/io/supertokens/oauth/OAuth.java
@@ -270,10 +270,16 @@ public class OAuth {
 
     private static void checkNonSuccessResponse(HttpRequestForOAuthProvider.Response response) throws OAuthAPIException, OAuthClientNotFoundException {
         if (response.statusCode >= 400) {
-            String error = response.jsonResponse.getAsJsonObject().get("error").getAsString();
+            String error = "unknown_error";
             String errorDescription = null;
-            if (response.jsonResponse.getAsJsonObject().has("error_description")) {
-                errorDescription = response.jsonResponse.getAsJsonObject().get("error_description").getAsString();
+            if (response.jsonResponse != null && response.jsonResponse.isJsonObject()) {
+                JsonObject responseObject = response.jsonResponse.getAsJsonObject();
+                if (responseObject.has("error") && responseObject.get("error").isJsonPrimitive()) {
+                    error = responseObject.get("error").getAsString();
+                }
+                if (responseObject.has("error_description") && responseObject.get("error_description").isJsonPrimitive()) {
+                    errorDescription = responseObject.get("error_description").getAsString();
+                }
             }
             throw new OAuthAPIException(error, errorDescription, response.statusCode);
         }

--- a/src/main/java/io/supertokens/session/jwt/JWT.java
+++ b/src/main/java/io/supertokens/session/jwt/JWT.java
@@ -79,9 +79,15 @@ public class JWT {
             return new JWTPreParseInfo(splittedInput, AccessToken.VERSION.V2, null);
         }
 
-        JsonObject parsedHeader = new JsonParser().parse(Utils.convertFromBase64(splittedInput[0])).getAsJsonObject();
+        JsonObject parsedHeader;
+        try {
+            parsedHeader = new JsonParser().parse(Utils.convertFromBase64(splittedInput[0])).getAsJsonObject();
+        } catch (RuntimeException e) {
+            // malformed base64 / JSON / non-object header is invalid input, not a server error
+            throw new JWTException("Invalid JWT");
+        }
 
-        if (parsedHeader.get("typ") == null) {
+        if (parsedHeader.get("typ") == null || !parsedHeader.get("typ").isJsonPrimitive()) {
             throw new JWTException("JWT header missing - typ");
         }
         JsonPrimitive typ = parsedHeader.get("typ").getAsJsonPrimitive();
@@ -89,7 +95,7 @@ public class JWT {
             throw new JWTException("JWT header mismatch - typ");
         }
 
-        if (parsedHeader.get("alg") == null) {
+        if (parsedHeader.get("alg") == null || !parsedHeader.get("alg").isJsonPrimitive()) {
             throw new JWTException("JWT header missing - alg");
         }
         JsonPrimitive alg = parsedHeader.get("alg").getAsJsonPrimitive();
@@ -102,6 +108,9 @@ public class JWT {
         String versionString = AccessToken.getVersionStringFromAccessTokenVersion(AccessToken.getLatestVersion());
 
         if (versionElement != null) {
+            if (!versionElement.isJsonPrimitive()) {
+                throw new JWTException("JWT header mismatch - version");
+            }
             JsonPrimitive version = versionElement.getAsJsonPrimitive();
             if (!version.isString() || version.getAsString().equals("1") || version.getAsString().equals("2")) {
                 throw new JWTException("JWT header mismatch - version");
@@ -110,14 +119,18 @@ public class JWT {
             versionString = version.getAsString();
         }
 
-        JsonPrimitive kid = parsedHeader.get("kid").getAsJsonPrimitive();
-        if (parsedHeader.get("kid") == null) {
+        if (parsedHeader.get("kid") == null || !parsedHeader.get("kid").isJsonPrimitive()) {
             throw new JWTException("JWT header missing - kid");
         }
+        JsonPrimitive kid = parsedHeader.get("kid").getAsJsonPrimitive();
         if (!kid.isString()) {
             throw new JWTException("JWT header mismatch - kid");
         }
-        return new JWTPreParseInfo(splittedInput, AccessToken.getVersionFromString(versionString), kid.getAsString());
+        try {
+            return new JWTPreParseInfo(splittedInput, AccessToken.getVersionFromString(versionString), kid.getAsString());
+        } catch (RuntimeException e) {
+            throw new JWTException("JWT header mismatch - version");
+        }
     }
 
     public static JWTInfo verifyJWTAndGetPayload(JWTPreParseInfo jwt, String publicSigningKey)

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -636,7 +636,12 @@ public abstract class WebserverAPI extends HttpServlet {
         String version = req.getHeader("cdi-version");
 
         if (version != null) {
-            SemVer versionFromRequest = new SemVer(version);
+            SemVer versionFromRequest;
+            try {
+                versionFromRequest = new SemVer(version);
+            } catch (RuntimeException e) {
+                throw new ServletException(new BadRequestException("cdi-version header is invalid"));
+            }
 
             if (versionFromRequest.greaterThan(maxCDIVersion)) {
                 throw new ServletException(

--- a/src/main/java/io/supertokens/webserver/api/oauth/OAuthTokenAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/oauth/OAuthTokenAPI.java
@@ -122,17 +122,21 @@ public class OAuthTokenAPI extends WebserverAPI {
         }
 
         Map<String, String> formFields = new HashMap<>();
-        for (Map.Entry<String, JsonElement> entry : bodyFromSDK.entrySet()) {
-            formFields.put(entry.getKey(), entry.getValue().getAsString());
-        }
-
         String clientId;
+        try {
+            for (Map.Entry<String, JsonElement> entry : bodyFromSDK.entrySet()) {
+                formFields.put(entry.getKey(), entry.getValue().getAsString());
+            }
 
-        if (authorizationHeader != null) {
-            String[] parsedHeader = Utils.convertFromBase64(authorizationHeader.replaceFirst("^Basic ", "").trim()).split(":");
-            clientId = parsedHeader[0];
-        } else {
-            clientId = formFields.get("client_id");
+            if (authorizationHeader != null) {
+                String[] parsedHeader = Utils.convertFromBase64(authorizationHeader.replaceFirst("^Basic ", "").trim()).split(":");
+                clientId = parsedHeader[0];
+            } else {
+                clientId = formFields.get("client_id");
+            }
+        } catch (RuntimeException e) {
+            // non-primitive body values / malformed Basic auth header
+            throw new ServletException(new BadRequestException("malformed request body or authorization header"));
         }
 
         try {

--- a/src/main/java/io/supertokens/webserver/api/oauth/RevokeOAuthTokenAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/oauth/RevokeOAuthTokenAPI.java
@@ -94,7 +94,15 @@ public class RevokeOAuthTokenAPI extends WebserverAPI {
                 String authorizationHeader = InputParser.parseStringOrThrowError(input, "authorizationHeader", true);
 
                 if (authorizationHeader != null) {
-                    String[] parsedHeader = Utils.convertFromBase64(authorizationHeader.replaceFirst("^Basic ", "").trim()).split(":");
+                    String[] parsedHeader;
+                    try {
+                        parsedHeader = Utils.convertFromBase64(authorizationHeader.replaceFirst("^Basic ", "").trim()).split(":");
+                    } catch (RuntimeException e) {
+                        throw new ServletException(new BadRequestException("authorizationHeader is not valid base64"));
+                    }
+                    if (parsedHeader.length != 2) {
+                        throw new ServletException(new BadRequestException("authorizationHeader must contain clientId:clientSecret"));
+                    }
                     clientId = parsedHeader[0];
                     clientSecret = parsedHeader[1];
                 } else {

--- a/src/test/java/io/supertokens/test/WebserverTest.java
+++ b/src/test/java/io/supertokens/test/WebserverTest.java
@@ -261,6 +261,30 @@ public class WebserverTest extends Mockito {
 
     }
 
+    // * - Give a cdi-version that is not in a valid version format and make sure it results in a
+    // 400 (it used to surface as a 500 from the SemVer constructor)
+    @Test
+    public void testInvalidVersionFormat() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcess process = TestingProcessManager.startIsolatedProcess(args);
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STARTED));
+
+        for (String invalidCdiVersion : new String[]{"abc", "2.x", "1..0", "2,7"}) {
+            try {
+                HttpRequestForTesting.sendGETRequest(process.getProcess(), "",
+                        "http://localhost:3567/hello", null, 1000, 1000, null, invalidCdiVersion, "");
+                fail();
+            } catch (io.supertokens.test.httpRequest.HttpResponseException e) {
+                assertEquals("Http error. Status Code: 400. Message: cdi-version header is invalid",
+                        e.getMessage());
+            }
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
+    }
+
     // * - Give no version and makes sure it treats it as the latest
     @Test
     public void testNoVersionGiven() throws Exception {

--- a/src/test/java/io/supertokens/test/oauth/api/TestMalformedInput5_2.java
+++ b/src/test/java/io/supertokens/test/oauth/api/TestMalformedInput5_2.java
@@ -1,0 +1,119 @@
+/*
+ *    Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.oauth.api;
+
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.featureflag.EE_FEATURES;
+import io.supertokens.featureflag.FeatureFlagTestContent;
+import io.supertokens.pluginInterface.STORAGE_TYPE;
+import io.supertokens.storageLayer.StorageLayer;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import io.supertokens.test.httpRequest.HttpRequestForTesting;
+import io.supertokens.test.httpRequest.HttpResponseException;
+import io.supertokens.utils.SemVer;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import static org.junit.Assert.*;
+
+/**
+ * Malformed input to the OAuth token API must result in a 400, not a 500. None of these requests
+ * reach the OAuth provider, so no provider setup is needed.
+ */
+public class TestMalformedInput5_2 {
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @Rule
+    public TestRule retryFlaky = Utils.retryFlakyTest();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    @Test
+    public void testTokenAPIMalformedInputReturns400() throws Exception {
+        String[] args = { "../" };
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[] { EE_FEATURES.OAUTH });
+
+        { // non-primitive value in the SDK body used to surface as a 500 from getAsString
+            JsonObject inputBody = new JsonObject();
+            inputBody.addProperty("grant_type", "client_credentials");
+            inputBody.add("scope", new JsonObject());
+
+            JsonObject body = new JsonObject();
+            body.addProperty("iss", "http://localhost:3567/auth");
+            body.add("inputBody", inputBody);
+            body.add("access_token", new JsonObject());
+            body.add("id_token", new JsonObject());
+
+            HttpResponseException e = assertThrows(HttpResponseException.class, () -> {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/oauth/token", body, 1000, 1000, null,
+                        SemVer.v5_2.get(), "");
+            });
+            assertEquals(400, e.statusCode);
+            assertEquals("Http error. Status Code: 400. Message: malformed request body or authorization header",
+                    e.getMessage());
+        }
+
+        { // malformed basic auth header used to surface as a 500 from the base64 decode
+            JsonObject inputBody = new JsonObject();
+            inputBody.addProperty("grant_type", "client_credentials");
+
+            JsonObject body = new JsonObject();
+            body.addProperty("iss", "http://localhost:3567/auth");
+            body.add("inputBody", inputBody);
+            body.add("access_token", new JsonObject());
+            body.add("id_token", new JsonObject());
+            body.addProperty("authorizationHeader", "Basic !!!not-base64!!!");
+
+            HttpResponseException e = assertThrows(HttpResponseException.class, () -> {
+                HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                        "http://localhost:3567/recipe/oauth/token", body, 1000, 1000, null,
+                        SemVer.v5_2.get(), "");
+            });
+            assertEquals(400, e.statusCode);
+            assertEquals("Http error. Status Code: 400. Message: malformed request body or authorization header",
+                    e.getMessage());
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+}

--- a/src/test/java/io/supertokens/test/session/JWTTest.java
+++ b/src/test/java/io/supertokens/test/session/JWTTest.java
@@ -107,6 +107,73 @@ public class JWTTest {
         }
     }
 
+    // every malformed header shape must surface as JWTException (mapped to 4xx by the APIs), never
+    // as a runtime error (which would end up as a 500)
+    @Test
+    public void preParseJWTInfoMalformedInputs() {
+        // not three dot-separated parts
+        assertPreParseThrows("not-a-jwt", "Invalid JWT");
+
+        // header is not valid base64
+        assertPreParseThrows("!!!notbase64!!!.payload.signature", "Invalid JWT");
+
+        // header is valid base64 but not valid JSON
+        assertPreParseThrows(io.supertokens.utils.Utils.convertToBase64("{") + ".payload.signature",
+                "Invalid JWT");
+
+        // header is a JSON scalar instead of an object
+        assertPreParseThrows(io.supertokens.utils.Utils.convertToBase64("\"hello\"") + ".payload.signature",
+                "Invalid JWT");
+
+        // header is a JSON array instead of an object
+        assertPreParseThrows(io.supertokens.utils.Utils.convertToBase64("[1, 2]") + ".payload.signature",
+                "Invalid JWT");
+
+        // typ is not a primitive
+        assertPreParseThrows(tokenWithHeader("{\"typ\": {}, \"alg\": \"RS256\", \"kid\": \"key1\"}"),
+                "JWT header missing - typ");
+
+        // alg is not a primitive
+        assertPreParseThrows(tokenWithHeader("{\"typ\": \"JWT\", \"alg\": [], \"kid\": \"key1\"}"),
+                "JWT header missing - alg");
+
+        // version is not a primitive
+        assertPreParseThrows(
+                tokenWithHeader("{\"typ\": \"JWT\", \"alg\": \"RS256\", \"version\": {}, \"kid\": \"key1\"}"),
+                "JWT header mismatch - version");
+
+        // version string that does not map to a known access token version
+        assertPreParseThrows(
+                tokenWithHeader("{\"typ\": \"JWT\", \"alg\": \"RS256\", \"version\": \"999\", \"kid\": \"key1\"}"),
+                "JWT header mismatch - version");
+
+        // missing kid; this used to throw a NullPointerException because the null check happened
+        // after the dereference
+        assertPreParseThrows(tokenWithHeader("{\"typ\": \"JWT\", \"alg\": \"RS256\"}"),
+                "JWT header missing - kid");
+
+        // kid is not a primitive
+        assertPreParseThrows(tokenWithHeader("{\"typ\": \"JWT\", \"alg\": \"RS256\", \"kid\": {}}"),
+                "JWT header missing - kid");
+
+        // kid is a primitive but not a string
+        assertPreParseThrows(tokenWithHeader("{\"typ\": \"JWT\", \"alg\": \"RS256\", \"kid\": 42}"),
+                "JWT header mismatch - kid");
+    }
+
+    private static String tokenWithHeader(String headerJson) {
+        return io.supertokens.utils.Utils.convertToBase64(headerJson) + ".payload.signature";
+    }
+
+    private static void assertPreParseThrows(String jwt, String expectedMessage) {
+        try {
+            JWT.preParseJWTInfo(jwt);
+            fail("expected JWTException for: " + jwt);
+        } catch (JWTException e) {
+            assertEquals(expectedMessage, e.getMessage());
+        }
+    }
+
     @Test
     public void signingSuccess()
             throws NoSuchAlgorithmException, InvalidKeySpecException, InvalidKeyException, SignatureException {


### PR DESCRIPTION
## Problem

`WebserverAPI.service()` maps checked exceptions to status codes but funnels any `RuntimeException`
to a 500. Several OAuth/JWT paths throw unchecked exceptions on malformed **client** input, so bad
requests are reported as server errors (and show up as 5xx in monitoring). All confirmed in
production traffic, each returning 500 in ~10ms:

| Input | Exception | Endpoint(s) |
|---|---|---|
| `idTokenHint=x.y.z` (invalid base64) | `IllegalArgumentException` from `Utils.convertFromBase64` in `JWT.preParseJWTInfo` | `GET /recipe/oauth/sessions/logout`, `POST /recipe/oauth/token/revoke` |
| valid base64, non-JSON / JSON scalar header | `JsonSyntaxException` / `IllegalStateException` | same |
| header without `kid` | **NPE - the null check runs after the dereference** (`JWT.java`) | same |
| `Basic` auth header without `:` | `ArrayIndexOutOfBoundsException` (`RevokeOAuthTokenAPI`) | `/recipe/oauth/token/revoke` |
| non-primitive body values / malformed `Basic` header parsed outside the try block | `IllegalStateException` / `IllegalArgumentException` (`OAuthTokenAPI`) | `/recipe/oauth/token` |
| upstream OAuth provider replies >=400 with a non-JSON body (e.g. an LB error page) | NPE in `OAuth.checkNonSuccessResponse` | any OAuth proxy endpoint |

Plus a wider one: a malformed `cdi-version` header makes `new SemVer(...)` throw, returning **500 on
every endpoint**.

## Change

- `JWT.preParseJWTInfo`: all malformed-token shapes now throw `JWTException` (invalid base64,
  non-JSON, scalar header, non-primitive `typ`/`alg`/`version`/`kid`, unknown version string), and the
  `kid` null check is moved before the dereference. Because `OAuthToken.getPayloadFromJWTToken` maps
  `JWTException -> TryRefreshTokenException` and `OAuth.verifyIdTokenAndGetPayload` maps that to
  `OAuthAPIException(..., 400)`, this fixes the logout/revoke paths end to end.
- `WebserverAPI.getVersionFromRequest`: invalid `cdi-version` -> 400.
- `OAuthTokenAPI`: body-field and `Basic` header parsing moved inside a guard -> 400.
- `RevokeOAuthTokenAPI`: invalid base64 or missing `clientId:clientSecret` -> 400.
- `OAuth.checkNonSuccessResponse`: null/non-JSON upstream error bodies no longer NPE; falls back to
  `unknown_error` plus the upstream status.

No behaviour change for valid input.

## Testing

Manual matrix (all 8 cases returned 500 before, 4xx after): invalid-base64 / non-JSON / scalar-header
/ missing-kid id token hints, garbage token to `/token/revoke`, `Basic` header without a colon,
object-valued body field to `/recipe/oauth/token`, and a garbage `cdi-version` on `/hello`.

Suggested unit tests for this PR: `JWT.preParseJWTInfo` asserting `JWTException` for each malformed
shape, and one webserver test asserting 400 for an invalid `cdi-version`.
