### PR TITLE
fix: route webserver logs by severity level

### DIFF
--- a/src/main/java/io/supertokens/webserver/WebServerLogging.java
+++ b/src/main/java/io/supertokens/webserver/WebServerLogging.java
@@ -16,13 +16,13 @@
 
 package io.supertokens.webserver;
 
-import ch.qos.logback.core.CoreConstants;
 import io.supertokens.Main;
 import io.supertokens.output.Logging;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.utils.Utils;
 
 import java.util.logging.Handler;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 
 public class WebServerLogging extends Handler {
@@ -37,7 +37,6 @@ public class WebServerLogging extends Handler {
     public void publish(LogRecord record) {
         StringBuilder sb = new StringBuilder();
 
-        sb.append(CoreConstants.LINE_SEPARATOR);
         sb.append(record.getInstant());
         sb.append(" | ");
         sb.append(record.getSourceClassName());
@@ -53,9 +52,15 @@ public class WebServerLogging extends Handler {
         if (record.getThrown() != null) {
             sb.append(" | ");
             sb.append(Utils.throwableStacktraceToString(record.getThrown()));
-            Logging.error(main, TenantIdentifier.BASE_TENANT, sb.toString(), false); // TODO logging
+            Logging.error(main, TenantIdentifier.BASE_TENANT, sb.toString(), false);
+        } else if (record.getLevel().intValue() >= Level.SEVERE.intValue()) {
+            Logging.error(main, TenantIdentifier.BASE_TENANT, sb.toString(), false);
+        } else if (record.getLevel().intValue() >= Level.WARNING.intValue()) {
+            Logging.warn(main, TenantIdentifier.BASE_TENANT, sb.toString());
+        } else if (record.getLevel().intValue() >= Level.INFO.intValue()) {
+            Logging.info(main, TenantIdentifier.BASE_TENANT, sb.toString(), false);
         } else {
-            Logging.debug(main, TenantIdentifier.BASE_TENANT, sb.toString()); // TODO logging
+            Logging.debug(main, TenantIdentifier.BASE_TENANT, sb.toString());
         }
     }
 


### PR DESCRIPTION
## Summary of change

Fix WebServerLogging to route web server log records by their real severity instead of hardcoding debug/error, and drop the stray blank-line prefix.

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core
  config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting
  the user as well if `deleteUserIdMappingToo` is false.
- [ ] If added a new recipe, then make sure to update the bulk import API to include the new recipe.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
