### PR TITLE
fix: hardening signature validation (backport to 11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [11.3.7] - 2026-08-05
+
+- hardening signature validation
+
 ## [11.3.6] - 2026-07-29
 
 - resolve api_keys and IP access config against the app's public tenant

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
     }
 }
 
-version = "11.3.6"
+version = "11.3.7"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/saml/SAML.java
+++ b/src/main/java/io/supertokens/saml/SAML.java
@@ -58,6 +58,7 @@ import org.opensaml.saml.saml2.core.Subject;
 import org.opensaml.saml.saml2.metadata.EntityDescriptor;
 import org.opensaml.saml.saml2.metadata.IDPSSODescriptor;
 import org.opensaml.saml.saml2.metadata.SingleSignOnService;
+import org.opensaml.saml.security.impl.SAMLSignatureProfileValidator;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.CredentialSupport;
 import org.opensaml.xmlsec.signature.KeyInfo;
@@ -364,8 +365,7 @@ public class SAML {
             throws SignatureException {
         Signature responseSignature = samlResponse.getSignature();
         if (responseSignature != null) {
-            Credential credential = CredentialSupport.getSimpleCredential(idpCertificate, null);
-            SignatureValidator.validate(responseSignature, credential);
+            validateSignature(responseSignature, idpCertificate);
             return;
         }
 
@@ -382,14 +382,35 @@ public class SAML {
                         "Unsigned assertion found in a response using assertion-level signing; " +
                         "all assertions must be individually signed to prevent XML Signature Wrapping");
             }
-            Credential credential = CredentialSupport.getSimpleCredential(idpCertificate, null);
-            SignatureValidator.validate(assertionSignature, credential);
+            validateSignature(assertionSignature, idpCertificate);
             foundSignedAssertion = true;
         }
 
         if (!foundSignedAssertion) {
             throw new RuntimeException("Neither SAML Response nor any Assertion is signed");
         }
+    }
+
+    /**
+     * Validates a single SAML signature in two mandatory steps.
+     *
+     * SAMLSignatureProfileValidator enforces the SAML signature profile *before* the
+     * cryptographic check: the signature must be enveloped in the object it signs, carry
+     * exactly one Reference, that Reference must resolve to the signed object's own ID, and
+     * only the enveloped-signature and canonicalisation transforms are permitted. Without
+     * it, SignatureValidator.validate() confirms only that *some* element in the document is
+     * correctly signed — not that the signature covers the Response/Assertion we go on to
+     * read. That gap is XML Signature Wrapping: an attacker reparents a signature the IdP
+     * produced for their own account onto a forged Response/Assertion and parks the genuinely
+     * signed element elsewhere in the document (e.g. samlp:Extensions or saml:Advice), where
+     * the Reference URI still resolves. Running the profile validator first rejects such a
+     * document because the Reference no longer names the enclosing object's ID.
+     */
+    private static void validateSignature(Signature signature, X509Certificate idpCertificate)
+            throws SignatureException {
+        new SAMLSignatureProfileValidator().validate(signature);
+        Credential credential = CredentialSupport.getSimpleCredential(idpCertificate, null);
+        SignatureValidator.validate(signature, credential);
     }
 
     private static void validateSamlResponseTimestamps(Response samlResponse) throws SAMLResponseVerificationFailedException {

--- a/src/test/java/io/supertokens/test/saml/MockSAML.java
+++ b/src/test/java/io/supertokens/test/saml/MockSAML.java
@@ -304,6 +304,191 @@ public class MockSAML {
         }
     }
 
