### PR TITLE
fix: compute the MAU series with one query; fix SAML stats aggregation

### DIFF
--- a/ee/src/main/java/io/supertokens/ee/EEFeatureFlag.java
+++ b/ee/src/main/java/io/supertokens/ee/EEFeatureFlag.java
@@ -41,6 +41,7 @@ import io.supertokens.version.Version;
 import org.jetbrains.annotations.TestOnly;
 
 import java.io.IOException;
+import java.util.Map;
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -376,12 +377,20 @@ public class EEFeatureFlag implements io.supertokens.featureflag.EEFeatureFlagIn
         JsonArray mauArr = new JsonArray();
         long now = System.currentTimeMillis();
 
-        for (int i = 1; i <= 31; i++) {
-            long timestamp = now - (i * 24 * 60 * 60 * 1000L);
-            ActiveUsersStorage activeUsersStorage = (ActiveUsersStorage) StorageLayer.getStorage(
-                    this.appIdentifier.getAsPublicTenantIdentifier(), main);
-            int mau = activeUsersStorage.countUsersActiveSince(this.appIdentifier, timestamp);
-            mauArr.add(new JsonPrimitive(mau));
+        ActiveUsersStorage activeUsersStorage = (ActiveUsersStorage) StorageLayer.getStorage(
+                this.appIdentifier.getAsPublicTenantIdentifier(), main);
+
+        // One bucketed query for the whole series instead of 31 separate COUNT(*)s, each of which
+        // scanned the app's entire user_last_active set.
+        long oldestTimestamp = now - (31L * 24 * 60 * 60 * 1000L);
+        Map<Integer, Integer> usersByDaysAgo = activeUsersStorage.countUsersActiveSinceGroupedByDay(
+                this.appIdentifier, oldestTimestamp, now);
+
+        // maus[i] == users active since (now - (i+1) days) == running total of buckets 0..i
+        int runningTotal = 0;
+        for (int day = 0; day < 31; day++) {
+            runningTotal += usersByDaysAgo.getOrDefault(day, 0);
+            mauArr.add(new JsonPrimitive(runningTotal));
         }
         return mauArr;
     }
@@ -405,8 +414,12 @@ public class EEFeatureFlag implements io.supertokens.featureflag.EEFeatureFlagIn
 
                 JsonObject stat = new JsonObject();
                 stat.addProperty("numberOfSAMLClients", samlStorage.countSAMLClients(tenantConfig.tenantIdentifier));
-                stat.add(tenantConfig.tenantIdentifier.getTenantId(), stat);
+                // was: stat.add(tenantId, stat) - added the object to itself (serialization recursion
+                // hazard) and tenantStat was never appended, so "tenants" was always empty.
+                tenantStat.add(tenantConfig.tenantIdentifier.getTenantId(), stat);
             }
+
+            tenantStats.add(tenantStat);
         }
 
         stats.add("tenants", tenantStats);

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -1492,6 +1492,16 @@ public class Start
         }
     }
 
+    @TestOnly
+    public void updateLastActive(AppIdentifier appIdentifier, String userId, long timestamp)
+            throws StorageQueryException {
+        try {
+            ActiveUsersQueries.updateUserLastActive(this, appIdentifier, userId, timestamp);
+        } catch (SQLException e) {
+            throw new StorageQueryException(e);
+        }
+    }
+
     @Override
     public Map<Integer, Integer> countUsersActiveSinceGroupedByDay(AppIdentifier appIdentifier, long sinceTime,
                                                                    long now) throws StorageQueryException {

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -1493,6 +1493,26 @@ public class Start
     }
 
     @Override
