### PR TITLE
ci: pin actions, scope tokens and stop over-sharing secrets with reusable workflows

### DIFF
--- a/.github/workflows/_release-add-tags.yml
+++ b/.github/workflows/_release-add-tags.yml
@@ -34,6 +34,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   add-release-tags:
     name: Add release tags

--- a/.github/workflows/_release-add-tags.yml
+++ b/.github/workflows/_release-add-tags.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: master

--- a/.github/workflows/_release-add-tags.yml
+++ b/.github/workflows/_release-add-tags.yml
@@ -2,6 +2,11 @@ name: Release – Add release tags
 
 on:
   workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
+      SUPERTOKENS_API_KEY:
+        required: true
     inputs:
       core-version:
         type: string

--- a/.github/workflows/_release-build-docker.yml
+++ b/.github/workflows/_release-build-docker.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: master
@@ -51,12 +52,14 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
           ref: ${{ inputs.core-sha }}
 
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ inputs.plugin-interface-sha }}
@@ -64,6 +67,7 @@ jobs:
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ inputs.postgresql-sha }}

--- a/.github/workflows/_release-build-docker.yml
+++ b/.github/workflows/_release-build-docker.yml
@@ -91,19 +91,19 @@ jobs:
           fi
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push dev image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           context: ./supertokens-root

--- a/.github/workflows/_release-build-docker.yml
+++ b/.github/workflows/_release-build-docker.yml
@@ -2,6 +2,9 @@ name: Release – Build Docker image
 
 on:
   workflow_call:
+    secrets:
+      DOCKERHUB_TOKEN:
+        required: true
     inputs:
       core-version:
         type: string

--- a/.github/workflows/_release-build-docker.yml
+++ b/.github/workflows/_release-build-docker.yml
@@ -22,6 +22,9 @@ on:
       dev-tag:
         value: ${{ jobs.build-docker.outputs.dev-tag }}
 
+permissions:
+  contents: read
+
 jobs:
   build-docker:
     name: Build Docker image

--- a/.github/workflows/_release-mark-passed.yml
+++ b/.github/workflows/_release-mark-passed.yml
@@ -2,6 +2,9 @@ name: Release – Mark tests as passed
 
 on:
   workflow_call:
+    secrets:
+      SUPERTOKENS_API_KEY:
+        required: true
     inputs:
       core-version:
         type: string

--- a/.github/workflows/_release-mark-passed.yml
+++ b/.github/workflows/_release-mark-passed.yml
@@ -16,6 +16,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   mark-as-passed:
     name: Mark as passed (${{ matrix.plugin }})

--- a/.github/workflows/_release-publish-docker.yml
+++ b/.github/workflows/_release-publish-docker.yml
@@ -2,6 +2,15 @@ name: Release – Publish Docker images
 
 on:
   workflow_call:
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+      ECR_REGISTRY:
+        required: true
     inputs:
       core-version:
         type: string

--- a/.github/workflows/_release-publish-docker.yml
+++ b/.github/workflows/_release-publish-docker.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: inputs.push-to-ecr
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@cbe3b392738ccf3f987d68400dafcf4b0624a56c # v6.2.4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Login to Amazon ECR
         if: inputs.push-to-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@03f1aad4c6c7ffd436567f42f9384779290529bd # v2.1.7
 
       - name: Push release images to ECR
         if: inputs.push-to-ecr

--- a/.github/workflows/_release-publish-docker.yml
+++ b/.github/workflows/_release-publish-docker.yml
@@ -22,6 +22,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   release-docker:
     name: Release Docker image

--- a/.github/workflows/_release-publish-docker.yml
+++ b/.github/workflows/_release-publish-docker.yml
@@ -41,6 +41,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/_release-register-versions.yml
+++ b/.github/workflows/_release-register-versions.yml
@@ -2,6 +2,9 @@ name: Release – Register versions
 
 on:
   workflow_call:
+    secrets:
+      SUPERTOKENS_API_KEY:
+        required: true
     inputs:
       core-version:
         type: string

