### PR TITLE
fix: verify database schema at startup and fail loudly on missing tables/columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [12.2.0]
+
+- **Upgrade note: the core now verifies the database schema at startup and, by default (`schema_check_strict_mode: true`), refuses to start when the base database is missing a manual migration — run the migration SQL from the CHANGELOGs (or set `schema_check_strict_mode: false`) before upgrading**
+- Verifies the database schema at startup: any database (base or tenant) missing a table or column this version needs is reported with the missing columns plus the SQL to add them
+- New config `schema_check_strict_mode` (boolean, default `true`, config.yaml / env only): in strict mode a mismatched tenant database refuses all queries until the migration is applied — re-checked every minute, so it resumes within a minute of the migration, no restart needed; the core still boots and serves all other tenants
+- With `schema_check_strict_mode: false`, mismatches are only logged: everything keeps working and just the queries touching the missing schema fail, with a "Schema mismatch ... check the core error logs" hint instead of a raw SQL error
+- Corrects the 12.1.0 migration note: the `session_info` columns are a manual step, not applied automatically
+
 ## [12.1.2]
 
 - Bulk import no longer borrows from the live connection pool: each worker claims, imports and finalises its chunk on one connection from a dedicated pool sized to `bulk_migration_parallelism`
 - Bulk import keeps claimed `bulk_import_users` rows locked until they are deleted or error-marked; a failed chunk rolls back to a savepoint instead of releasing the claim
 - Bulk import deletes only the rows of the partition it imported and bounds immediate retries after a database rollback
 - `BulkImport.importUser` (the single-user import API) now runs on the same bounded dedicated pool, opened for the duration of the call (one connection per user pool, previously a full-size proxy pool per user pool)
-- Verifies the database schema at startup: any database (base or tenant) missing a table or column this version
-  needs is reported with the missing columns plus the SQL to add them
-- **New config `schema_check_strict_mode` (boolean, default `true`, config.yaml / env only). In strict mode the
-  core REFUSES TO START when the base database schema is out of date (a skipped manual migration), and tenant
-  databases with a mismatched schema are not served until the migration is applied. If your database schema is
-  behind (see the Migration sections below), upgrading to this version will stop the core from booting until you
-  either run the migration SQL or set `schema_check_strict_mode: false`.** With strict mode off, mismatches are
-  only logged: the core boots, everything else keeps working, and just the queries touching the missing schema
-  fail - with a "Schema mismatch ... check the core error logs" message instead of a raw SQL error
-- Corrects the 12.1.0 migration note: the `session_info` columns are a manual step, not applied automatically
 
 ## [12.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Bulk import keeps claimed `bulk_import_users` rows locked until they are deleted or error-marked; a failed chunk rolls back to a savepoint instead of releasing the claim
 - Bulk import deletes only the rows of the partition it imported and bounds immediate retries after a database rollback
 - `BulkImport.importUser` (the single-user import API) uses the same dedicated-pool mechanism instead of a throwaway pool per call
-- Verifies the database schema at startup: if the base database is missing any table or column this version needs,
-  the core refuses to start and prints the missing columns plus the SQL to add them (instead of failing per request);
-  a tenant database with a mismatch is logged at ERROR and refuses queries until fixed
+- Verifies the database schema at startup: if a database (base or tenant) is missing any table or column this
+  version needs, an ERROR is logged with the missing columns plus the SQL to add them; the core still boots and
+  keeps serving everything else, and only the queries touching the missing schema fail - with a
+  "Schema mismatch ... check the core error logs" message instead of a raw SQL error
 - Corrects the 12.1.0 migration note: the `session_info` columns are a manual step, not applied automatically
 
 ## [12.1.1]
@@ -72,8 +73,9 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_recipe_user_tenants_search_tparty ON
 
 **Manual step required — NOT applied automatically.** The core only creates tables that do not exist yet
 (`CREATE TABLE IF NOT EXISTS`); it never adds columns to an existing table. On any database created by a core older