+    public Map<Integer, Integer> countUsersActiveSinceGroupedByDay(AppIdentifier appIdentifier, long sinceTime,
+                                                                   long now) throws StorageQueryException {
+        // in-memory storage is dev/test only: derive buckets from the existing cumulative counts
+        Map<Integer, Integer> buckets = new HashMap<>();
+        int previous = 0;
+        for (int day = 0; ; day++) {
+            long threshold = now - ((long) (day + 1)) * 24 * 60 * 60 * 1000L;
+            if (threshold < sinceTime) {
+                break;
+            }
+            int cumulative = countUsersActiveSince(appIdentifier, threshold);
+            if (cumulative - previous > 0) {
+                buckets.put(day, cumulative - previous);
+            }
+            previous = cumulative;
+        }
+        return buckets;
+    }
+
+    @Override
     public int countUsersActiveSince(AppIdentifier appIdentifier, long time) throws StorageQueryException {
         try {
             return ActiveUsersQueries.countUsersActiveSince(this, appIdentifier, time);

--- a/src/main/java/io/supertokens/inmemorydb/queries/ActiveUsersQueries.java
+++ b/src/main/java/io/supertokens/inmemorydb/queries/ActiveUsersQueries.java
@@ -7,6 +7,7 @@ import io.supertokens.inmemorydb.config.Config;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.inmemorydb.Start;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
+import org.jetbrains.annotations.TestOnly;
 
 import static io.supertokens.inmemorydb.QueryExecutorTemplate.execute;
 import static io.supertokens.inmemorydb.QueryExecutorTemplate.update;
@@ -116,6 +117,22 @@ public class ActiveUsersQueries {
             pst.setString(2, userId);
             pst.setLong(3, now);
             pst.setLong(4, now);
+        });
+    }
+
+    @TestOnly
+    public static int updateUserLastActive(Start start, AppIdentifier appIdentifier, String userId, long timestamp)
+            throws SQLException, StorageQueryException {
+        String QUERY = "INSERT INTO " + Config.getConfig(start).getUserLastActiveTable()
+                +
+                "(app_id, user_id, last_active_time) VALUES(?, ?, ?) ON CONFLICT(app_id, user_id) DO UPDATE SET " +
+                "last_active_time = ?";
+
+        return update(start, QUERY, pst -> {
+            pst.setString(1, appIdentifier.getAppId());
+            pst.setString(2, userId);
+            pst.setLong(3, timestamp);
+            pst.setLong(4, timestamp);
         });
     }
 

--- a/src/test/java/io/supertokens/test/ActiveUsersTest.java
+++ b/src/test/java/io/supertokens/test/ActiveUsersTest.java
@@ -1,12 +1,18 @@
 package io.supertokens.test;
 
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.supertokens.ActiveUsers;
 import io.supertokens.Main;
 import io.supertokens.ProcessState;
+import io.supertokens.ResourceDistributor;
 import io.supertokens.featureflag.EE_FEATURES;
+import io.supertokens.featureflag.FeatureFlag;
 import io.supertokens.featureflag.FeatureFlagTestContent;
+import io.supertokens.pluginInterface.ActiveUsersStorage;
 import io.supertokens.pluginInterface.STORAGE_TYPE;
+import io.supertokens.pluginInterface.Storage;
+import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
@@ -19,8 +25,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
 
+import java.lang.reflect.Method;
 import java.util.HashMap;