--- a/.github/workflows/_release-register-versions.yml
+++ b/.github/workflows/_release-register-versions.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         # No ref: — defaults to github.sha (workflow branch), gets latest helper scripts
       - name: Fetch release data files from release branch
         run: |
@@ -62,10 +64,13 @@ jobs:
     steps:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         # No ref: — defaults to github.sha (workflow branch), gets latest helper scripts
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-plugin
           repository: supertokens/supertokens-postgresql-plugin
           ref: ${{ inputs.postgresql-sha }}

--- a/.github/workflows/_release-register-versions.yml
+++ b/.github/workflows/_release-register-versions.yml
@@ -22,6 +22,9 @@ on:
         type: boolean
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   register-core-version:
     name: Register core version

--- a/.github/workflows/_release-resolve-deps.yml
+++ b/.github/workflows/_release-resolve-deps.yml
@@ -37,6 +37,8 @@ jobs:
       postgresql-sha: ${{ steps.shas.outputs.postgresql }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:

--- a/.github/workflows/_release-resolve-deps.yml
+++ b/.github/workflows/_release-resolve-deps.yml
@@ -2,6 +2,9 @@ name: Release – Resolve dependencies
 
 on:
   workflow_call:
+    secrets:
+      GH_TOKEN:
+        required: true
     inputs:
       core-version:
         type: string

--- a/.github/workflows/_release-resolve-deps.yml
+++ b/.github/workflows/_release-resolve-deps.yml
@@ -31,7 +31,7 @@ jobs:
       postgresql-sha: ${{ steps.shas.outputs.postgresql }}
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
           run-for: add-dev-tag

--- a/.github/workflows/_release-resolve-deps.yml
+++ b/.github/workflows/_release-resolve-deps.yml
@@ -20,6 +20,9 @@ on:
       postgresql-sha:
         value: ${{ jobs.resolve.outputs.postgresql-sha }}
 
+permissions:
+  contents: read
+
 jobs:
   resolve:
     name: Resolve dependencies

--- a/.github/workflows/_release-run-tests.yml
+++ b/.github/workflows/_release-run-tests.yml
@@ -63,6 +63,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: master
@@ -70,12 +71,14 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
           ref: ${{ inputs.core-sha }}
 
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ inputs.plugin-interface-sha }}
@@ -84,6 +87,7 @@ jobs:
         if: matrix.plugin == 'postgresql'
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ inputs.postgresql-sha }}

--- a/.github/workflows/_release-run-tests.yml
+++ b/.github/workflows/_release-run-tests.yml
@@ -21,6 +21,9 @@ on:
 env:
   total-runners: 6
 
+permissions:
+  contents: read
+
 jobs:
   runner-indexes:
     name: Generate runner indexes
@@ -39,6 +42,10 @@ jobs:
     name: "Tests (${{ matrix.plugin }}), runner #${{ matrix.runner-index }}"
     needs: runner-indexes
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      # The JUnit report step publishes a check run.
+      checks: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/_release-run-tests.yml
+++ b/.github/workflows/_release-run-tests.yml
@@ -159,7 +159,7 @@ jobs:
           ./test.sh
 
       - name: Publish test report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d # v6.5.0
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/add-dev-tag.yml
+++ b/.github/workflows/add-dev-tag.yml
@@ -36,6 +36,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
@@ -55,6 +57,7 @@ jobs:
           distribution: zulu
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: ./supertokens-root
           ref: master

--- a/.github/workflows/add-dev-tag.yml
+++ b/.github/workflows/add-dev-tag.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
           run-for: add-dev-tag

--- a/.github/workflows/add-dev-tag.yml
+++ b/.github/workflows/add-dev-tag.yml
@@ -23,6 +23,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   dependency-branches:
     name: Dependency Branches

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -60,6 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 
@@ -109,6 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           fetch-depth: 0
           token: ${{ secrets.GH_TOKEN }}
 

--- a/.github/workflows/batch-generate-jars.yml
+++ b/.github/workflows/batch-generate-jars.yml
@@ -18,6 +18,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # ── Parse the free-text version list into a JSON matrix ──────────────
   prepare:

