### PR TITLE
fix: SAML login redirect uses & when the IdP SSO URL already has a query string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixes the SAML login redirect appending `SAMLRequest` with `?` when the IdP SingleSignOnService URL already has a query string (e.g. Google's `.../saml2/idp?idpid=...`); it now uses `&` so the existing query is preserved.
+
 ## [12.2.0]
 
 - Fixes app and connection URI domain configuration updates being incorrectly rejected as conflicting when affected

--- a/src/main/java/io/supertokens/saml/SAML.java
+++ b/src/main/java/io/supertokens/saml/SAML.java
@@ -243,7 +243,10 @@ public class SAML {
 
         samlStorage.saveRelayStateInfo(tenantIdentifier, new SAMLRelayStateInfo(relayState, clientId, state, redirectURI), config.getSAMLRelayStateValidity());
 
-        return idpSsoUrl + "?SAMLRequest=" + samlRequest + "&RelayState=" + URLEncoder.encode(relayState, StandardCharsets.UTF_8);
+        // The IdP SSO URL may already carry a query string (e.g. Google's
+        // ...o/saml2/idp?idpid=...), so pick the right separator instead of always using '?'.
+        String separator = idpSsoUrl.contains("?") ? "&" : "?";
+        return idpSsoUrl + separator + "SAMLRequest=" + samlRequest + "&RelayState=" + URLEncoder.encode(relayState, StandardCharsets.UTF_8);
     }
 
     public static EntityDescriptor loadIdpMetadata(String metadataXML) throws MalformedSAMLMetadataXMLException {

--- a/src/test/java/io/supertokens/test/saml/api/CreateSamlLoginRedirectAPITest5_4.java
+++ b/src/test/java/io/supertokens/test/saml/api/CreateSamlLoginRedirectAPITest5_4.java
@@ -219,4 +219,59 @@ public class CreateSamlLoginRedirectAPITest5_4 {
         process.kill();
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
+
+    @Test
+    public void testLoginRedirectWhenSsoUrlAlreadyHasQueryString() throws Exception {
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        FeatureFlagTestContent.getInstance(process.getProcess())
+                .setKeyValue(FeatureFlagTestContent.ENABLED_FEATURES, new EE_FEATURES[]{
+                        EE_FEATURES.SAML});
+
+        // An IdP whose SingleSignOnService URL already carries a query string, e.g. Google:
+        // https://accounts.google.com/o/saml2/idp?idpid=...
+        MockSAML.KeyMaterial keyMaterial = MockSAML.generateSelfSignedKeyMaterial();
+        java.security.cert.X509Certificate cert = keyMaterial.certificate;
+        String idpEntityId = "https://saml.example.com/entityid";
+        String idpSsoUrl = "https://accounts.google.com/o/saml2/idp?idpid=C03iijont";
+        String metadataXML = MockSAML.generateIdpMetadataXML(idpEntityId, idpSsoUrl, cert);
+        String metadataXMLBase64 = java.util.Base64.getEncoder().encodeToString(metadataXML.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        JsonObject createClientInput = new JsonObject();
+        createClientInput.addProperty("spEntityId", "http://example.com/saml");
+        createClientInput.addProperty("defaultRedirectURI", "http://localhost:3000/auth/callback/saml-mock");
+        createClientInput.add("redirectURIs", new JsonArray());
+        createClientInput.get("redirectURIs").getAsJsonArray().add("http://localhost:3000/auth/callback/saml-mock");
+        createClientInput.addProperty("metadataXML", metadataXMLBase64);
+
+        JsonObject createResp = HttpRequestForTesting.sendJsonPUTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/saml/clients", createClientInput, 1000, 1000, null, SemVer.v5_4.get(), "saml");
+        assertEquals("OK", createResp.get("status").getAsString());
+        String clientId = createResp.get("clientId").getAsString();
+
+        JsonObject body = new JsonObject();
+        body.addProperty("clientId", clientId);
+        body.addProperty("redirectURI", "http://localhost:3000/auth/callback/saml-mock");
+        body.addProperty("acsURL", "http://localhost:3000/acs");
+        body.addProperty("state", "abc123");
+
+        JsonObject resp = HttpRequestForTesting.sendJsonPOSTRequest(process.getProcess(), "",
+                "http://localhost:3567/recipe/saml/login", body, 1000, 1000, null, SemVer.v5_4.get(), "saml");
+
+        assertEquals("OK", resp.get("status").getAsString());
+        assertTrue(resp.has("ssoRedirectURI"));
+        String ssoRedirectURI = resp.get("ssoRedirectURI").getAsString();
+
+        // SAMLRequest must be appended with '&' (not '?') because the SSO URL already has a query.
+        assertTrue(ssoRedirectURI.startsWith(idpSsoUrl + "&SAMLRequest="));
+        // The existing query is preserved and there is no stray second '?'.
+        assertEquals(ssoRedirectURI.indexOf('?'), ssoRedirectURI.lastIndexOf('?'));
+        assertTrue(ssoRedirectURI.contains("idpid=C03iijont"));
+        assertTrue(ssoRedirectURI.contains("RelayState="));
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }


### PR DESCRIPTION
## Summary

`POST /<tenantId>/recipe/saml/login` builds the `ssoRedirectURI` by always appending `?SAMLRequest=...`. When the IdP's `SingleSignOnService` URL already carries a query string, this yields a malformed redirect with two `?` and drops the existing query.

Example (Google IdP, SSO URL `https://accounts.google.com/o/saml2/idp?idpid=C03iijont`):

- Before: `...idp?idpid=C03iijont?SAMLRequest=...&RelayState=...`  ← second `?` is wrong
- After:  `...idp?idpid=C03iijont&SAMLRequest=...&RelayState=...`

## Fix

`SAML.createRedirectURL` (`src/main/java/io/supertokens/saml/SAML.java`) now picks the separator based on whether the SSO URL already contains a query string:

```java
String separator = idpSsoUrl.contains("?") ? "&" : "?";
```

`SAMLRequest` and `RelayState` were already URL-encoded (`deflateAndBase64RedirectMessage` / `URLEncoder.encode`), so only the separator changes. I deliberately did **not** reuse the callback path's full `java.net.URI` reconstruction here — rebuilding the URI would re-encode the IdP's existing (already-encoded) query params and risk double-encoding; the separator choice preserves the IdP query verbatim.

## Test

Added `CreateSamlLoginRedirectAPITest5_4.testLoginRedirectWhenSsoUrlAlreadyHasQueryString`: an IdP whose metadata SSO URL is `https://accounts.google.com/o/saml2/idp?idpid=C03iijont`; asserts the redirect starts with `...idpid=C03iijont&SAMLRequest=`, contains exactly one `?`, preserves `idpid=C03iijont`, and carries `RelayState=`. Fails on the base, passes with this change.

Ran `CreateSamlLoginRedirectAPITest5_4` locally against PostgreSQL — 5/5 pass.

Target: **12.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