+import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
@@ -224,6 +233,74 @@ public class ActiveUsersTest {
 
         assert res.get("status").getAsString().equals("OK");
         assert res.get("count").getAsInt() == 2;
+    }
+
+    @Test
+    public void testMauSeriesWithActivityAcrossDayBuckets() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.startIsolatedProcess(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        Main main = process.getProcess();
+        final long day = 24 * 60 * 60 * 1000L;
+        final long halfDay = 12 * 60 * 60 * 1000L;
+        long now = System.currentTimeMillis();
+
+        AppIdentifier appIdentifier = ResourceDistributor.getAppForTesting().toAppIdentifier();
+        Storage storage = StorageLayer.getStorage(main);
+
+        // Both the in-memory storage and the postgresql plugin expose a @TestOnly
+        // updateLastActive(AppIdentifier, String, long) overload for backdating. The plugin class
+        // is not on the compile-time classpath, so look the method up reflectively.
+        Method backdate = storage.getClass().getMethod("updateLastActive", AppIdentifier.class, String.class,
+                long.class);
+
+        // existing MAU tests only create activity at "now" (bucket 0), so the summation across
+        // buckets was never exercised. Backdate activity into several distinct day buckets,
+        // leave a middle bucket empty, and add activity beyond the 31 day window.
+        backdate.invoke(storage, appIdentifier, "bucket0-user", now - halfDay);
+        backdate.invoke(storage, appIdentifier, "bucket1-user-a", now - day - halfDay);
+        backdate.invoke(storage, appIdentifier, "bucket1-user-b", now - day - halfDay);
+        // bucket 2 is intentionally left empty
+        backdate.invoke(storage, appIdentifier, "bucket3-user", now - 3 * day - halfDay);
+        backdate.invoke(storage, appIdentifier, "bucket30-user", now - 30 * day - halfDay);
+        backdate.invoke(storage, appIdentifier, "outside-window-user", now - 32 * day);
+
+        Map<Integer, Integer> buckets = ((ActiveUsersStorage) storage)
+                .countUsersActiveSinceGroupedByDay(appIdentifier, now - 31 * day, now);
+
+        assertEquals(1, buckets.getOrDefault(0, 0).intValue());
+        assertEquals(2, buckets.getOrDefault(1, 0).intValue());
+        assertEquals(0, buckets.getOrDefault(2, 0).intValue());
+        assertEquals(1, buckets.getOrDefault(3, 0).intValue());
+        assertEquals(1, buckets.getOrDefault(30, 0).intValue());
+
+        // the running total of buckets 0..i must equal the cumulative count for the same threshold
+        int runningTotal = 0;
+        for (int i = 0; i <= 30; i++) {
+            runningTotal += buckets.getOrDefault(i, 0);
+            assertEquals("running total of buckets 0.." + i + " should match countUsersActiveSince",
+                    ActiveUsers.countUsersActiveSince(main, now - (i + 1) * day), runningTotal);
+        }
+        assertEquals(5, runningTotal); // outside-window-user is not part of the series
+
+        // the maus series is built from the bucketed query and must reflect the same numbers
+        JsonArray maus = FeatureFlag.getInstance(main).getPaidFeatureStats().get("maus").getAsJsonArray();
+        assertEquals(31, maus.size());
+        assertEquals(1, maus.get(0).getAsInt());
+        assertEquals(3, maus.get(1).getAsInt());
+        assertEquals(3, maus.get(2).getAsInt()); // empty bucket keeps the previous total
+        assertEquals(4, maus.get(3).getAsInt());
+        assertEquals(4, maus.get(29).getAsInt());
+        assertEquals(5, maus.get(30).getAsInt()); // bucket 30 only shows up in the last value
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
 
     @Test

--- a/src/test/java/io/supertokens/test/FeatureFlagTest.java
+++ b/src/test/java/io/supertokens/test/FeatureFlagTest.java
@@ -38,6 +38,7 @@ import io.supertokens.session.Session;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.httpRequest.HttpRequestForTesting;
 import io.supertokens.test.multitenant.api.TestMultitenancyAPIHelper;
+import io.supertokens.test.saml.SAMLTestUtils;
 import io.supertokens.webserver.WebserverAPI;
 import org.junit.*;
 import org.junit.rules.TestRule;
@@ -988,5 +989,43 @@ public class FeatureFlagTest {
         }
 
         assertEquals(requiredFeatures, foundFeatures);
+    }
+
+    @Test
+    public void testSAMLStatsContainTenantStats() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.startIsolatedProcess(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        FeatureFlag.getInstance(process.getProcess()).setLicenseKeyAndSyncFeatures(OPAQUE_KEY_WITH_SAML_FEATURE);
+
+        SAMLTestUtils.createClientWithGeneratedMetadata(process, "http://localhost:3000/callback",
+                "http://localhost:3567/recipe/saml/callback", "https://saml.example.com/entity-1",
+                "https://mocksaml.com/api/saml/sso");
+        SAMLTestUtils.createClientWithGeneratedMetadata(process, "http://localhost:3000/callback2",
+                "http://localhost:3567/recipe/saml/callback", "https://saml.example.com/entity-2",
+                "https://mocksaml.com/api/saml/sso");
+
+        JsonObject stats = FeatureFlag.getInstance(process.getProcess()).getPaidFeatureStats();
+        assertTrue(stats.has("saml"));
+        JsonObject samlStats = stats.get("saml").getAsJsonObject();
+
+        // regression: "tenants" used to always be an empty array because the per-tenant stat
+        // object was added to itself instead of being appended to the array
+        JsonArray tenants = samlStats.get("tenants").getAsJsonArray();
+        assertEquals(1, tenants.size());
+
+        JsonObject publicTenantStat = tenants.get(0).getAsJsonObject();
+        assertEquals("public", publicTenantStat.get("tenantId").getAsString());
+        assertEquals(2,
+                publicTenantStat.get("public").getAsJsonObject().get("numberOfSAMLClients").getAsInt());
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
 }


