### PR TITLE
ci: use BACKEND_APIS_PR_KEY for the backend-apis migration PR job

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -171,7 +171,10 @@ jobs:
         with:
           repository: supertokens/supertokens-backend-apis
           ref: dev
-          token: ${{ secrets.GH_TOKEN }}
+          # Org-level secret with access to supertokens-backend-apis; GH_TOKEN
+          # has no grant for that repo. Also persisted by checkout for the
+          # git push below.
+          token: ${{ secrets.BACKEND_APIS_PR_KEY }}
           path: backend-apis
       - name: Checkout supertokens-postgresql-plugin
         uses: actions/checkout@v5
@@ -182,7 +185,9 @@ jobs:
           path: plugin
       - name: Generate migration and open PR
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          # gh pr create targets supertokens-backend-apis, so it needs the
+          # same org-level key as the checkout above, not GH_TOKEN.
+          GH_TOKEN: ${{ secrets.BACKEND_APIS_PR_KEY }}
           # Passed via env (not expanded into the shell) so the release inputs
           # can't inject GitHub-Actions expressions into this run block.
           CORE_VERSION: ${{ inputs.core-version }}


### PR DESCRIPTION
## Problem

The `open-backend-apis-migration-pr` job in the v12.2.0 release failed at checkout with `remote: Write access to repository not granted` (403): `GH_TOKEN` has no grant for `supertokens/supertokens-backend-apis`, so the CORE_MIGRATIONS PR for the 12.2.0 migration was never opened and the SaaS rollout stays deferred.

## Fix

Use the org-level `BACKEND_APIS_PR_KEY` secret for everything that touches backend-apis in that job:

- the `actions/checkout` of supertokens-backend-apis (its persisted credential also serves the `git push origin core-migration/v12.2.0`)
- the `GH_TOKEN` env of the "Generate migration and open PR" step, which `gh pr create --repo supertokens/supertokens-backend-apis` reads

The postgresql-plugin checkout in the same job keeps `GH_TOKEN` — that grant works (the derive job uses it for the same repo).

`do-release-java15.yml` is untouched: it deliberately has no backend-apis job (backport migrations are registered by hand).

Once merged, the job can be re-run for v12.2.0 — it is idempotent (registry-exists and branch-exists guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jeK7hRjvTA7LurfFrRhW5