--- a/.github/workflows/batch-generate-jars.yml
+++ b/.github/workflows/batch-generate-jars.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout workflow tooling
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Parse versions into matrix
         id: parse

--- a/.github/workflows/batch-generate-jars.yml
+++ b/.github/workflows/batch-generate-jars.yml
@@ -50,4 +50,7 @@ jobs:
       core-version: ${{ matrix.version }}
       java-version: ${{ inputs.java-version }}
       commit-to-github: ${{ inputs.commit-to-github }}
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Run Trivy vulnerability scanner
         id: container-scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         continue-on-error: true
         with:
           image-ref: supertokens/supertokens-postgresql:latest
@@ -107,7 +107,7 @@ jobs:
 
       - name: Post notification on Slack channel
         id: deployment_message
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/container-check.yml
+++ b/.github/workflows/container-check.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   container-scan:
     name: Scan SuperTokens PostgreSQL Container

--- a/.github/workflows/dev-tag.yml
+++ b/.github/workflows/dev-tag.yml
@@ -19,6 +19,8 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         with:
           run-for: PR
@@ -31,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
@@ -56,9 +60,12 @@ jobs:
       steps:
         - name: Checkout
           uses: actions/checkout@v5
+          with:
+            persist-credentials: false
         - name: Checkout
           uses: actions/checkout@v5
           with:
+            persist-credentials: false
             path: ./supertokens-plugin
             repository: supertokens/supertokens-${{ matrix.plugin }}-plugin
             ref: ${{ fromJson(needs.dependency-versions.outputs.branches)[matrix.plugin] }}
@@ -87,6 +94,8 @@ jobs:
           python-version: '3.11'
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Wait for Docker build
         env:

--- a/.github/workflows/dev-tag.yml
+++ b/.github/workflows/dev-tag.yml
@@ -7,6 +7,9 @@ on:
     tags:
     - 'dev-*'
 
+permissions:
+  contents: read
+
 jobs:
   dependency-versions:
     name: Dependency Versions

--- a/.github/workflows/dev-tag.yml
+++ b/.github/workflows/dev-tag.yml
@@ -16,7 +16,7 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         with:
           run-for: PR
         id: result
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Mark plugin as passed
         if: matrix.plugin != 'sqlite' && fromJson(needs.dependency-versions.outputs.versions)[matrix.plugin] != ''
-        uses: muhfaris/request-action@main
+        uses: muhfaris/request-action@e9c380f048db96e11665fbb8edabf795e269ff7f # main, latest
         with:
           url: https://api.supertokens.io/0/plugin
           method: PATCH
@@ -127,7 +127,7 @@ jobs:
             }
       - name: Mark core as passed
         if: matrix.plugin == 'sqlite' && fromJson(needs.dependency-versions.outputs.versions)['core'] != ''
-        uses: muhfaris/request-action@main
+        uses: muhfaris/request-action@e9c380f048db96e11665fbb8edabf795e269ff7f # main, latest
         with:
           url: https://api.supertokens.io/0/core
           method: PATCH

--- a/.github/workflows/do-release-java15.yml
+++ b/.github/workflows/do-release-java15.yml
@@ -55,6 +55,9 @@ on:
 env:
   total-runners: 6
 
+permissions:
+  contents: read
+
 jobs:
   # ── Validate inputs ───────────────────────────────────────────────
   # Fail fast on invalid input combinations before anything is registered
@@ -265,6 +268,10 @@ jobs:
     name: Tests (${{ matrix.plugin }}) plugin, runner #${{ matrix.runner-index }}"
     needs: [ update-deps, register-core-version, runner-indexes ]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      # The JUnit report step publishes a check run.
+      checks: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/do-release-java15.yml
+++ b/.github/workflows/do-release-java15.yml
@@ -573,7 +573,11 @@ jobs:
       is-latest-for-major: ${{ inputs.is-latest-for-major }}
       push-to-ecr: ${{ inputs.push-to-ecr }}
       dev-tag: ${{ needs.build-docker.outputs.dev-tag }}
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
 
   # ── Tag all repos with release versions ───────────────────────────
   add-release-tags:
