### PR TITLE
fix: update OTel javaagent to 2.29.0 and pin httpclient5/httpcore5 to CVE-fixed versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   key at the same moment must leave exactly one new key in storage and agree on the `kid` they sign with.
   The test reproduces the race against an unfixed storage layer and passes once key creation is serialised
   per app, which postgresql-plugin 9.7.2 does with a per-app advisory lock.
+- Updates the bundled OpenTelemetry javaagent from 2.27.0 to 2.29.0 (CVE-2026-54704: JDBC connect-string passwords could leak into span attributes)
+- Pins transitive httpclient5 to 5.6.4 and httpcore5 / httpcore5-h2 to 5.4.3 (CVE-2026-64607, CVE-2026-54399, CVE-2026-54428)
 
 ## [12.1.1]
 

--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,16 @@ dependencies {
         // velocity-engine-core 2.4.1 (via opensaml-saml-impl) pins 3.17.0, which is
         // affected by CVE-2025-48924 (uncontrolled recursion); fixed in 3.18.0
         implementation 'org.apache.commons:commons-lang3:3.20.0'
+
+        // opensaml 5.2.3 pulls httpclient5 5.3.1 / httpcore5 5.2.x, affected by
+        // CVE-2026-64607 (connection leak on invalid Content-Encoding; fixed in 5.6.3),
+        // CVE-2026-54399 (HTTP/1.1 parser memory exhaustion; fixed in 5.4.3) and
+        // CVE-2026-54428 (HPACK decoder memory exhaustion; fixed in 5.4.3).
+        // httpclient5 5.6.4 is built against httpcore5 5.4.3.
+        implementation 'org.apache.httpcomponents.client5:httpclient5:5.6.4'
+        implementation 'org.apache.httpcomponents.client5:httpclient5-cache:5.6.4'
+        implementation 'org.apache.httpcomponents.core5:httpcore5:5.4.3'
+        implementation 'org.apache.httpcomponents.core5:httpcore5-h2:5.4.3'
     }
 
     compileOnly project(":supertokens-plugin-interface")

--- a/implementationDependencies.json
+++ b/implementationDependencies.json
@@ -197,24 +197,24 @@
 		"src":"https://build.shibboleth.net/nexus/content/repositories/releases/net/shibboleth/shib-networking/9.2.3/shib-networking-9.2.3-sources.jar"
 	},
 	{
-		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5-cache/5.3.1/httpclient5-cache-5.3.1.jar",
-		"name":"httpclient5-cache 5.3.1",
-		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5-cache/5.3.1/httpclient5-cache-5.3.1-sources.jar"
+		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5-cache/5.6.4/httpclient5-cache-5.6.4.jar",
+		"name":"httpclient5-cache 5.6.4",
+		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5-cache/5.6.4/httpclient5-cache-5.6.4-sources.jar"
 	},
 	{
-		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1.jar",
-		"name":"httpclient5 5.3.1",
-		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.3.1/httpclient5-5.3.1-sources.jar"
+		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.6.4/httpclient5-5.6.4.jar",
+		"name":"httpclient5 5.6.4",
+		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/client5/httpclient5/5.6.4/httpclient5-5.6.4-sources.jar"
 	},
 	{
-		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4.jar",
-		"name":"httpcore5-h2 5.2.4",
-		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/5.2.4/httpcore5-h2-5.2.4-sources.jar"
+		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/5.4.3/httpcore5-h2-5.4.3.jar",
+		"name":"httpcore5-h2 5.4.3",
+		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5-h2/5.4.3/httpcore5-h2-5.4.3-sources.jar"
 	},
 	{
-		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.2.5/httpcore5-5.2.5.jar",
-		"name":"httpcore5 5.2.5",
-		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.2.5/httpcore5-5.2.5-sources.jar"
+		"jar":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.4.3/httpcore5-5.4.3.jar",
+		"name":"httpcore5 5.4.3",
+		"src":"https://repo.maven.apache.org/maven2/org/apache/httpcomponents/core5/httpcore5/5.4.3/httpcore5-5.4.3-sources.jar"
 	},
 	{
 		"jar":"https://repo.maven.apache.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.84/bcpkix-jdk18on-1.84.jar",


### PR DESCRIPTION
Fixes the dependency CVEs AWS Inspector flags on the `supertokens-postgresql` docker image:

- **opentelemetry-javaagent 2.27.0 → 2.29.0** (`src/main/resources/`) — CVE-2026-54704: the JDBC instrumentation could leak double-quoted connect-string passwords into span attributes. This one file feeds both flagged locations: the copy embedded in the core fat jar and `/usr/lib/supertokens/agent/` (copied by `setupTestEnv`). Matches the 2.29.0-alpha instrumentation BOM already in `build.gradle`; jar sha256 verified against Maven Central.
- **httpclient5(-cache) → 5.6.4, httpcore5/httpcore5-h2 → 5.4.3** via dependency constraints — CVE-2026-64607 (connection leak on invalid `Content-Encoding`), CVE-2026-54399 (HTTP/1.1 parser memory exhaustion), CVE-2026-54428 (HPACK decoder memory exhaustion). These are pulled transitively by opensaml 5.2.3; httpclient5 5.6.4 is built against exactly httpcore5 5.4.3.
- `implementationDependencies.json` regenerated (only the four artifacts changed).

Verified: full build green; smoke-built the docker image and confirmed the 5.6.4/5.4.3 jars land in `/usr/lib/supertokens/core/` and both agent copies report 2.29.0.

Companion PRs: supertokens/jre#4 (new JRE bundles), supertokens-postgresql-plugin `fix/container-image-cves` (Dockerfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rh6Ee6Hs2831zeHiMwNELJ