### PR TITLE
ci: fix backend-apis release branch + make GitHub release creation idempotent

### DIFF
--- a/.github/workflows/_release-add-tags.yml
+++ b/.github/workflows/_release-add-tags.yml
@@ -111,21 +111,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          repo="supertokens/supertokens-plugin-interface"
           if [ "${{ inputs.is-canary }}" == "true" ]; then
             tag="v${{ inputs.plugin-interface-version }}-canary"
-            gh release create "$tag" \
-              --repo supertokens/supertokens-plugin-interface \
-              --title "$tag" \
-              --target "${{ inputs.plugin-interface-sha }}" \
-              --generate-notes \
-              --prerelease \
-              --latest=false
+            extra=(--target "${{ inputs.plugin-interface-sha }}" --prerelease --latest=false)
           else
-            gh release create "v${{ inputs.plugin-interface-version }}" \
-              --repo supertokens/supertokens-plugin-interface \
-              --title "v${{ inputs.plugin-interface-version }}" \
-              --generate-notes \
-              ${{ inputs.is-latest-release == true && '--latest' || '--latest=false' }}
+            tag="v${{ inputs.plugin-interface-version }}"
+            extra=(${{ inputs.is-latest-release == true && '--latest' || '--latest=false' }})
+          fi
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "Release $tag already exists on $repo — skipping creation (idempotent re-run)"
+          else
+            gh release create "$tag" --repo "$repo" --title "$tag" --generate-notes "${extra[@]}"
           fi
 
       - name: Tag postgresql-plugin
@@ -140,21 +137,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          repo="supertokens/supertokens-postgresql-plugin"
           if [ "${{ inputs.is-canary }}" == "true" ]; then
             tag="v${{ inputs.postgresql-plugin-version }}-canary"
-            gh release create "$tag" \
-              --repo supertokens/supertokens-postgresql-plugin \
-              --title "$tag" \
-              --target "${{ inputs.postgresql-sha }}" \
-              --generate-notes \
-              --prerelease \
-              --latest=false
+            extra=(--target "${{ inputs.postgresql-sha }}" --prerelease --latest=false)
           else
-            gh release create "v${{ inputs.postgresql-plugin-version }}" \
-              --repo supertokens/supertokens-postgresql-plugin \
-              --title "v${{ inputs.postgresql-plugin-version }}" \
-              --generate-notes \
-              ${{ inputs.is-latest-release == true && '--latest' || '--latest=false' }}
+            tag="v${{ inputs.postgresql-plugin-version }}"
+            extra=(${{ inputs.is-latest-release == true && '--latest' || '--latest=false' }})
+          fi
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "Release $tag already exists on $repo — skipping creation (idempotent re-run)"
+          else
+            gh release create "$tag" --repo "$repo" --title "$tag" --generate-notes "${extra[@]}"
           fi
 
       - name: Tag core
@@ -171,19 +165,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
+          repo="supertokens/supertokens-core"
           if [ "${{ inputs.is-canary }}" == "true" ]; then
             tag="v${{ inputs.core-version }}-canary"
-            gh release create "$tag" \
-              --repo supertokens/supertokens-core \
-              --title "$tag" \
-              --target "${{ inputs.core-sha }}" \
-              --generate-notes \
-              --prerelease \
-              --latest=false
+            extra=(--target "${{ inputs.core-sha }}" --prerelease --latest=false)
           else
-            gh release create "v${{ inputs.core-version }}" \
-              --repo supertokens/supertokens-core \
-              --title "v${{ inputs.core-version }}" \
-              --generate-notes \
-              ${{ inputs.is-latest-release == true && '--latest' || '--latest=false' }}
+            tag="v${{ inputs.core-version }}"
+            extra=(${{ inputs.is-latest-release == true && '--latest' || '--latest=false' }})
+          fi
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "Release $tag already exists on $repo — skipping creation (idempotent re-run)"
+          else
+            gh release create "$tag" --repo "$repo" --title "$tag" --generate-notes "${extra[@]}"
           fi

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -170,7 +170,9 @@ jobs:
         uses: actions/checkout@v5
         with:
           repository: supertokens/supertokens-backend-apis
-          ref: dev
+          # The migration-awareness companion (generate-core-migration.mjs + the
+          # CORE_MIGRATIONS registry) lives on master, not dev.
+          ref: master
           # Org-level secret with access to supertokens-backend-apis; GH_TOKEN
           # has no grant for that repo. Also persisted by checkout for the
           # git push below.
@@ -282,7 +284,7 @@ jobs:
             echo
             echo "Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           } > "$bodyFile"
-          gh pr create --repo supertokens/supertokens-backend-apis --base dev --head "$branch" \
+          gh pr create --repo supertokens/supertokens-backend-apis --base master --head "$branch" \
             --title "$title" \
             --body-file "$bodyFile"
 


### PR DESCRIPTION
## Summary

Fixes two release-workflow bugs surfaced by the 12.2.0 / 9.8.0 / 10.0.0 release run.

### 1. backend-apis migration job checked out the wrong branch (`do-release.yml`)

The `open-backend-apis-migration-pr` job checked out `supertokens-backend-apis` at `ref: dev` and opened the migration PR with `--base dev`. But the migration-awareness companion — `apps/backend-api/scripts/generate-core-migration.mjs` and the `CORE_MIGRATIONS` registry (backend-apis PR #1381) — lives on **`master`**, not `dev`. So the release job failed with:

```
Error: Cannot find module '.../backend-apis/apps/backend-api/scripts/generate-core-migration.mjs'
```

Fix: point both the checkout `ref` and the PR `--base` at `master`, where the registry lives (so the migration branch is cut from, and targets, the branch that actually has the pipeline).

### 2. GitHub release creation was not idempotent (`_release-add-tags.yml`)

The three `gh release create` steps (plugin-interface, postgresql-plugin, core) had no existence check. Re-running a release whose tags already exist failed with:

```
HTTP 422: Validation Failed — Release.tag_name already exists
```

and, under `bash -e`, that failed the whole job — so a partially-completed release train couldn't be re-run to finish. (This is what happened: `v10.0.0` was already created earlier, and the re-run died here.)

Fix: guard each create with `gh release view "$tag"` and skip when the release already exists, so the tag/release job is safely re-runnable. The canary/non-canary flag handling is preserved (moved into an `extra=(...)` array).

## Verification

- Both workflow files re-reviewed for structure/indentation.
- The idempotency guard was exercised locally with a mocked `gh` across all four paths (canary/non-canary × release exists/missing): it skips when the release exists, creates with the correct flags when missing, and survives `errexit`.

Target: **12.2** (the branch that ran the failing release; `master`'s `do-release.yml` doesn't yet carry the backend-apis migration job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
