### PR TITLE
fix: enforce dashboard session expiry at verification time (GHSA-w9fp-wv6g-pqv8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Dashboard session tokens are now checked for expiry when verified: `Dashboard.isValidUserSession` and `getEmailFromSessionId` reject a session whose `expiry` has passed (and revoke the expired row) instead of relying solely on the twice-daily cleanup cron, which does not run for the first 12 hours of a process' life.
+
 ## [12.2.0]
 
 - Fixes app and connection URI domain configuration updates being incorrectly rejected as conflicting when affected

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Dashboard session tokens are now checked for expiry when verified: `Dashboard.isValidUserSession` and `getEmailFromSessionId` reject a session whose `expiry` has passed (and revoke the expired row) instead of relying solely on the twice-daily cleanup cron, which does not run for the first 12 hours of a process' life.
+- Dashboard sessions are now checked for expiry at verification time, so an expired session is rejected and revoked instead of relying solely on the cleanup cron (GHSA-w9fp-wv6g-pqv8).
 
 ## [12.2.0]
 

--- a/src/main/java/io/supertokens/dashboard/Dashboard.java
+++ b/src/main/java/io/supertokens/dashboard/Dashboard.java
@@ -399,6 +399,14 @@ public class Dashboard {
         DashboardSessionInfo sessionInfo = StorageUtils.getDashboardStorage(storage)
                 .getSessionInfoWithSessionId(appIdentifier, sessionId);
         if (sessionInfo != null) {
+            // Enforce the session lifetime at verification time. The DeleteExpiredDashboardSessions cron
+            // only reclaims rows, and does not run for the first 12 hours of a process' life, so it cannot
+            // be relied on to end a session. Revoke the expired row here so it stops authenticating even on
+            // a core that restarts more often than the cron interval.
+            if (isSessionExpired(sessionInfo)) {
+                revokeSessionWithSessionId(appIdentifier, storage, sessionId);
+                return false;
+            }
             // check if user is suspended
             if (isUserSuspended(appIdentifier, storage, main, null, sessionInfo.userId)) {
                 throw new UserSuspendedException();
@@ -408,12 +416,16 @@ public class Dashboard {
         return false;
     }
 
+    private static boolean isSessionExpired(DashboardSessionInfo sessionInfo) {
+        return sessionInfo.expiry <= System.currentTimeMillis();
+    }
+
     public static String getEmailFromSessionId(AppIdentifier appIdentifier, Storage storage, String sessionId)
             throws StorageQueryException {
         DashboardSessionInfo sessionInfo = StorageUtils.getDashboardStorage(storage)
                 .getSessionInfoWithSessionId(appIdentifier, sessionId);
 
-        if (sessionInfo != null) {
+        if (sessionInfo != null && !isSessionExpired(sessionInfo)) {
             String userId = sessionInfo.userId;
 
             DashboardUser user = StorageUtils.getDashboardStorage(storage)

--- a/src/test/java/io/supertokens/test/dashboard/DashboardTest.java
+++ b/src/test/java/io/supertokens/test/dashboard/DashboardTest.java
@@ -216,6 +216,49 @@ public class DashboardTest {
     }
 
     @Test
+    public void testExpiredSessionIsRejectedAtVerification() throws Exception {
+        String[] args = {"../"};
+
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STARTED));
+
+        if (StorageLayer.getStorage(process.getProcess()).getType() != STORAGE_TYPE.SQL) {
+            return;
+        }
+
+        String email = "test@example.com";
+        String password = "password123";
+        DashboardUser user = Dashboard.signUpDashboardUser(process.getProcess(), email, password);
+
+        DashboardSQLStorage storage = (DashboardSQLStorage) StorageLayer.getStorage(process.getProcess());
+
+        // Create a session whose expiry is in the past, without waiting for the cleanup cron. This is the
+        // shape of a token whose 30-day lifetime has elapsed.
+        String expiredSessionId = io.supertokens.utils.Utils.getUUID();
+        long now = System.currentTimeMillis();
+        storage.createNewDashboardUserSession(process.getAppForTesting().toAppIdentifier(), user.userId,
+                expiredSessionId, now - Dashboard.DASHBOARD_SESSION_DURATION - 1000, now - 1000);
+
+        // The row exists, but verification must not accept it and must not leak the user's email.
+        assertFalse(Dashboard.isValidUserSession(process.getProcess(), expiredSessionId));
+        assertNull(Dashboard.getEmailFromSessionId(process.getAppForTesting().toAppIdentifier(),
+                storage, expiredSessionId));
+
+        // Verifying an expired session revokes it, so it does not depend on the 12-hour cleanup cron.
+        assertNull(storage.getSessionInfoWithSessionId(process.getAppForTesting().toAppIdentifier(),
+                expiredSessionId));
+
+        // Positive control: a freshly issued session still authenticates and resolves its email.
+        String validSessionId = Dashboard.signInDashboardUser(process.getProcess(), email, password);
+        assertTrue(Dashboard.isValidUserSession(process.getProcess(), validSessionId));
+        assertEquals(email, Dashboard.getEmailFromSessionId(process.getAppForTesting().toAppIdentifier(),
+                storage, validSessionId));
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(PROCESS_STATE.STOPPED));
+    }
+
+    @Test
     public void testUpdatingDashboardUsersCredentialsShouldRevokeSessions() throws Exception {
 
         String[] args = {"../"};


### PR DESCRIPTION
## Summary

Fixes the private advisory **GHSA-w9fp-wv6g-pqv8** (CWE-613, insufficient session
expiration). `Dashboard.isValidUserSession` treated "a row exists for this session id" as
"the session is valid" — it checked user suspension and nothing else, never consulting the
`expiry` column that the same code persists. `getEmailFromSessionId` had the same gap. The
only thing ending a dashboard session was the `DeleteExpiredDashboardSessions` cron, whose
first sweep runs 12 hours after process start, so a core that restarts more often than every
12 hours never ran it, and even a long-lived process left a 0–12 h window past the 30-day
lifetime.

Net effect: an expired dashboard session token kept authenticating as the dashboard
administrator — full admin control of the user store (list/search users, read/modify
account info, change email/password, delete users, read/modify tenant core config).

I verified the report against source at `v12.1.1` and this `12.2` base: the two methods and
`getSessionInfoWithSessionId` are byte-for-byte the unfixed version on both.

## Fix

Enforce the lifetime where the session is resolved, so it holds for every storage backend at
once (the check is above the storage query, in storage-agnostic domain code):

- `isValidUserSession` — an expired session is rejected **and revoked** on access, so it stops
  authenticating immediately regardless of whether the cleanup cron has run.
- `getEmailFromSessionId` — returns `null` for an expired session (defence in depth; it is a
  public method and a second read path to the same row).

The cron is unchanged; it remains useful for reclaiming rows in bulk, it is just no longer the
only thing enforcing the lifetime.

## Test

`DashboardTest.testExpiredSessionIsRejectedAtVerification` reproduces the advisory: a session
row written with a past `expiry` (no waiting on the cron) must not authenticate
(`isValidUserSession` → false), must not leak the email (`getEmailFromSessionId` → null), and
is revoked on access; a freshly issued session is the positive control. Fails on the base,
passes with this change.

Ran `io.supertokens.test.dashboard.DashboardTest` against PostgreSQL locally — 7/7 pass.

## Follow-up (not in this PR)

Defence in depth: add `AND expiry > ?` to `getSessionInfoWithSessionId` in each storage
implementation (postgresql / mysql / in-memory) so the invariant holds even if a future
caller forgets the verification-time check. Left out here to keep the security fix to one repo
and reviewable; happy to open the storage-side PRs if you'd like them alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