-than 12.1.0, run the following **before** starting the new core (from 12.1.2 the core refuses to start until these
-columns exist; 12.1.0/12.1.1 start but fail every session API with `column prev_refresh_token_hash_2 does not exist`):
+than 12.1.0, run the following **before** starting the new core (from 12.1.2 the core reports the missing
+columns at startup and session APIs fail with a schema-mismatch message pointing at the logs; 12.1.0/12.1.1 start
+silently and fail every session API with `column prev_refresh_token_hash_2 does not exist`):
 
 ```sql
 ALTER TABLE session_info ADD COLUMN IF NOT EXISTS prev_refresh_token_hash_2 VARCHAR(128);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Bulk import keeps claimed `bulk_import_users` rows locked until they are deleted or error-marked; a failed chunk rolls back to a savepoint instead of releasing the claim
 - Bulk import deletes only the rows of the partition it imported and bounds immediate retries after a database rollback
 - `BulkImport.importUser` (the single-user import API) uses the same dedicated-pool mechanism instead of a throwaway pool per call
+- Verifies the database schema at startup: if the base database is missing any table or column this version needs,
+  the core refuses to start and prints the missing columns plus the SQL to add them (instead of failing per request);
+  a tenant database with a mismatch is logged at ERROR and refuses queries until fixed
+- Corrects the 12.1.0 migration note: the `session_info` columns are a manual step, not applied automatically
 
 ## [12.1.1]
 
@@ -66,15 +70,18 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_recipe_user_tenants_search_tparty ON
 
 ### Migration
 
-Additive only, applied automatically at startup; no backfill required. `session_info` gains nullable
-`prev_refresh_token_hash_2` and `refresh_token_rotated_at` columns, and M2M token stats move to a new
-`oauth_m2m_token_stats` rollup table (the legacy `oauth_m2m_tokens` table drains via the existing 31-day retention
-sweep).
+**Manual step required — NOT applied automatically.** The core only creates tables that do not exist yet
+(`CREATE TABLE IF NOT EXISTS`); it never adds columns to an existing table. On any database created by a core older
+than 12.1.0, run the following **before** starting the new core (from 12.1.2 the core refuses to start until these
+columns exist; 12.1.0/12.1.1 start but fail every session API with `column prev_refresh_token_hash_2 does not exist`):
 
 ```sql
-ALTER TABLE session_info ADD COLUMN prev_refresh_token_hash_2 VARCHAR(128);
-ALTER TABLE session_info ADD COLUMN refresh_token_rotated_at BIGINT;
+ALTER TABLE session_info ADD COLUMN IF NOT EXISTS prev_refresh_token_hash_2 VARCHAR(128);
+ALTER TABLE session_info ADD COLUMN IF NOT EXISTS refresh_token_rotated_at BIGINT;
 ```
+
+Both columns are nullable; no backfill is required. The new `oauth_m2m_token_stats` rollup table *is* created
+automatically at startup (the legacy `oauth_m2m_tokens` table drains via the existing 31-day retention sweep).
 
 ## [12.0.10]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,15 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Bulk import keeps claimed `bulk_import_users` rows locked until they are deleted or error-marked; a failed chunk rolls back to a savepoint instead of releasing the claim
 - Bulk import deletes only the rows of the partition it imported and bounds immediate retries after a database rollback
 - `BulkImport.importUser` (the single-user import API) uses the same dedicated-pool mechanism instead of a throwaway pool per call
-- Verifies the database schema at startup: if a database (base or tenant) is missing any table or column this
-  version needs, an ERROR is logged with the missing columns plus the SQL to add them; the core still boots and
-  keeps serving everything else, and only the queries touching the missing schema fail - with a
-  "Schema mismatch ... check the core error logs" message instead of a raw SQL error
+- Verifies the database schema at startup: any database (base or tenant) missing a table or column this version
+  needs is reported with the missing columns plus the SQL to add them
+- **New config `schema_check_strict_mode` (boolean, default `true`, config.yaml / env only). In strict mode the
+  core REFUSES TO START when the base database schema is out of date (a skipped manual migration), and tenant
+  databases with a mismatched schema are not served until the migration is applied. If your database schema is
+  behind (see the Migration sections below), upgrading to this version will stop the core from booting until you
+  either run the migration SQL or set `schema_check_strict_mode: false`.** With strict mode off, mismatches are
+  only logged: the core boots, everything else keeps working, and just the queries touching the missing schema
+  fail - with a "Schema mismatch ... check the core error logs" message instead of a raw SQL error
 - Corrects the 12.1.0 migration note: the `session_info` columns are a manual step, not applied automatically
 
 ## [12.1.1]
@@ -73,9 +78,10 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_recipe_user_tenants_search_tparty ON
 
 **Manual step required — NOT applied automatically.** The core only creates tables that do not exist yet
 (`CREATE TABLE IF NOT EXISTS`); it never adds columns to an existing table. On any database created by a core older
-than 12.1.0, run the following **before** starting the new core (from 12.1.2 the core reports the missing
-columns at startup and session APIs fail with a schema-mismatch message pointing at the logs; 12.1.0/12.1.1 start
-silently and fail every session API with `column prev_refresh_token_hash_2 does not exist`):
+than 12.1.0, run the following **before** starting the new core (from 12.1.2 the core detects the missing
+columns at startup: with the default `schema_check_strict_mode: true` it **refuses to start** until they exist,
+with `false` it logs them and session APIs fail with a schema-mismatch message pointing at the logs;
+12.1.0/12.1.1 start silently and fail every session API with `column prev_refresh_token_hash_2 does not exist`):
 
 ```sql
 ALTER TABLE session_info ADD COLUMN IF NOT EXISTS prev_refresh_token_hash_2 VARCHAR(128);

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
     }
 }
 