@@ -702,7 +706,10 @@ jobs:
       plugin-interface-version: ${{ inputs.plugin-interface-version }}
       postgresql-plugin-version: ${{ inputs.postgresql-plugin-version }}
       commit-to-github: true
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   # ── Notify Slack about the successful release ─────────────────────
   notify-slack:

--- a/.github/workflows/do-release-java15.yml
+++ b/.github/workflows/do-release-java15.yml
@@ -80,7 +80,7 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
           run-for: add-dev-tag
@@ -401,7 +401,7 @@ jobs:
           ./test.sh
 
       - name: Publish test report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d # v6.5.0
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'
@@ -524,19 +524,19 @@ jobs:
           echo "TAG=${{ inputs.core-version }}-dev" >> $GITHUB_OUTPUT
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push dev image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           context: ./supertokens-root
@@ -709,7 +709,7 @@ jobs:
         # The release itself succeeded at this point — a failed notification
         # must not fail the workflow. The step below leaves a memo instead.
         continue-on-error: true
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/do-release-java15.yml
+++ b/.github/workflows/do-release-java15.yml
@@ -83,6 +83,8 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
@@ -114,6 +116,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: for_jdk_15_releases
@@ -121,6 +124,7 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['core'] }}
           token: ${{ secrets.GH_TOKEN }}
@@ -128,6 +132,7 @@ jobs:
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['plugin-interface'] }}
@@ -136,6 +141,7 @@ jobs:
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['postgresql'] }}
@@ -201,6 +207,8 @@ jobs:
     steps:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         # No ref: — defaults to github.sha (workflow branch), gets latest helper scripts
       - name: Fetch release data files from release branch
         run: |
@@ -227,11 +235,14 @@ jobs:
     steps:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
         # No ref: — defaults to github.sha (workflow branch), gets latest helper scripts
         # (No data files from core are needed here; postgresql plugin provides them)
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-plugin
           repository: supertokens/supertokens-postgresql-plugin
           ref: ${{ needs.update-deps.outputs.postgresql-sha }}
@@ -290,6 +301,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: for_jdk_15_releases
@@ -297,12 +309,14 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
           ref: ${{ needs.update-deps.outputs.core-sha }}
 
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ needs.update-deps.outputs.plugin-interface-sha }}
@@ -311,6 +325,7 @@ jobs:
         if: matrix.plugin == 'postgresql'
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ needs.update-deps.outputs.postgresql-sha }}
@@ -482,6 +497,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: for_jdk_15_releases
@@ -489,12 +505,14 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
           ref: ${{ needs.update-deps.outputs.core-sha }}
 
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ needs.update-deps.outputs.plugin-interface-sha }}
@@ -502,6 +520,7 @@ jobs:
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ needs.update-deps.outputs.postgresql-sha }}
@@ -596,6 +615,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: for_jdk_15_releases

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -57,6 +57,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # Fail fast on invalid input combinations before anything is registered
   # or published. Every other job depends on dependency-branches, so gating

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -190,7 +190,7 @@ jobs:
         # The release itself succeeded at this point — a failed notification
         # must not fail the workflow. The step below leaves a memo instead.
         continue-on-error: true
-        uses: slackapi/slack-github-action@v3
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -86,7 +86,8 @@ jobs:
       core-version: ${{ inputs.core-version }}
       plugin-interface-version: ${{ inputs.plugin-interface-version }}
       postgresql-plugin-version: ${{ inputs.postgresql-plugin-version }}
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   register-versions:
     needs: dependency-branches
@@ -98,7 +99,8 @@ jobs:
       postgresql-sha: ${{ needs.dependency-branches.outputs.postgresql-sha }}
       release-postgresql-plugin: ${{ inputs.release-postgresql-plugin }}
       is-canary: ${{ inputs.is-canary }}
-    secrets: inherit
+    secrets:
+      SUPERTOKENS_API_KEY: ${{ secrets.SUPERTOKENS_API_KEY }}
 
   test:
     needs: [ dependency-branches, register-versions ]