+    private static void signResponse(Response response, KeyMaterial km) {
+        try {
+            Credential cred = CredentialSupport.getSimpleCredential(km.certificate, km.privateKey);
+            SignatureBuilder signatureBuilder = new SignatureBuilder();
+            Signature signature = signatureBuilder.buildObject();
+            signature.setSigningCredential(cred);
+            signature.setSignatureAlgorithm(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256);
+            signature.setCanonicalizationAlgorithm(SignatureConstants.ALGO_ID_C14N_EXCL_OMIT_COMMENTS);
+            signature.setKeyInfo(buildKeyInfoWithCert(km.certificate));
+
+            response.setSignature(signature);
+            XMLObjectSupport.marshall(response);
+            Signer.signObject(signature);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Response buildSingleAssertionResponse(
+            String issuerEntityId, String audience, String acsUrl, String nameId,
+            String inResponseTo, Instant now, Instant notOnOrAfter, boolean withConditions) {
+        Response response = build(Response.DEFAULT_ELEMENT_NAME);
+        response.setID(randomId());
+        response.setVersion(SAMLVersion.VERSION_20);
+        response.setIssueInstant(now);
+        response.setDestination(acsUrl);
+        if (inResponseTo != null) {
+            response.setInResponseTo(inResponseTo);
+        }
+
+        Issuer issuer = build(Issuer.DEFAULT_ELEMENT_NAME);
+        issuer.setValue(issuerEntityId);
+        response.setIssuer(issuer);
+
+        Status status = build(Status.DEFAULT_ELEMENT_NAME);
+        StatusCode statusCode = build(StatusCode.DEFAULT_ELEMENT_NAME);
+        statusCode.setValue(StatusCode.SUCCESS);
+        status.setStatusCode(statusCode);
+        response.setStatus(status);
+
+        response.getAssertions().add(buildAssertion(
+                issuerEntityId, nameId, audience, acsUrl, inResponseTo, now, notOnOrAfter, withConditions));
+        return response;
+    }
+
+    /**
+     * XML Signature Wrapping — response-level variant (advisory variant A).
+     *
+     * The IdP legitimately signs a Response for the attacker's own account (response-level
+     * signature, Reference URI = that Response's ID). The attacker lifts that ds:Signature out
+     * and reparents it onto a freshly authored Response whose assertion names the victim, then
+     * parks the original signed Response — untouched apart from the removed signature, so its ID
+     * still matches the Reference — inside a samlp:Extensions element of the new Response.
+     *
+     * SignatureValidator.validate() alone accepts this: the Reference still resolves (to the
+     * parked Response) and the cryptography checks out. Only SAMLSignatureProfileValidator, which
+     * requires the Reference to name the enclosing Response's own ID, rejects it.
+     */
+    public static String generateResponseLevelXSWWrappedSAMLResponseBase64(
+            String issuerEntityId, String audience, String acsUrl,
+            String legitimateNameId, String forgedNameId, String inResponseTo,
+            KeyMaterial keyMaterial, int notOnOrAfterSeconds) {
+        Instant now = Instant.now();
+        Instant notOnOrAfter = now.plusSeconds(Math.max(60, notOnOrAfterSeconds));
+
+        Response legit = buildSingleAssertionResponse(
+                issuerEntityId, audience, acsUrl, legitimateNameId, inResponseTo, now, notOnOrAfter, true);
+        signResponse(legit, keyMaterial);
+        org.w3c.dom.Document legitDoc = parseXml(toXmlString(legit));
+        org.w3c.dom.Element legitResp = legitDoc.getDocumentElement();
+        org.w3c.dom.Element sig = firstChildNS(legitResp, DS_NS, "Signature");
+        legitResp.removeChild(sig);
+
+        Response evil = buildSingleAssertionResponse(
+                issuerEntityId, audience, acsUrl, forgedNameId, inResponseTo, now, notOnOrAfter, true);
+        org.w3c.dom.Document evilDoc = parseXml(toXmlString(evil));
+        org.w3c.dom.Element evilResp = evilDoc.getDocumentElement();
+
+        // Reparent the borrowed signature onto the forged Response (right after Issuer).
+        org.w3c.dom.Node importedSig = evilDoc.importNode(sig, true);
+        insertAfter(evilResp, importedSig, firstChildNS(evilResp, SAML_NS, "Issuer"));
+
+        // Park the genuinely-signed (now signature-less) Response under samlp:Extensions,
+        // where its ID keeps the borrowed signature's Reference resolvable.
+        org.w3c.dom.Element extensions = evilDoc.createElementNS(SAMLP_NS, "samlp:Extensions");
+        extensions.appendChild(evilDoc.importNode(legitResp, true));
+        insertAfter(evilResp, extensions, importedSig);
+
+        return Base64.getEncoder().encodeToString(serialize(evilResp).getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * XML Signature Wrapping — assertion-level variant (advisory variant B).
+     *
+     * The IdP legitimately signs an assertion for the attacker's own account. The attacker lifts
+     * that assertion's ds:Signature onto a forged assertion naming the victim, and parks the
+     * genuinely-signed (now signature-less) attacker assertion inside the forged assertion's
+     * saml:Advice element, where its ID keeps the Reference resolvable. This survives the
+     * per-assertion "every assertion must carry a valid signature" loop — the forged assertion
+     * does carry one — but SAMLSignatureProfileValidator rejects it because the Reference names
+     * the parked assertion's ID, not the forged assertion's own ID.
+     */
+    public static String generateAssertionLevelXSWWrappedSAMLResponseBase64(
+            String issuerEntityId, String audience, String acsUrl,
+            String legitimateNameId, String forgedNameId, String inResponseTo,
+            KeyMaterial keyMaterial, int notOnOrAfterSeconds) {
+        Instant now = Instant.now();
+        Instant notOnOrAfter = now.plusSeconds(Math.max(60, notOnOrAfterSeconds));
+
+        // Attacker's own response with an assertion-level signature.
+        Response legit = buildSingleAssertionResponse(
+                issuerEntityId, audience, acsUrl, legitimateNameId, inResponseTo, now, notOnOrAfter, true);
+        signAssertion(legit.getAssertions().get(0), keyMaterial);
+        org.w3c.dom.Document legitDoc = parseXml(toXmlString(legit));
+        org.w3c.dom.Element legitAssertion = firstChildNS(legitDoc.getDocumentElement(), SAML_NS, "Assertion");
+        org.w3c.dom.Element aSig = firstChildNS(legitAssertion, DS_NS, "Signature");
+        legitAssertion.removeChild(aSig);
+
+        // Forged, unsigned response naming the victim.
+        Response evil = buildSingleAssertionResponse(
+                issuerEntityId, audience, acsUrl, forgedNameId, inResponseTo, now, notOnOrAfter, true);
+        org.w3c.dom.Document evilDoc = parseXml(toXmlString(evil));
+        org.w3c.dom.Element evilResp = evilDoc.getDocumentElement();
+        org.w3c.dom.Element forgedAssertion = firstChildNS(evilResp, SAML_NS, "Assertion");
+
+        // Reparent the borrowed signature onto the forged assertion (right after its Issuer).
+        org.w3c.dom.Node importedSig = evilDoc.importNode(aSig, true);
+        insertAfter(forgedAssertion, importedSig, firstChildNS(forgedAssertion, SAML_NS, "Issuer"));
+
+        // Park the genuinely-signed (now signature-less) attacker assertion in saml:Advice.
+        org.w3c.dom.Element advice = evilDoc.createElementNS(SAML_NS, "saml:Advice");
+        advice.appendChild(evilDoc.importNode(legitAssertion, true));
+        forgedAssertion.appendChild(advice);
+
+        return Base64.getEncoder().encodeToString(serialize(evilResp).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final String SAMLP_NS = "urn:oasis:names:tc:SAML:2.0:protocol";
+    private static final String SAML_NS = "urn:oasis:names:tc:SAML:2.0:assertion";
+    private static final String DS_NS = "http://www.w3.org/2000/09/xmldsig#";
+
+    private static org.w3c.dom.Document parseXml(String xml) {
+        try {
+            javax.xml.parsers.DocumentBuilderFactory dbf = javax.xml.parsers.DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            return dbf.newDocumentBuilder().parse(
+                    new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static org.w3c.dom.Element firstChildNS(org.w3c.dom.Element parent, String ns, String localName) {
+        org.w3c.dom.NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            org.w3c.dom.Node n = children.item(i);
+            if (n.getNodeType() == org.w3c.dom.Node.ELEMENT_NODE
+                    && ns.equals(n.getNamespaceURI()) && localName.equals(n.getLocalName())) {
+                return (org.w3c.dom.Element) n;
+            }
+        }
+        throw new IllegalStateException("child element {" + ns + "}" + localName + " not found");
+    }
+
+    private static void insertAfter(org.w3c.dom.Element parent, org.w3c.dom.Node newNode, org.w3c.dom.Node refNode) {
+        org.w3c.dom.Node next = refNode.getNextSibling();
+        if (next == null) {
+            parent.appendChild(newNode);
+        } else {
+            parent.insertBefore(newNode, next);
+        }
+    }
+
+    private static String serialize(org.w3c.dom.Node node) {
+        try {
+            javax.xml.transform.Transformer t = javax.xml.transform.TransformerFactory.newInstance().newTransformer();
+            java.io.StringWriter sw = new java.io.StringWriter();
+            t.transform(new javax.xml.transform.dom.DOMSource(node),
+                    new javax.xml.transform.stream.StreamResult(sw));
+            return sw.toString();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Builds a SAML Response that demonstrates the XML Signature Wrapping (XSW) attack:
      *

--- a/src/test/java/io/supertokens/test/saml/api/SAMLXSWTest5_4.java
+++ b/src/test/java/io/supertokens/test/saml/api/SAMLXSWTest5_4.java
@@ -138,4 +138,105 @@ public class SAMLXSWTest5_4 {
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
+
+    /**
+     * Response-level signature wrapping (advisory variant A).
+     *
+     * The attacker holds a Response the IdP signed for their own account. Its ds:Signature is
+     * reparented onto a forged Response whose assertion names the victim, and the original signed
+     * Response is parked under samlp:Extensions so the signature's Reference URI still resolves.
+     * The relocated signature is cryptographically valid, so SignatureValidator.validate() passes;
+     * only SAMLSignatureProfileValidator (Reference must name the enclosing Response's own ID)
+     * rejects it.
+     *
+     * Without the fix the callback returns OK and authenticates the victim — FAIL.
+     * With the fix the callback returns SAML_RESPONSE_VERIFICATION_FAILED_ERROR — PASS.
+     */
+    @Test
+    public void xswAttack_responseLevelRelocatedSignatureMustBeRejected() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[]{EE_FEATURES.SAML});
+
+        SAMLTestUtils.CreatedClientInfo clientInfo = SAMLTestUtils.createClientWithGeneratedMetadata(
+                process, DEFAULT_REDIRECT_URI, ACS_URL, IDP_ENTITY_ID, IDP_SSO_URL);
+
+        String relayState = SAMLTestUtils.createLoginRequestAndGetRelayState(
+                process, clientInfo.clientId, clientInfo.defaultRedirectURI,
+                clientInfo.acsURL, "test-state");
+
+        String xswResponseBase64 = MockSAML.generateResponseLevelXSWWrappedSAMLResponseBase64(
+                clientInfo.idpEntityId, SP_ENTITY_ID, clientInfo.acsURL,
+                ATTACKER_EMAIL, VICTIM_EMAIL, relayState, clientInfo.keyMaterial, 300);
+
+        JsonObject callbackBody = new JsonObject();
+        callbackBody.addProperty("samlResponse", xswResponseBase64);
+        callbackBody.addProperty("relayState", relayState);
+
+        JsonObject callbackResp = HttpRequestForTesting.sendJsonPOSTRequest(
+                process.getProcess(), "",
+                "http://localhost:3567/recipe/saml/callback",
+                callbackBody, 1000, 1000, null, SemVer.v5_4.get(), "saml");
+
+        assertEquals(
+                "Response-level XSW was not rejected: a relocated signature whose Reference URI " +
+                "does not cover the enclosing Response must be refused",
+                "SAML_RESPONSE_VERIFICATION_FAILED_ERROR", callbackResp.get("status").getAsString());
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    /**
+     * Assertion-level signature wrapping (advisory variant B).
+     *
+     * The attacker holds an assertion the IdP signed for their own account. Its ds:Signature is
+     * reparented onto a forged assertion naming the victim, and the original signed assertion is
+     * parked inside the forged assertion's saml:Advice so the Reference URI still resolves. This
+     * defeats the "every assertion must carry a valid signature" loop, because the forged
+     * assertion does carry one; only SAMLSignatureProfileValidator rejects it.
+     *
+     * Without the fix the callback returns OK and authenticates the victim — FAIL.
+     * With the fix the callback returns SAML_RESPONSE_VERIFICATION_FAILED_ERROR — PASS.
+     */
+    @Test
+    public void xswAttack_assertionLevelRelocatedSignatureMustBeRejected() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[]{EE_FEATURES.SAML});
+
+        SAMLTestUtils.CreatedClientInfo clientInfo = SAMLTestUtils.createClientWithGeneratedMetadata(
+                process, DEFAULT_REDIRECT_URI, ACS_URL, IDP_ENTITY_ID, IDP_SSO_URL);
+
+        String relayState = SAMLTestUtils.createLoginRequestAndGetRelayState(
+                process, clientInfo.clientId, clientInfo.defaultRedirectURI,
+                clientInfo.acsURL, "test-state");
+
+        String xswResponseBase64 = MockSAML.generateAssertionLevelXSWWrappedSAMLResponseBase64(
+                clientInfo.idpEntityId, SP_ENTITY_ID, clientInfo.acsURL,
+                ATTACKER_EMAIL, VICTIM_EMAIL, relayState, clientInfo.keyMaterial, 300);
+
+        JsonObject callbackBody = new JsonObject();
+        callbackBody.addProperty("samlResponse", xswResponseBase64);
+        callbackBody.addProperty("relayState", relayState);
+
+        JsonObject callbackResp = HttpRequestForTesting.sendJsonPOSTRequest(
+                process.getProcess(), "",
+                "http://localhost:3567/recipe/saml/callback",
+                callbackBody, 1000, 1000, null, SemVer.v5_4.get(), "saml");
+
+        assertEquals(
+                "Assertion-level XSW was not rejected: a relocated signature whose Reference URI " +
+                "does not cover the enclosing assertion must be refused",
+                "SAML_RESPONSE_VERIFICATION_FAILED_ERROR", callbackResp.get("status").getAsString());
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }


### PR DESCRIPTION
Automated backport of `9cba541ae2ed87b878d11b257bc9b8b78341f50a` onto `11.3`, released as **11.3.7**.

- Cherry-picked with `-x` — each commit message carries its source SHA.
- A separate `chore` commit bumps `build.gradle` to `11.3.7` and adds the `[11.3.7]` CHANGELOG section.

Triggered from **Backport** by @tamassoltesz.

> Reviewer: confirm the generated CHANGELOG bullets read well for the `11.3` line.