-version = "12.1.2"
+version = "12.2.0"
 
 repositories {
     mavenCentral()

--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,12 @@ core_config_version: 0
 # "TOKEN_THEFT" | "UNAUTHORISED". The session is revoked regardless of this setting.
 # recent_token_reuse_behaviour:
 
+# (OPTIONAL | Default: true) boolean value. If true, the core refuses to start when the base database is missing
+# tables or columns this version needs (a skipped manual migration), and tenant databases with a mismatched schema
+# are not served. If false, mismatches are only logged and just the queries touching the missing schema fail.
+# schema_check_strict_mode:
+
+
 
 # (DIFFERENT_ACROSS_TENANTS | OPTIONAL | Default: 3600000) long value. Time in milliseconds for how long a password
 # reset token / link is valid for.

--- a/devConfig.yaml
+++ b/devConfig.yaml
@@ -59,6 +59,12 @@ core_config_version: 0
 # "TOKEN_THEFT" | "UNAUTHORISED". The session is revoked regardless of this setting.
 # recent_token_reuse_behaviour:
 
+# (OPTIONAL | Default: true) boolean value. If true, the core refuses to start when the base database is missing
+# tables or columns this version needs (a skipped manual migration), and tenant databases with a mismatched schema
+# are not served. If false, mismatches are only logged and just the queries touching the missing schema fail.
+# schema_check_strict_mode:
+
+
 
 # (DIFFERENT_ACROSS_TENANTS | OPTIONAL | Default: 3600000) long value. Time in milliseconds for how long a password
 # reset token / link is valid for.

--- a/src/main/java/io/supertokens/Main.java
+++ b/src/main/java/io/supertokens/Main.java
@@ -210,14 +210,18 @@ public class Main {
         }
 
         // Verify once, at startup, that the base database has every table/column this version needs. This is
-        // deliberately separate from initStorage (re-entered on tenant refresh / pool re-creation): a database
-        // whose manual "### Migration" step was skipped must refuse to start, not fail per request.
+        // deliberately separate from initStorage (re-entered on tenant refresh / pool re-creation). A mismatch
+        // (a skipped manual "### Migration" step) is reported loudly here but does NOT prevent booting: the
+        // core keeps serving everything that does not touch the missing schema, and only the affected queries
+        // fail - with a schema-mismatch hint pointing at these logs instead of a raw SQL error.
         try {
             StorageLayer.getBaseStorage(this).verifySchema();
         } catch (SchemaMismatchException e) {
-            throw new QuitProgramException(e.getMessage());
+            Logging.error(this, TenantIdentifier.BASE_TENANT, e.getMessage(), true, e);
+            ProcessState.getInstance(this).addState(ProcessState.PROCESS_STATE.SCHEMA_MISMATCH, e);
         } catch (StorageQueryException e) {
-            throw new QuitProgramException(e);
+            Logging.error(this, TenantIdentifier.BASE_TENANT,
+                    "Could not verify the database schema at startup", false, e);
         }
 
         // enable ee features if license key is provided.

--- a/src/main/java/io/supertokens/Main.java
+++ b/src/main/java/io/supertokens/Main.java
@@ -210,16 +210,23 @@ public class Main {
         }
 
         // Verify once, at startup, that the base database has every table/column this version needs. This is
-        // deliberately separate from initStorage (re-entered on tenant refresh / pool re-creation). A mismatch
-        // (a skipped manual "### Migration" step) is reported loudly here but does NOT prevent booting: the
-        // core keeps serving everything that does not touch the missing schema, and only the affected queries
-        // fail - with a schema-mismatch hint pointing at these logs instead of a raw SQL error.
+        // deliberately separate from initStorage (re-entered on tenant refresh / pool re-creation). How a
+        // mismatch (a skipped manual "### Migration" step) is handled depends on schema_check_strict_mode:
+        // strict (the default) refuses to start; non-strict logs it and boots, with only the queries touching
+        // the missing schema failing (they carry a schema-mismatch hint pointing at these logs).
+        boolean schemaCheckStrictMode = Config.getBaseConfig(this).getSchemaCheckStrictMode();
         try {
-            StorageLayer.getBaseStorage(this).verifySchema();
+            StorageLayer.getBaseStorage(this).verifySchema(schemaCheckStrictMode);
         } catch (SchemaMismatchException e) {
+            if (schemaCheckStrictMode) {
+                throw new QuitProgramException(e.getMessage());
+            }
             Logging.error(this, TenantIdentifier.BASE_TENANT, e.getMessage(), true, e);
             ProcessState.getInstance(this).addState(ProcessState.PROCESS_STATE.SCHEMA_MISMATCH, e);
         } catch (StorageQueryException e) {
+            if (schemaCheckStrictMode) {
+                throw new QuitProgramException(e);
+            }
             Logging.error(this, TenantIdentifier.BASE_TENANT,
                     "Could not verify the database schema at startup", false, e);
         }

--- a/src/main/java/io/supertokens/Main.java
+++ b/src/main/java/io/supertokens/Main.java
@@ -44,6 +44,7 @@ import io.supertokens.multitenancy.MultitenancyHelper;
 import io.supertokens.output.Logging;
 import io.supertokens.pluginInterface.exceptions.DbInitException;
 import io.supertokens.pluginInterface.exceptions.InvalidConfigException;
+import io.supertokens.pluginInterface.exceptions.SchemaMismatchException;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.storageLayer.StorageLayer;
@@ -205,6 +206,17 @@ public class Main {
         try {
             StorageLayer.getBaseStorage(this).initStorage(true, List.of());
         } catch (DbInitException e) {
+            throw new QuitProgramException(e);
+        }
+
+        // Verify once, at startup, that the base database has every table/column this version needs. This is
+        // deliberately separate from initStorage (re-entered on tenant refresh / pool re-creation): a database
+        // whose manual "### Migration" step was skipped must refuse to start, not fail per request.
+        try {
+            StorageLayer.getBaseStorage(this).verifySchema();
+        } catch (SchemaMismatchException e) {
+            throw new QuitProgramException(e.getMessage());
+        } catch (StorageQueryException e) {
             throw new QuitProgramException(e);
         }
 

--- a/src/main/java/io/supertokens/ProcessState.java
+++ b/src/main/java/io/supertokens/ProcessState.java
@@ -99,7 +99,8 @@ public class ProcessState extends ResourceDistributor.SingletonResource {
         PASSWORD_VERIFY_FIREBASE_SCRYPT, ADDING_REMOTE_ADDRESS_FILTER, LICENSE_KEY_CHECK_NETWORK_CALL,
         INVALID_LICENSE_KEY, SERVER_ERROR_DURING_LICENSE_KEY_CHECK_FAIL, LOADING_ALL_TENANT_CONFIG,
         LOADING_ALL_TENANT_STORAGE, TENANTS_CHANGED_DURING_REFRESH_FROM_DB,
-        // Storage.verifySchema() failed for a non-base tenant storage (base storage failures abort startup)
+        // Storage.verifySchema() found missing tables/columns for a storage (base or tenant). The core
+        // keeps running; only queries touching the missing schema fail, with a schema-mismatch hint.
         SCHEMA_MISMATCH,
         BULK_IMPORT_COMPLETE,
         BULK_IMPORT_SKIPPED_EMPTY_QUEUE,

--- a/src/main/java/io/supertokens/ProcessState.java
+++ b/src/main/java/io/supertokens/ProcessState.java
@@ -99,6 +99,8 @@ public class ProcessState extends ResourceDistributor.SingletonResource {
         PASSWORD_VERIFY_FIREBASE_SCRYPT, ADDING_REMOTE_ADDRESS_FILTER, LICENSE_KEY_CHECK_NETWORK_CALL,
         INVALID_LICENSE_KEY, SERVER_ERROR_DURING_LICENSE_KEY_CHECK_FAIL, LOADING_ALL_TENANT_CONFIG,
         LOADING_ALL_TENANT_STORAGE, TENANTS_CHANGED_DURING_REFRESH_FROM_DB,
+        // Storage.verifySchema() failed for a non-base tenant storage (base storage failures abort startup)
+        SCHEMA_MISMATCH,
         BULK_IMPORT_COMPLETE,
         BULK_IMPORT_SKIPPED_EMPTY_QUEUE,
         BACKFILL_COMPLETE,

--- a/src/main/java/io/supertokens/config/CoreConfig.java
+++ b/src/main/java/io/supertokens/config/CoreConfig.java
@@ -122,6 +122,16 @@ public class CoreConfig {
     @EnumProperty({"TOKEN_THEFT", "UNAUTHORISED"})
     private String recent_token_reuse_behaviour = "TOKEN_THEFT";
 
+    @EnvName("SCHEMA_CHECK_STRICT_MODE")
+    @ConfigYamlOnly
+    @JsonProperty
+    @ConfigDescription(
+            "If true, the core refuses to start when the base database is missing tables or columns this version "
+                    + "needs (a skipped manual migration), and tenant databases with a mismatched schema are not "
+                    + "served. If false, mismatches are only logged and just the queries touching the missing "
+                    + "schema fail. (Default: true)")
+    private boolean schema_check_strict_mode = true;
+
     @EnvName("PASSWORD_RESET_TOKEN_LIFETIME")
     @IgnoreForAnnotationCheck
     @JsonProperty
@@ -666,6 +676,10 @@ public class CoreConfig {
 
     public String getRecentTokenReuseBehaviour() {
         return recent_token_reuse_behaviour;
+    }
+
+    public boolean getSchemaCheckStrictMode() {
+        return schema_check_strict_mode;
     }
 
     public long getPasswordResetTokenLifetime() {

--- a/src/main/java/io/supertokens/cronjobs/syncCoreConfigWithDb/SyncCoreConfigWithDb.java
+++ b/src/main/java/io/supertokens/cronjobs/syncCoreConfigWithDb/SyncCoreConfigWithDb.java
@@ -22,6 +22,7 @@ import io.supertokens.cronjobs.CronTaskTest;
 import io.supertokens.multitenancy.MultitenancyHelper;
 import io.supertokens.pluginInterface.multitenancy.TenantIdentifier;
 import io.supertokens.pluginInterface.opentelemetry.WithinOtelSpan;
+import io.supertokens.storageLayer.StorageLayer;
 
 public class SyncCoreConfigWithDb extends CronTask {
 
@@ -63,5 +64,9 @@ public class SyncCoreConfigWithDb extends CronTask {
     @Override
     protected void doTaskForTargetTenant(TenantIdentifier targetTenant) throws Exception {
         MultitenancyHelper.getInstance(main).refreshTenantsInCoreBasedOnChangesInCoreConfigOrIfTenantListChanged(true);
+        // A storage fenced off by a startup schema mismatch (schema_check_strict_mode) recovers here within a
+        // minute of the migration being applied; the refresh above short-circuits when no tenant changed, so
+        // it alone would never re-verify. Free in the steady state - verified storages are a cached no-op.
+        StorageLayer.retrySchemaVerification(main);
     }
 }

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -236,6 +236,11 @@ public class Start
     }
 
     @Override
+    public void verifySchema() {
+        // The in-memory database is created fresh by this process, so it always matches this version's schema.
+    }
+
+    @Override
     public <T> T startTransaction(TransactionLogic<T> logic)
             throws StorageTransactionLogicException, StorageQueryException {
         return startTransaction(logic, TransactionIsolationLevel.READ_COMMITTED);

--- a/src/main/java/io/supertokens/inmemorydb/Start.java
+++ b/src/main/java/io/supertokens/inmemorydb/Start.java
@@ -236,7 +236,7 @@ public class Start
     }
 
     @Override
-    public void verifySchema() {
+    public void verifySchema(boolean strictMode) {
         // The in-memory database is created fresh by this process, so it always matches this version's schema.
     }
 

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -755,11 +755,12 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
                         return;
                     }
                     // Schema verification runs once per storage (the plugin caches a success), so this is a
-                    // no-op for already-verified pools on refresh. A mismatch is only reported: the core keeps
-                    // serving this storage, and only queries that touch the missing schema fail (with a
-                    // schema-mismatch hint pointing at these logs).
+                    // no-op for already-verified pools on refresh. A tenant mismatch never takes the core down:
+                    // in strict mode (schema_check_strict_mode, the default) the storage refuses all queries
+                    // until re-verified after the migration is applied; in non-strict mode it stays fully in
+                    // use and only queries touching the missing schema fail (with a schema-mismatch hint).
                     try {
-                        storage.verifySchema();
+                        storage.verifySchema(Config.getBaseConfig(main).getSchemaCheckStrictMode());
                     } catch (SchemaMismatchException e) {
                         Logging.error(main, TenantIdentifier.BASE_TENANT,
                                 "Schema verification failed for storage of tenants " + tenants + ": "

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -30,6 +30,7 @@ import io.supertokens.pluginInterface.authRecipe.AuthRecipeStorage;
 import io.supertokens.pluginInterface.authRecipe.exceptions.UnknownUserIdException;
 import io.supertokens.pluginInterface.exceptions.DbInitException;
 import io.supertokens.pluginInterface.exceptions.InvalidConfigException;
+import io.supertokens.pluginInterface.exceptions.SchemaMismatchException;
 import io.supertokens.pluginInterface.exceptions.StorageQueryException;
 import io.supertokens.pluginInterface.multitenancy.AppIdentifier;
 import io.supertokens.pluginInterface.multitenancy.MultitenancyStorage;
@@ -751,6 +752,21 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
                         storage.initFileLogging(infoLogPath, errorLogPath, telemetry);
                     } catch (DbInitException e) {
                         Logging.error(main, TenantIdentifier.BASE_TENANT, e.getMessage(), false, e);
+                        return;
+                    }
+                    // Schema verification runs once per storage (the plugin caches a success), so this is a
+                    // no-op for already-verified pools on refresh. A mismatch must not take the whole core
+                    // down for one tenant's database: log loudly and leave that storage refusing queries.
+                    try {
+                        storage.verifySchema();
+                    } catch (SchemaMismatchException e) {
+                        Logging.error(main, TenantIdentifier.BASE_TENANT,
+                                "Schema verification failed for storage of tenants " + tenants + ": "
+                                        + e.getMessage(), true, e);
+                        ProcessState.getInstance(main).addState(ProcessState.PROCESS_STATE.SCHEMA_MISMATCH, e);
+                    } catch (StorageQueryException e) {
+                        Logging.error(main, TenantIdentifier.BASE_TENANT,
+                                "Could not verify schema for storage of tenants " + tenants, false, e);
                     }
                 }, executor));
             }

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -757,8 +757,9 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
                     // Schema verification runs once per storage (the plugin caches a success), so this is a
                     // no-op for already-verified pools on refresh. A tenant mismatch never takes the core down:
                     // in strict mode (schema_check_strict_mode, the default) the storage refuses all queries
-                    // until re-verified after the migration is applied; in non-strict mode it stays fully in
-                    // use and only queries touching the missing schema fail (with a schema-mismatch hint).
+                    // until a re-verification passes (retrySchemaVerification runs one every minute, so the
+                    // storage resumes within a minute of the migration being applied); in non-strict mode it
+                    // stays fully in use and only queries touching the missing schema fail (with a hint).
                     try {
                         storage.verifySchema(Config.getBaseConfig(main).getSchemaCheckStrictMode());
                     } catch (SchemaMismatchException e) {
@@ -773,6 +774,35 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
                 }, executor));
             }
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        }
+    }
+
+    /**
+     * Gives every loaded storage whose schema verification has not yet passed another chance to pass. Called
+     * from {@link io.supertokens.cronjobs.syncCoreConfigWithDb.SyncCoreConfigWithDb} every minute, so a tenant
+     * storage that is refusing queries in strict mode (schema_check_strict_mode) resumes within a minute of
+     * the operator applying the migration SQL - no restart or tenant change needed. A storage that already
+     * verified returns from {@link Storage#verifySchema} without touching the database, so this is free in the
+     * steady state; a still-mismatched storage costs one schema-inspection query per run and stays quiet here,
+     * because the startup ERROR log already carries the full report.
+     */
+    public static void retrySchemaVerification(Main main) {
+        Set<Storage> storages = new HashSet<>();
+        for (ResourceDistributor.SingletonResource resource : main.getResourceDistributor()
+                .getAllResourcesWithResourceKey(RESOURCE_KEY).values()) {
+            storages.add(((StorageLayer) resource).storage);
+        }
+        boolean strictMode = Config.getBaseConfig(main).getSchemaCheckStrictMode();
+        for (Storage storage : storages) {
+            try {
+                storage.verifySchema(strictMode);
+            } catch (SchemaMismatchException e) {
+                // still mismatched: the startup ERROR already reported the details, and affected queries
+                // carry a hint pointing at it - do not repeat the report every minute
+            } catch (StorageQueryException e) {
+                Logging.debug(main, TenantIdentifier.BASE_TENANT,
+                        "Could not re-verify the database schema: " + e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/io/supertokens/storageLayer/StorageLayer.java
+++ b/src/main/java/io/supertokens/storageLayer/StorageLayer.java
@@ -755,8 +755,9 @@ public class StorageLayer extends ResourceDistributor.SingletonResource {
                         return;
                     }
                     // Schema verification runs once per storage (the plugin caches a success), so this is a
-                    // no-op for already-verified pools on refresh. A mismatch must not take the whole core
-                    // down for one tenant's database: log loudly and leave that storage refusing queries.
+                    // no-op for already-verified pools on refresh. A mismatch is only reported: the core keeps
+                    // serving this storage, and only queries that touch the missing schema fail (with a
+                    // schema-mismatch hint pointing at these logs).
                     try {
                         storage.verifySchema();
                     } catch (SchemaMismatchException e) {


### PR DESCRIPTION
(#1386)

Calls Storage.verifySchema() once per storage after its first successful initStorage: a mismatch on the base database aborts startup with the missing columns and the SQL to add them; a mismatch on a tenant database is logged at ERROR (SCHEMA_MISMATCH state) and that storage refuses queries until fixed. Deliberately not part of initStorage/pool init, which is re-entered on tenant refresh and lazy pool re-creation.

Also corrects the 12.1.0 changelog: the session_info columns are a manual migration step, not applied automatically.

## Summary of change

(A few sentences about this PR)

## Related issues

- Link to issue1 here
- Link to issue1 here

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your
changes work. Bonus points for screenshots and videos!)

## Documentation changes

(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here
highlighting the necessary changes)

## Checklist for important updates

- [ ] Changelog has been updated
    - [ ] If there are any db schema changes, mention those changes clearly
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed)
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
    - In `build.gradle`
- [ ] If added a new paid feature, edit the `getPaidFeatureStats` function in FeatureFlag.java file
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them
  in `implementationDependencies.json`.
- [ ] Update function `getValidFields` in `io/supertokens/config/CoreConfig.java` if new aliases were added for any core
  config (similar to the `access_token_signing_key_update_interval` config alias).
- [ ] Issue this PR against the latest non released version branch.
    - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the
      latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
    - If no such branch exists, then create one from the latest released branch.
- [ ] If added a foreign key constraint on `app_id_to_user_id` table, make sure to delete from this table when deleting
  the user as well if `deleteUserIdMappingToo` is false.
- [ ] If added a new recipe, then make sure to update the bulk import API to include the new recipe.

## Remaining TODOs for this PR

- [ ] Item1
- [ ] Item2