### PR DESCRIPTION
## Problem

`GET /appid-<app>/ee/featureflag` recomputes `getPaidFeatureStats()` on every call (only
`getEnabledFeatures` is cached). The dominant cost is `getMAUs()`, which issues **31 sequential
`COUNT(*)` queries** - one per day threshold - each on its own pooled connection:

```sql
SELECT COUNT(*) FROM user_last_active WHERE app_id = ? AND last_active_time >= ?
```

The 31 queries overlap almost entirely (the 31-day query re-counts everything the 1-day query
counted), and `user_last_active` has no `(app_id, last_active_time)` index - only `(app_id)`, the PK,
and a time-leading `(last_active_time DESC, app_id DESC)` - so they degrade to sequential scans.

`EXPLAIN (ANALYZE, BUFFERS)` on eight production databases (114k-628k rows in `user_last_active`):
each count costs 46-579 ms and the 31-query loop accounts for the endpoint's full 1.4-3 s response
time. It is polled on a fixed schedule, so this runs continuously on every shared core.

Separately: the index DDL for `user_last_active` only ever runs inside
`if (!doesTableExists(...))`, so **databases created before an index was introduced never receive
it**. Of the eight databases inspected, none had the composite index and six had no
`last_active_time` index at all.

## Change

**`ActiveUsersStorage`** (internal interface): add
`countUsersActiveSinceGroupedByDay(appIdentifier, sinceTime, now)` returning
`Map<daysAgo, userCount>`.

**postgresql-plugin**
- `ActiveUsersQueries.countUsersActiveSinceGroupedByDay`: one bounded query
  ```sql
  SELECT FLOOR((? - last_active_time) / 86400000) AS days_ago, COUNT(*)
    FROM user_last_active WHERE app_id = ? AND last_active_time >= ? GROUP BY days_ago
  ```
- New index `user_last_active_app_id_last_active_time_index (app_id, last_active_time)`.
- `GeneralQueries` now also emits that index for **already existing** tables. These statements are
  deliberately kept **out of** the main `executeDDLBatch` list: that batch runs in a single
  transaction and rolls back on any failure, so a slow index build hitting a lock/statement timeout
  would abort table creation and prevent startup. A new `executeBackfillIndexDDL` runs each statement
  in its own autocommit transaction and logs failures instead of throwing - a missing index degrades
  performance but does not break correctness, and the next start retries.

**core**
- `EEFeatureFlag.getMAUs()`: one call plus a running total. `maus[i]` (users active since
  `now - (i+1) days`) is by definition the cumulative sum of buckets `0..i`, so the output array is
  identical.
- `inmemorydb` implements the new method (derives buckets from the existing count API).
- `getSAMLStats()` bug fixes: `stat.add(tenantId, stat)` added the object **to itself** (a JSON
  serialization recursion hazard for SAML-enabled apps), and `tenantStat` was never appended to
  `tenantStats`, so `"tenants"` was always an empty array.

## Measured effect

The bucketed query costs about the same as a **single** 31-day count on every database inspected
(e.g. 493 ms vs 424 ms on the largest, 180 ms vs 180 ms, 67 ms vs 49 ms), i.e. roughly a 20-30x
reduction in database work per poll, plus 31 -> 1 connection acquisitions.

## Rollout note

On large tables the index build blocks writes for its duration. Recommended: create it out of band
first with `CREATE INDEX CONCURRENTLY IF NOT EXISTS user_last_active_app_id_last_active_time_index ON
user_last_active (app_id, last_active_time);` on the biggest databases, then deploy.

## Testing

- The `maus` array from `/ee/featureflag` must be identical before and after (pure refactor of the
  same counts) - diff the arrays on a database with activity.
- `\d user_last_active` shows the new index after start.
- For a SAML-enabled app, `usageStats.saml.tenants` is now populated (was always `[]`).

## Merge order

`supertokens-plugin-interface` first, then `supertokens-postgresql-plugin`, then `supertokens-core`.
