### PR TITLE
fix: upgrade embedded Tomcat 11.0.22 -> 11.0.25 for critical CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Upgrades the embedded Tomcat from 11.0.22 to 11.0.25 to clear three critical CVEs (CVE-2026-65182, CVE-2026-65905, CVE-2026-68525)
 
 ## [12.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-- Upgrades the embedded Tomcat from 11.0.22 to 11.0.25 to clear three critical CVEs (CVE-2026-65182, CVE-2026-65905, CVE-2026-68525)
-
 ## [12.2.0]
 
 - **Upgrade note: the core now verifies the database schema at startup and, with `schema_check_strict_mode: true` (default), refuses to start until the manual migrations from the CHANGELOGs are applied**
@@ -23,6 +21,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adds a regression test for the duplicate signing-key race on concurrent rotation (fixed in postgresql-plugin 9.8.0)
 - Corrects the 12.1.0 migration note: the `session_info` columns are a manual step
 - Updates the OTel javaagent to 2.29.0 and pins httpclient5/httpcore5 (CVE fixes)
+- Upgrades the embedded Tomcat to 11.0.25 to clear three critical CVEs (CVE-2026-65182, CVE-2026-65905, CVE-2026-68525)
 
 ### Migration
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.22.1'
 
     // https://mvnrepository.com/artifact/org.apache.tomcat.embed/tomcat-embed-core
-    api group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '11.0.22'
+    api group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '11.0.25'
 
     // https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'

--- a/implementationDependencies.json
+++ b/implementationDependencies.json
@@ -2,14 +2,14 @@
 "_comment": "Contains list of implementation dependencies URL for this project. This is a generated file, don't modify the contents by hand.",
 "list": [
 	{
-		"jar":"https://repo.maven.apache.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.22/tomcat-embed-core-11.0.22.jar",
-		"name":"tomcat-embed-core 11.0.22",
-		"src":"https://repo.maven.apache.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.22/tomcat-embed-core-11.0.22-sources.jar"
+		"jar":"https://repo.maven.apache.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.25/tomcat-embed-core-11.0.25.jar",
+		"name":"tomcat-embed-core 11.0.25",
+		"src":"https://repo.maven.apache.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/11.0.25/tomcat-embed-core-11.0.25-sources.jar"
 	},
 	{
-		"jar":"https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22.jar",
-		"name":"tomcat-annotations-api 11.0.22",
-		"src":"https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.22/tomcat-annotations-api-11.0.22-sources.jar"
+		"jar":"https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.25/tomcat-annotations-api-11.0.25.jar",
+		"name":"tomcat-annotations-api 11.0.25",
+		"src":"https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat-annotations-api/11.0.25/tomcat-annotations-api-11.0.25-sources.jar"
 	},
 	{
 		"jar":"https://repo.maven.apache.org/maven2/com/google/code/gson/gson/2.13.1/gson-2.13.1.jar",


### PR DESCRIPTION
## Summary

Upgrades the embedded Tomcat `org.apache.tomcat.embed:tomcat-embed-core` from **11.0.22 → 11.0.25** to clear three **critical** CVEs flagged by the scheduled container security scan ([run 33828526770](https://github.com/supertokens/supertokens-core/actions/runs/33828526770)):

| CVE | Issue |
|---|---|
| CVE-2026-65182 | Security-constraint bypass via improper access control |
| CVE-2026-65905 | Authentication bypass via limited replay in the DIGEST authenticator |
| CVE-2026-68525 | Unauthorized resource access via FORM authentication bypass |

All three are fixed in Tomcat 11.0.25.

## Note on exploitability

These CVEs target Tomcat's built-in container authentication (DIGEST auth, FORM auth, `<security-constraint>` access control), which SuperTokens core does not use — it runs embedded Tomcat purely as an HTTP server and does its own API-key/session auth. So real-world exploitability against the core is low; this is a keep-the-scan-clean hygiene bump.

## Scope

One-line dependency bump (`build.gradle`) plus a CHANGELOG entry. The other criticals in the scan (`perl-base`, `zlib1g`) are Debian base-image packages with no upstream fix and live in the Docker image repo, not here.

## Verification

- Compiles cleanly with 11.0.25 (dependency resolves; core + ee recompiled).
- `HelloAPITest` — 5/5 pass, confirming the embedded server boots and serves on the new Tomcat.

Target: **12.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
