### PR TITLE
fix: session refresh never holds two DB connections at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [12.2.0]
 
+- Session refresh never holds two DB connections at once: the legacy Case-B refresh retry now runs after its
+  transaction has released its connection (previously `connection_pool_size` concurrent such refreshes deadlocked the
+  pool, failing requests at the 5s connection timeout)
+- Signing-key lookups during token minting are served from a cache warmed before the session transaction, instead of
+  opening a nested transaction while it holds a connection; static-key lookups no longer hit the DB on every mint
 - Fixes app and connection URI domain configuration updates being incorrectly rejected as conflicting when affected
   tenants inherit the changed values.
 - **Upgrade note: the core now verifies the database schema at startup and, by default (`schema_check_strict_mode: true`), refuses to start when the base database is missing a manual migration — run the migration SQL from the CHANGELOGs (or set `schema_check_strict_mode: false`) before upgrading**

--- a/src/main/java/io/supertokens/session/Session.java
+++ b/src/main/java/io/supertokens/session/Session.java
@@ -56,6 +56,8 @@ import io.supertokens.session.info.SessionInformationHolder;
 import io.supertokens.session.info.TokenInfo;
 import io.supertokens.session.jwt.JWT;
 import io.supertokens.session.refreshToken.RefreshToken;
+import io.supertokens.session.refreshToken.RefreshTokenKey;
+import io.supertokens.signingkeys.SigningKeys;
 import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.useridmapping.UserIdMapping;
 import io.supertokens.useridmapping.UserIdType;
