### PR TITLE
fix: resolve api_keys and IP access config against the app's public tenant (backport to 11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [11.0.8] - 2026-07-29
+
+- resolve api_keys and IP access config against the app's public tenant
+
 ## [11.0.7]
 
 - Backport: fixes thread leak in bulk import

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ java {
     }
 }
 
-version = "11.0.7"
+version = "11.0.8"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -197,9 +197,12 @@ public abstract class WebserverAPI extends HttpServlet {
         try {
             String apiKey = getApiKeyFromRequest(req);
 
-            // first we try the normal API key
+            // Resolve the API keys from the app's public tenant rather than the raw request
+            // tenant. api_keys is @NotConflictingInApp (identical across an app's tenants), so
+            // this is equivalent for a real tenant while keeping the check well-defined when the
+            // request tenant cannot be resolved.
             String[] keys = Config.getConfig(
-                    new TenantIdentifier(getConnectionUriDomain(req), getAppId(req), getTenantId(req)),
+                    new TenantIdentifier(getConnectionUriDomain(req), getAppId(req), null),
                     this.main).getAPIKeys();
             if (keys != null) {
                 if (apiKey == null) {
@@ -233,7 +236,10 @@ public abstract class WebserverAPI extends HttpServlet {
                 throw new ServletException(new APIKeyUnauthorisedException());
             }
         } catch (TenantOrAppNotFoundException e) {
-            // ignore as the tenant doesn't exist, we expect API to handle this issue
+            // The app/CUD does not exist, so there is no api_keys config to enforce and no app
+            // to operate on — let the app-specific handler return its "app not found" (400).
+            // (For a request tenant under a real app the lookup above resolves the app's public
+            // tenant, so this branch is not reached in that case.)
         }
     }
 
@@ -431,7 +437,13 @@ public abstract class WebserverAPI extends HttpServlet {
         try {
             config = Config.getConfig(getTenantIdentifierWithoutVerifying(req), main);
         } catch (TenantOrAppNotFoundException e) {
-            return true; // tenant not found, so no IP access control
+            // Request tenant not found: fall back to the app's public-tenant IP rules so IP
+            // access control stays defined for the app rather than being skipped.
+            try {
+                config = Config.getConfig(getAppIdentifierWithoutVerifying(req).getAsPublicTenantIdentifier(), main);
+            } catch (TenantOrAppNotFoundException e2) {
+                return true; // no app either, so no IP access control to apply
+            }
         }
         String allow = config.getIpAllowRegex();
         String deny = config.getIpDenyRegex();


### PR DESCRIPTION
Automated backport of `e8e99e84` onto `11.0`, released as **11.0.8**.

- Cherry-picked with `-x` — each commit message carries its source SHA.
- A separate `chore` commit bumps `build.gradle` to `11.0.8` and adds the `[11.0.8]` CHANGELOG section.

Triggered from **Backport** by @tamassoltesz.

> Reviewer: confirm the generated CHANGELOG bullets read well for the `11.0` line.