@@ -108,7 +110,6 @@ jobs:
       plugin-interface-sha: ${{ needs.dependency-branches.outputs.plugin-interface-sha }}
       postgresql-sha: ${{ needs.dependency-branches.outputs.postgresql-sha }}
       fast-release: ${{ inputs.fast-release }}
-    secrets: inherit
 
   mark-as-passed:
     needs: [ register-versions, test ]
@@ -119,7 +120,8 @@ jobs:
       postgresql-plugin-version: ${{ inputs.postgresql-plugin-version }}
       release-postgresql-plugin: ${{ inputs.release-postgresql-plugin }}
       is-canary: ${{ inputs.is-canary }}
-    secrets: inherit
+    secrets:
+      SUPERTOKENS_API_KEY: ${{ secrets.SUPERTOKENS_API_KEY }}
 
   build-docker:
     needs: dependency-branches
@@ -130,7 +132,8 @@ jobs:
       core-sha: ${{ needs.dependency-branches.outputs.core-sha }}
       plugin-interface-sha: ${{ needs.dependency-branches.outputs.plugin-interface-sha }}
       postgresql-sha: ${{ needs.dependency-branches.outputs.postgresql-sha }}
-    secrets: inherit
+    secrets:
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
   stress-tests:
     if: inputs.run-stress-tests
@@ -150,7 +153,11 @@ jobs:
       is-latest-for-major: ${{ inputs.is-latest-for-major }}
       push-to-ecr: ${{ inputs.push-to-ecr }}
       dev-tag: ${{ needs.build-docker.outputs.dev-tag }}
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
 
   add-release-tags:
     needs: [dependency-branches, release-docker]
@@ -167,7 +174,9 @@ jobs:
       release-postgresql-plugin: ${{ inputs.release-postgresql-plugin }}
       is-canary: ${{ inputs.is-canary }}
       is-latest-release: ${{ inputs.is-latest-release }}
-    secrets: inherit
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      SUPERTOKENS_API_KEY: ${{ secrets.SUPERTOKENS_API_KEY }}
 
   build-jars:
     needs: [add-release-tags]
@@ -178,7 +187,10 @@ jobs:
       plugin-interface-version: ${{ inputs.plugin-interface-version }}
       postgresql-plugin-version: ${{ inputs.postgresql-plugin-version }}
       commit-to-github: true
-    secrets: inherit
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   # build-jars is skipped for canary releases; !failure() lets the
   # notification still fire in that case.

--- a/.github/workflows/generate-jars.yml
+++ b/.github/workflows/generate-jars.yml
@@ -26,6 +26,13 @@ on:
         type: boolean
         default: false
   workflow_call:
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      GH_TOKEN:
+        required: true
     inputs:
       core-version:
         required: true

--- a/.github/workflows/generate-jars.yml
+++ b/.github/workflows/generate-jars.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Checkout workflow tooling
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: ./workflow-tools
 
       - name: Set up JDK ${{ inputs.java-version }}
@@ -77,6 +78,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: ./supertokens-root
           ref: ${{ startsWith(inputs.java-version, '15') && 'for_jdk_15_releases' || 'master' }}

--- a/.github/workflows/generate-jars.yml
+++ b/.github/workflows/generate-jars.yml
@@ -45,6 +45,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   generate-jars:
     environment: publish

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
       with:
         changeLogPath: 'CHANGELOG.md'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -8,7 +8,7 @@ jobs:
     name: Lint PR title
     runs-on: ubuntu-latest
     steps:
-    - uses: amannn/action-semantic-pull-request@v6
+    - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - uses: dangoslen/changelog-enforcer@v3.7.0
+    - uses: dangoslen/changelog-enforcer@8b5e9dc3121363bb7c0115f8533404d92af382de # v3.7.0
       with:
         changeLogPath: 'CHANGELOG.md'
         skipLabels: 'Skip-Changelog'

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review, labeled, unlabeled ]
 
+permissions:
+  contents: read
+  # Both checks read the pull request title and metadata.
+  pull-requests: read
+
 jobs:
   pr-title:
     name: Lint PR title

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
           run-for: PR