@@ -518,6 +520,7 @@ public class Session {
             SessionSQLStorage sessionStorage = (SessionSQLStorage) StorageUtils.getSessionStorage(storage);
             try {
                 CoreConfig config = Config.getConfig(tenantIdentifier, main);
+                warmSigningMaterial(tenantIdentifier, main);
                 return sessionStorage.startTransaction(con -> {
                     try {
 
@@ -812,6 +815,18 @@ public class Session {
                 newAccessToken, newRefreshToken, idRefreshToken, antiCsrfToken);
     }
 
+    // Warms the signing-material caches while this thread holds no DB connection. Token minting inside the
+    // transaction lambdas of getSession/refreshSessionHelper is then served from cache: any key-cache refresh
+    // that is due (cold start, dynamic-key rotation window) does its DB round trip here instead of checking
+    // out a second connection while the transaction holds the first - which deadlocks the pool once pool-size
+    // requests do it concurrently.
+    private static void warmSigningMaterial(TenantIdentifier tenantIdentifier, Main main)
+            throws StorageQueryException, StorageTransactionLogicException, TenantOrAppNotFoundException,
+            UnsupportedJWTSigningAlgorithmException {
+        SigningKeys.getInstance(tenantIdentifier.toAppIdentifier(), main).getAllKeys();
+        RefreshTokenKey.getInstance(tenantIdentifier.toAppIdentifier(), main).getKey();
+    }
+
     private static SessionInformationHolder refreshSessionHelper(
             TenantIdentifier tenantIdentifier, Storage storage, Main main, String refreshToken,
             RefreshToken.RefreshTokenInfo refreshTokenInfo,
@@ -831,7 +846,8 @@ public class Session {
             SessionSQLStorage sessionStorage = (SessionSQLStorage) StorageUtils.getSessionStorage(storage);
             try {
                 CoreConfig config = Config.getConfig(tenantIdentifier, main);
-                return sessionStorage.startTransaction(con -> {
+                warmSigningMaterial(tenantIdentifier, main);
+                SessionInformationHolder result = sessionStorage.startTransaction(con -> {
                     try {
                         String sessionHandle = refreshTokenInfo.sessionHandle;
                         io.supertokens.pluginInterface.session.SessionInfo sessionInfo = sessionStorage
@@ -975,9 +991,11 @@ public class Session {
 
                             sessionStorage.commitTransaction(con);
 
-                            return refreshSessionHelper(tenantIdentifier, storage, main, refreshToken,
-                                    refreshTokenInfo, enableAntiCsrf,
-                                    accessTokenVersion, shouldUseStaticKey, cdiVersion, accessTokenValidity);
+                            // Case-B promoted the presented token; null tells the caller to retry AFTER this
+                            // transaction has returned its connection to the pool. Recursing here (the previous
+                            // shape) checked out a second connection while still holding this one, deadlocking
+                            // the pool at pool-size concurrent Case-B refreshes.
+                            return null;
                         }
 
                         sessionStorage.commitTransaction(con);
@@ -994,6 +1012,15 @@ public class Session {
                         throw new StorageTransactionLogicException(e);
                     }
                 });
+                if (result == null) {
+                    // Case-B promote: retry now that the transaction above has released its connection, so a
+                    // refresh never holds more than one connection at a time. The re-read sees the promoted
+                    // state and takes the plain rotation path.
+                    return refreshSessionHelper(tenantIdentifier, storage, main, refreshToken, refreshTokenInfo,
+                            enableAntiCsrf, accessTokenVersion, shouldUseStaticKey, cdiVersion,
+                            accessTokenValidity);
+                }
+                return result;
             } catch (StorageTransactionLogicException e) {
                 if (e.actualException instanceof UnauthorisedException) {
                     UnauthorisedException ue = (UnauthorisedException) e.actualException;

--- a/src/main/java/io/supertokens/session/accessToken/AccessToken.java
+++ b/src/main/java/io/supertokens/session/accessToken/AccessToken.java
@@ -303,8 +303,11 @@ public class AccessToken {
             keyToUse = SigningKeys.getInstance(tenantIdentifier.toAppIdentifier(), main)
                     .getStaticKeyForAlgorithm(JWTSigningKey.SupportedAlgorithms.RS256);
         } else {
+            // WithoutRefresh: minting can run inside a session transaction, where triggering a key-cache
+            // refresh would check out a second DB connection while the transaction holds the first.
             keyToUse = Utils.getJWTSigningKeyInfoFromKeyInfo(
-                    SigningKeys.getInstance(tenantIdentifier.toAppIdentifier(), main).getLatestIssuedDynamicKey());
+                    SigningKeys.getInstance(tenantIdentifier.toAppIdentifier(), main)
+                            .getLatestIssuedDynamicKeyWithoutRefresh());
         }
 
         String token;
@@ -349,7 +352,8 @@ public class AccessToken {
             TenantOrAppNotFoundException, UnsupportedJWTSigningAlgorithmException, AccessTokenPayloadError {
 
         Utils.PubPriKey signingKey = new Utils.PubPriKey(
-                SigningKeys.getInstance(tenantIdentifier.toAppIdentifier(), main).getLatestIssuedDynamicKey().value);
+                SigningKeys.getInstance(tenantIdentifier.toAppIdentifier(), main)
+                        .getLatestIssuedDynamicKeyWithoutRefresh().value);
         long now = System.currentTimeMillis();
         AccessTokenInfo accessToken;
 

--- a/src/main/java/io/supertokens/signingkeys/SigningKeys.java
+++ b/src/main/java/io/supertokens/signingkeys/SigningKeys.java
@@ -184,6 +184,19 @@ public class SigningKeys extends ResourceDistributor.SingletonResource {
     public JWTSigningKeyInfo getStaticKeyForAlgorithm(JWTSigningKey.SupportedAlgorithms algorithm)
             throws StorageQueryException, StorageTransactionLogicException, UnsupportedJWTSigningAlgorithmException,
             TenantOrAppNotFoundException {
+        // Static keys are never rotated, so a cached key for the algorithm is authoritative. This keeps the
+        // steady state DB-free: token minting calls this while already holding a transaction connection, and
+        // the getOrCreate below opens its own transaction - a second connection held on top of the first,
+        // which deadlocks the pool at pool-size concurrent mints (see Session.refreshSessionHelper).
+        List<JWTSigningKeyInfo> cachedStaticKeys = this.staticKeys;
+        if (cachedStaticKeys != null) {
+            for (JWTSigningKeyInfo cachedKey : cachedStaticKeys) {
+                if (algorithm.equalsString(cachedKey.algorithm)) {
+                    return cachedKey;
+                }
+            }
+        }
+
         JWTSigningKeyInfo key = JWTSigningKey.getInstance(appIdentifier, main)
                 .getOrCreateAndGetKeyForAlgorithm(algorithm);
 
@@ -200,8 +213,31 @@ public class SigningKeys extends ResourceDistributor.SingletonResource {
     public KeyInfo getLatestIssuedDynamicKey()
             throws StorageQueryException, StorageTransactionLogicException, TenantOrAppNotFoundException,
             UnsupportedJWTSigningAlgorithmException {
+        return pickKeyForSigning(getDynamicKeys());
+    }
+
+    // Cache-only variant for token minting inside a storage transaction: never triggers a cache refresh, so
+    // it acquires no DB connection on top of the one the caller's transaction already holds. During a
+    // rotation window this serves the outgoing key, which remains valid for signing throughout the overlap
+    // period; the refresh itself happens at the pre-transaction warm-up (Session's getAllKeys() call) where
+    // the thread holds no connection. Falls back to the refreshing path only when nothing is cached to serve.
+    public KeyInfo getLatestIssuedDynamicKeyWithoutRefresh()
+            throws StorageQueryException, StorageTransactionLogicException, TenantOrAppNotFoundException,
+            UnsupportedJWTSigningAlgorithmException {
+        List<KeyInfo> cached = this.dynamicKeys;
+        if (cached != null) {
+            List<KeyInfo> valid = cached.stream().filter(k -> k.expiryTime >= System.currentTimeMillis())
+                    .collect(Collectors.toList());
+            if (!valid.isEmpty()) {
+                return pickKeyForSigning(valid);
+            }
+        }
+        return getLatestIssuedDynamicKey();
+    }
+
+    private KeyInfo pickKeyForSigning(List<KeyInfo> dynamicKeys)
+            throws TenantOrAppNotFoundException {
         CoreConfig config = Config.getConfig(appIdentifier.getAsPublicTenantIdentifier(), main);
-        List<KeyInfo> dynamicKeys = getDynamicKeys();
 
         KeyInfo latest = dynamicKeys.get(0);
         if (dynamicKeys.size() > 1 && // if we have more than 1 available

--- a/src/test/java/io/supertokens/test/session/SessionRefreshPoolDeadlockTest.java
+++ b/src/test/java/io/supertokens/test/session/SessionRefreshPoolDeadlockTest.java
@@ -1,0 +1,170 @@
+/*
+ *    Copyright (c) 2026, VRAI Labs and/or its affiliates. All rights reserved.
+ *
+ *    This software is licensed under the Apache License, Version 2.0 (the
+ *    "License") as published by the Apache Software Foundation.
+ *
+ *    You may not use this file except in compliance with the License. You may
+ *    obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *    License for the specific language governing permissions and limitations
+ *    under the License.
+ */
+
+package io.supertokens.test.session;
+
+import com.google.gson.JsonObject;
+import io.supertokens.ProcessState;
+import io.supertokens.session.Session;
+import io.supertokens.session.accessToken.AccessToken;
+import io.supertokens.session.info.SessionInformationHolder;
+import io.supertokens.test.TestingProcessManager;
+import io.supertokens.test.Utils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.TestCase.assertNotNull;
+
+/*
+ * Session refresh must never hold more than one DB connection at a time. It used to hold two:
+ * the legacy Case-B promote recursed into refreshSessionHelper from inside the transaction lambda
+ * (second connection while the first was still checked out), and token minting inside the lambda
+ * could open a nested transaction for signing-key lookups (always, for static-key sessions). With
+ * pool-size concurrent refreshes doing this, no thread could acquire its second connection and the
+ * whole pool deadlocked until the connection timeout. These tests only bound the pool when running
+ * against a real SQL plugin (the config keys are plugin-scoped); in-memory runs exercise the same
+ * code paths without the pool limit.
+ */
+public class SessionRefreshPoolDeadlockTest {
+
+    @Rule
+    public TestRule watchman = Utils.getOnFailure();
+
+    @Rule
+    public TestRule retryFlaky = Utils.retryFlakyTest();
+
+    @AfterClass
+    public static void afterTesting() {
+        Utils.afterTesting();
+    }
+
+    @Before
+    public void beforeEach() {
+        Utils.reset();
+    }
+
+    // Legacy (CDI <= 5.4) rotation: a refresh mints a child token but the DB keeps the parent as
+    // current, so the FIRST use of every freshly rotated refresh token takes the Case-B promote
+    // path. Returns such a token for a fresh session.
+    private String makeCaseBToken(TestingProcessManager.TestingProcess process, String userId, boolean useStaticKey)
+            throws Exception {
+        SessionInformationHolder session = Session.createNewSession(process.getProcess(), userId,
+                new JsonObject(), new JsonObject(), false, AccessToken.getLatestVersion(), useStaticKey);
+        SessionInformationHolder refreshed = Session.refreshSession(process.getProcess(),
+                session.refreshToken.token, session.antiCsrfToken, false, AccessToken.getLatestVersion());
+        return refreshed.refreshToken.token;
+    }
+
+    // Production shape: pool of 3, three concurrent Case-B refreshes. Pre-fix each held one
+    // connection while acquiring a second, so all three deadlocked and failed at the pool's
+    // connection timeout.
+    @Test
+    public void concurrentCaseBRefreshesAtPoolSizeDoNotDeadlock() throws Exception {
+        final int poolSize = 3;
+        Utils.setValueInConfig("postgresql_connection_pool_size", String.valueOf(poolSize));
+
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        String[] caseBTokens = new String[poolSize];
+        for (int i = 0; i < poolSize; i++) {
+            caseBTokens[i] = makeCaseBToken(process, "user" + i, false);
+        }
+
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+        try {
+            CountDownLatch startSignal = new CountDownLatch(1);
+            List<Future<SessionInformationHolder>> results = new ArrayList<>();
+            for (String token : caseBTokens) {
+                results.add(executor.submit(() -> {
+                    startSignal.await();
+                    return Session.refreshSession(process.getProcess(), token, null, false,
+                            AccessToken.getLatestVersion());
+                }));
+            }
+            startSignal.countDown();
+            for (Future<SessionInformationHolder> result : results) {
+                assertNotNull(result.get(30, TimeUnit.SECONDS).accessToken);
+            }
+        } finally {
+            executor.shutdown();
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+
+    // The invariant itself: a refresh holds at most one connection, so every path must succeed with
+    // a pool of exactly one. Pre-fix, a single Case-B refresh deadlocked here deterministically, and
+    // so did any static-key refresh (static key lookups opened a nested transaction on every mint).
+    @Test
+    public void refreshSucceedsWithPoolSizeOne() throws Exception {
+        Utils.setValueInConfig("postgresql_connection_pool_size", "1");
+
+        String[] args = {"../"};
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        // dynamic-key session and static-key session, each through the Case-B promote path
+        for (boolean useStaticKey : new boolean[]{false, true}) {
+            String caseBToken = makeCaseBToken(process, "user-" + useStaticKey, useStaticKey);
+            SessionInformationHolder refreshed = Session.refreshSession(process.getProcess(), caseBToken, null,
+                    false, AccessToken.getLatestVersion());
+            assertNotNull(refreshed.accessToken);
+            assertNotNull(refreshed.refreshToken);
+        }
+
+        // a small concurrent burst still gets through the single connection by serializing
+        final int concurrency = 4;
+        String[] caseBTokens = new String[concurrency];
+        for (int i = 0; i < concurrency; i++) {
+            caseBTokens[i] = makeCaseBToken(process, "burst-user" + i, i % 2 == 0);
+        }
+        ExecutorService executor = Executors.newFixedThreadPool(concurrency);
+        try {
+            CountDownLatch startSignal = new CountDownLatch(1);
+            List<Future<SessionInformationHolder>> results = new ArrayList<>();
+            for (String token : caseBTokens) {
+                results.add(executor.submit(() -> {
+                    startSignal.await();
+                    return Session.refreshSession(process.getProcess(), token, null, false,
+                            AccessToken.getLatestVersion());
+                }));
+            }
+            startSignal.countDown();
+            for (Future<SessionInformationHolder> result : results) {
+                assertNotNull(result.get(30, TimeUnit.SECONDS).accessToken);
+            }
+        } finally {
+            executor.shutdown();
+        }
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
+}

--- a/src/test/java/io/supertokens/test/session/SessionRefreshPoolDeadlockTest.java
+++ b/src/test/java/io/supertokens/test/session/SessionRefreshPoolDeadlockTest.java
@@ -21,6 +21,7 @@ import io.supertokens.ProcessState;
 import io.supertokens.session.Session;
 import io.supertokens.session.accessToken.AccessToken;
 import io.supertokens.session.info.SessionInformationHolder;
+import io.supertokens.storageLayer.StorageLayer;
 import io.supertokens.test.TestingProcessManager;
 import io.supertokens.test.Utils;
 import org.junit.AfterClass;
@@ -45,9 +46,10 @@ import static junit.framework.TestCase.assertNotNull;
  * (second connection while the first was still checked out), and token minting inside the lambda
  * could open a nested transaction for signing-key lookups (always, for static-key sessions). With
  * pool-size concurrent refreshes doing this, no thread could acquire its second connection and the
- * whole pool deadlocked until the connection timeout. These tests only bound the pool when running
- * against a real SQL plugin (the config keys are plugin-scoped); in-memory runs exercise the same
- * code paths without the pool limit.
+ * whole pool deadlocked until the connection timeout. These tests run only against a real SQL
+ * plugin: the pool-size config keys are plugin-scoped, and the in-memory (SQLite shared-cache)
+ * storage has no connection pool to pin down - its cache contention under this concurrency fails
+ * for unrelated reasons.
  */
 public class SessionRefreshPoolDeadlockTest {
 
@@ -91,6 +93,12 @@ public class SessionRefreshPoolDeadlockTest {
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
 
+        if (StorageLayer.isInMemDb(process.getProcess())) {
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+            return;
+        }
+
         String[] caseBTokens = new String[poolSize];
         for (int i = 0; i < poolSize; i++) {
             caseBTokens[i] = makeCaseBToken(process, "user" + i, false);
@@ -129,6 +137,12 @@ public class SessionRefreshPoolDeadlockTest {
         String[] args = {"../"};
         TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        if (StorageLayer.isInMemDb(process.getProcess())) {
+            process.kill();
+            assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+            return;
+        }
 
         // dynamic-key session and static-key session, each through the Case-B promote path
         for (boolean useStaticKey : new boolean[]{false, true}) {


### PR DESCRIPTION
## Problem

One in-flight session refresh could occupy **two** pool connections, so the deadlock threshold for the whole core was just `connection_pool_size` concurrent refreshes: each holds connection #1 while waiting for #2, nobody can proceed, and every waiter dies at HikariCP's hardcoded 5,000 ms connection timeout. Confirmed in production (11.1.1 and 12.0.10; the code shape is identical on 12.2).

Two mechanisms:

1. **Case-B promote recursion** — the legacy refresh path recursed into `refreshSessionHelper` from *inside* the `startTransaction` lambda, opening a second transaction while the first connection was still checked out. Case B is the first use of every freshly rotated refresh token on CDI <= 5.4, so this is a hot path, not an edge case.
2. **Signing-key lookups during token minting** inside both session transaction lambdas (`getSession` and `refreshSessionHelper`) could open a nested transaction: on **every mint** for static-key sessions (`getStaticKeyForAlgorithm` always hit the DB), and on rotation windows/cold starts for dynamic keys.

## Fix

- The Case-B lambda now returns a "promoted, retry" signal instead of recursing; the retry runs after `startTransaction` has returned its connection to the pool. Behaviorally identical — the recursion re-read all state from the DB anyway.
- `getStaticKeyForAlgorithm` is cache-first (static keys never rotate); the DB round trip happens only on a per-JVM cold miss.
- Both session lambdas warm the signing material (`SigningKeys.getAllKeys()` + `RefreshTokenKey.getKey()`) **before** opening their transaction, and minting inside the transaction uses a new cache-only accessor (`getLatestIssuedDynamicKeyWithoutRefresh`) that serves the stale-but-valid key during rotation windows instead of triggering a refresh — the refresh itself always runs at the warm-up, where the thread holds no connection. This composes with the single-flight refresh from #1398.

Invariant after this PR: **the session transaction lambdas acquire no DB connections.**

## Tests

`SessionRefreshPoolDeadlockTest`, verified both ways against postgres:

- On **unfixed** code, both tests fail with the exact production signature — `refreshSessionHelper → lambda$1 → startTransaction → "Connection is not available, request timed out after 5000ms (total=3, active=3, idle=0, waiting=2)"` — the first reproduction of the production incidents.
- `concurrentCaseBRefreshesAtPoolSizeDoNotDeadlock`: pool=3, three concurrent Case-B refreshes (the production shape).
- `refreshSucceedsWithPoolSizeOne`: the invariant itself — the full refresh path, static and dynamic keys, sequential and a 4-thread burst, succeeds at pool size 1.

Full `io.supertokens.test.session.*` suite (261 tests) passes against postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeK7hRjvTA7LurfFrRhW5