@@ -85,17 +85,17 @@ jobs:
           echo "TAG=${GITHUB_REF}" | sed 's/refs\/heads\///g' | sed 's/\//_/g' >> $GITHUB_OUTPUT
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           push: true
           context: ./supertokens-root

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
@@ -46,20 +48,24 @@ jobs:
           distribution: zulu
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: ./supertokens-root
           ref: master
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: ./supertokens-root/supertokens-core
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: ./supertokens-root/supertokens-plugin-interface
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['plugin-interface'] }}
       - uses: actions/checkout@v5
         if: matrix.plugin != 'sqlite'
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-${{ matrix.plugin }}-plugin
           path: ./supertokens-root/supertokens-${{ matrix.plugin }}-plugin
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)[matrix.plugin] }}

--- a/.github/workflows/publish-dev-docker.yml
+++ b/.github/workflows/publish-dev-docker.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'dev-*'
 
+permissions:
+  contents: read
+
 jobs:
   dependency-branches:
     name: Dependency Branches

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -23,6 +23,8 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
@@ -46,6 +48,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: master
@@ -53,6 +56,7 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
           token: ${{ secrets.GH_TOKEN }}
           ref: ${{ github.head_ref }}
@@ -60,6 +64,7 @@ jobs:
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['plugin-interface'] }}
@@ -68,6 +73,7 @@ jobs:
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['postgresql'] }}
@@ -163,6 +169,7 @@ jobs:
       - name: Checkout supertokens-root
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: supertokens-root
           ref: master
@@ -170,11 +177,13 @@ jobs:
       - name: Checkout supertokens-core
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: supertokens-root/supertokens-core
 
       - name: Checkout supertokens-plugin-interface
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: supertokens-root/supertokens-plugin-interface
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['plugin-interface'] }}
@@ -183,6 +192,7 @@ jobs:
         if: matrix.plugin == 'postgresql'
         uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-postgresql-plugin
           path: supertokens-root/supertokens-postgresql-plugin
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['postgresql'] }}
@@ -261,6 +271,8 @@ jobs:
       tag: ${{ steps.set_tag.outputs.TAG }}
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   dependency-branches:
     name: Resolve dependencies
@@ -123,6 +126,10 @@ jobs:
     needs: [dependency-branches, update-deps]
     if: needs.update-deps.outputs.deps_changed == 'false'
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      # The JUnit report step publishes a check run.
+      checks: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -20,7 +20,7 @@ jobs:
       branches: ${{ steps.result.outputs.branches }}
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
           run-for: PR
@@ -236,7 +236,7 @@ jobs:
           ./gradlew test
 
       - name: Publish test report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d # v6.5.0
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/retag-docker.yml
+++ b/.github/workflows/retag-docker.yml
@@ -12,6 +12,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   retag:
     name: Retag Docker image

--- a/.github/workflows/retag-docker.yml
+++ b/.github/workflows/retag-docker.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/retag-docker.yml
+++ b/.github/workflows/retag-docker.yml
@@ -21,16 +21,16 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Retag and push
         run: |

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   stress-tests:
     runs-on: ubuntu-22.04

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -38,6 +38,8 @@ jobs:
     name: stress-tests (${{ matrix.mode }})
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@v5
         with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: supertokens/get-core-dependencies-action@main
+      - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
           run-for: PR
@@ -78,7 +78,7 @@ jobs:
           cd supertokens-root
           ./gradlew test
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d # v6.5.0
         if: always()
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: supertokens/get-core-dependencies-action@e886228a75714e77975b4d533e2f58f778211594 # main, latest
         id: result
         with:
@@ -47,20 +49,24 @@ jobs:
           distribution: zulu
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-root
           path: ./supertokens-root
           ref: master
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           path: ./supertokens-root/supertokens-core
       - uses: actions/checkout@v5
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-plugin-interface
           path: ./supertokens-root/supertokens-plugin-interface
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)['plugin-interface'] }}
       - uses: actions/checkout@v5
         if: matrix.plugin != 'sqlite'
         with:
+          persist-credentials: false
           repository: supertokens/supertokens-${{ matrix.plugin }}-plugin
           path: ./supertokens-root/supertokens-${{ matrix.plugin }}-plugin
           ref: ${{ fromJson(needs.dependency-branches.outputs.branches)[matrix.plugin] }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,6 +3,9 @@ name: Unit Tests
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   dependency-branches:
     name: Dependency Branches
@@ -32,6 +35,10 @@ jobs:
           # - mongodb
 
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      # The JUnit report step publishes a check run.
+      checks: write
     steps:
       - name: Set up JDK 21.0.7
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary of change

Four commits across the 21 workflows, no application code touched.

Every third party action now points to a full commit SHA with the resolved tag in a comment, readable and cross-checkable. A tag or branch ref is a movable pointer: whoever controls the action repository can repoint it and the next run executes their code with this repo's secrets, the release PAT, the Docker Hub token and the AWS keys included. That is the March 2025 tj-actions/changed-files incident (CVE-2025-30066). The trivy ref moves from the floating master branch to its current release, and your two same-org actions on main are pinned to the current tip, happy to drop those two pins if you would rather trust your own org unpinned. First party actions (actions/*) stay on their tags, though Scorecard's pinned-dependencies check would want those pinned too.

All 21 workflows now declare token permissions. Everything write-shaped here already authenticates outside the workflow token, the release flows with the GH_TOKEN PAT and the registries with Docker Hub and AWS credentials, so the token drops to read everywhere. The JUnit reporter jobs keep `checks: write` and the PR checks read pull request metadata.

The biggest blast-radius reduction: every `workflow_call` site passed the caller's entire secret set with `secrets: inherit`, which handed the release PAT and the AWS keys to jobs that needed a Docker Hub token or nothing at all. Each reusable workflow now declares exactly the secrets it uses and the callers forward exactly that set, the test runner gets none.

Finally, all 66 checkouts persisted the workflow token in `.git/config` with nothing pushing through it, they now set `persist-credentials: false`.

If a hash bump ever feels like churn, a dependabot github-actions config keeps SHA pins updated the same way it bumps tags, happy to add that block in a follow-up. One heads-up: an allowed-actions list using tag patterns (`owner/action@v1`) stops matching SHA refs and fails workflows at startup, the fix is `owner/action@*` in the allowed-actions settings.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.

## Related issues

- None, this is a direct hardening PR with no issue attached.

## Test Plan

- Every workflow file parses (checked with a strict YAML loader that also rejects duplicate keys).
- Every pin is behavior-identical: the SHA is the commit its comment's tag points to, verifiable per ref with `git ls-remote <action-repo> refs/tags/<tag>`.
- The secret forwarding matches usage: each reusable workflow's declared secrets are exactly the `secrets.*` references in its file, so no call can lose a secret the callee reads.
- The PR's own CI run exercises pr-checks and the unit test workflows directly, which covers the permissions and checkout changes on the paths that run per PR. The release and docker workflows are dispatch or master triggered and were reviewed statically, their auth flows (PAT and registry credentials) are untouched.

## Documentation changes

- None needed, the change is CI configuration only.

## Checklist for important updates

- [ ] Changelog has been updated
    - Not updated: CI-only change, no user-facing behavior. Happy to add an entry if you want CI changes in the changelog.
- [ ] `coreDriverInterfaceSupported.json` file has been updated (if needed) - not needed, no interface change
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed) - not needed, no interface change
- [ ] Changes to the version if needed - not needed, no code change
- [ ] If added a new paid feature... - no feature added
- [ ] Had installed and ran the pre-commit hook - not run, the hook lints and builds the Java code and this PR touches only `.github/workflows`
- [ ] New dependencies in `build.gradle`... - none added
- [ ] Update function `getValidFields`... - no config change
- [ ] Issue this PR against the latest non released version branch - targeted `master` deliberately: the change is CI-only and the scheduled and dispatch workflows execute from master. If you would rather take it on the current version branch, say so and I retarget.
- [ ] Foreign key constraint on `app_id_to_user_id`... - no schema change
- [ ] If added a new recipe... - no recipe added

## Remaining TODOs for this PR

- None.