### PR TITLE
chore: activity-log release prep — core 12.3.0 + CDI 5.7 for ledger counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [12.3.0]
+
+- Adds an `activity_log` lifecycle/activity event ledger: user creation, import, deletion, account (un)linking, tenant (dis)association and semantic activity events (`sign_in`, `token_refresh`, `session_create`, `sign_out`, `oauth_token_exchange`, `oauth_authorize`) are written atomically with their mutation, enforced by a compile-time AspectJ audit guard on raw `startTransaction`. New protected configs `activity_log_retention_days` (default 31) and `activity_log_throttle_enabled` (default `true`).
+- `GET /users/count` serves an exact `anchor + fold` of the ledger instead of recomputing per request. From CDI 5.7 this is the default single-tenant behaviour (carrying `approximate`/`asOf`); CDI 5.6 keeps its released contract where the ledger value is opt-in via `allowApproximate=true`; older CDI is unchanged.
+- `user_last_active` is now derived by the new `RollupUserLastActive` cron folding activity events (its sole writer); `ActiveUsers.updateLastActive` only appends throttled events, so MAU counts reflect activity within a rollup interval.
+- Active-user activity and its projection now live on the user's own storage (not the app-public tenant), and active-user counts (`GET /users/count/active`, telemetry MAU) sum across every storage backing the app, so a user on a tenant with its own database is counted correctly.
+- In-memory (SQLite) parity for the ledger and rollup storage contract (transactional audit insert, last-active fold/reconcile, windowed event read, and the connection-taking sign-up/tenant-removal variants).
+
+### Migration
+
+The `activity_log.payload` column changes from `TEXT` to `JSONB` (structured lifecycle-event payloads). Applied automatically at startup by the core (guarded and idempotent — skipped when the column is already `JSONB`), so an in-place upgrade needs no manual step. The canonical SQL is in supertokens-postgresql-plugin `migration-scripts/v9.9.0.sql`.
+
+**Large-deployment note:** this is an `ALTER COLUMN ... TYPE JSONB` on the partitioned `activity_log` parent, which rewrites every partition under an `ACCESS EXCLUSIVE` lock. On a large `activity_log` run the migration script *before* upgrading to avoid a startup stall (all historical payloads are `NULL`, so the cast is a pure type rewrite).
+
 ## [12.2.0]
 
 - Fixes app and connection URI domain configuration updates being incorrectly rejected as conflicting when affected
@@ -25,11 +39,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   per app, which postgresql-plugin 9.7.2 does with a per-app advisory lock.
 - Updates the bundled OpenTelemetry javaagent from 2.27.0 to 2.29.0 (CVE-2026-54704: JDBC connect-string passwords could leak into span attributes)
 - Pins transitive httpclient5 to 5.6.4 and httpcore5 / httpcore5-h2 to 5.4.3 (CVE-2026-64607, CVE-2026-54399, CVE-2026-54428)
-- Adds an `activity_log` lifecycle/activity event ledger: user creation, import, deletion, account (un)linking, tenant (dis)association and semantic activity events (`sign_in`, `token_refresh`, `session_create`, `sign_out`, `oauth_token_exchange`, `oauth_authorize`) are written atomically with their mutation, enforced by a compile-time AspectJ audit guard on raw `startTransaction`. New protected configs `activity_log_retention_days` (default 31) and `activity_log_throttle_enabled` (default `true`).
-- `GET /users/count` now serves an exact `anchor + fold` of the ledger instead of recomputing per request: the default single-tenant path does so from CDI 5.6 (older CDI unchanged), and the `allowApproximate` parameter becomes a no-op.
-- `user_last_active` is now derived by the new `RollupUserLastActive` cron folding activity events (its sole writer); `ActiveUsers.updateLastActive` only appends throttled events, so MAU counts reflect activity within a rollup interval.
-- Active-user activity and its projection now live on the user's own storage (not the app-public tenant), and active-user counts (`GET /users/count/active`, telemetry MAU) sum across every storage backing the app, so a user on a tenant with its own database is counted correctly.
-- In-memory (SQLite) parity for the ledger and rollup storage contract (transactional audit insert, last-active fold/reconcile, windowed event read, and the connection-taking sign-up/tenant-removal variants).
 
 ## [12.1.1]
 

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
     }
 }
 
-version = "12.2.0"
+version = "12.3.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/utils/SemVer.java
+++ b/src/main/java/io/supertokens/utils/SemVer.java
@@ -42,6 +42,7 @@ public class SemVer implements Comparable<SemVer> {
     public static final SemVer v5_4 = new SemVer("5.4");
     public static final SemVer v5_5 = new SemVer("5.5");
     public static final SemVer v5_6 = new SemVer("5.6");
+    public static final SemVer v5_7 = new SemVer("5.7");
 
     final private String version;
 

--- a/src/main/java/io/supertokens/webserver/WebserverAPI.java
+++ b/src/main/java/io/supertokens/webserver/WebserverAPI.java
@@ -85,6 +85,7 @@ public abstract class WebserverAPI extends HttpServlet {
         supportedVersions.add(SemVer.v5_4);
         supportedVersions.add(SemVer.v5_5);
         supportedVersions.add(SemVer.v5_6);
+        supportedVersions.add(SemVer.v5_7);
     }
 
     public static SemVer getLatestCDIVersion() {

--- a/src/main/java/io/supertokens/webserver/api/core/UsersCountAPI.java
+++ b/src/main/java/io/supertokens/webserver/api/core/UsersCountAPI.java
@@ -76,12 +76,16 @@ public class UsersCountAPI extends WebserverAPI {
             includeAllTenants = false;
         }
 
-        // From the CDI version that serves counts from the lifecycle-event ledger, the default (param-less)
-        // path returns the fast anchor+fold value and carries the approximate/asOf metadata (PLAN-010). The
-        // historical `allowApproximate` opt-in is now a no-op - accepted (unknown query params are ignored) so
-        // clients still sending it keep working, but it changes nothing. Older CDI versions see byte-for-byte
-        // unchanged behaviour: an exact recompute and never the new fields.
-        boolean ledgerServed = getVersionFromRequest(req).greaterThanOrEqualTo(SemVer.v5_6);
+        // CDI 5.7+ serves the exact lifecycle-ledger `anchor + fold` value by default and always carries the
+        // approximate/asOf metadata (PLAN-010). CDI 5.6 keeps its released behaviour: the ledger value is
+        // opt-in via `allowApproximate=true`; without the opt-in (and on any CDI < 5.6) the count is an exact
+        // recompute and the approximate/asOf fields are omitted. 5.6 must not be redefined — it already
+        // shipped in core 12.2.0 with the opt-in contract.
+        String allowApproximateStr = InputParser.getQueryParamOrThrowError(req, "allowApproximate", true);
+        boolean allowApproximate = allowApproximateStr != null && allowApproximateStr.equalsIgnoreCase("true");
+        SemVer cdiVersion = getVersionFromRequest(req);
+        boolean ledgerServed = cdiVersion.greaterThanOrEqualTo(SemVer.v5_7)
+                || (allowApproximate && cdiVersion.greaterThanOrEqualTo(SemVer.v5_6));
 
         RECIPE_ID[] recipeIdsEnum = recipeIdsEnumBuilder.build().toArray(RECIPE_ID[]::new);
 


### PR DESCRIPTION
## Activity-log release prep — core 12.3.0 (CDI 5.7 for ledger counts)

The 12.2 train shipped **without** the activity-log feature, so it moves to its own version. Targets `feat/activity-log`.

- `build.gradle` **12.2.0 → 12.3.0** (minor: additive, no public API removed).
- Adds **`SemVer.v5_7`** and registers it in `WebserverAPI.supportedVersions`.
- **Re-gates `GET /users/count`:** the exact `anchor + fold` ledger count is the default only from **CDI 5.7**. CDI **5.6 keeps its released contract** — the ledger value is opt-in via `allowApproximate=true`, and without it (or on older CDI) the count is an exact recompute with no `approximate`/`asOf` fields. 5.6 already shipped in 12.2.0 and must not be redefined.
- CHANGELOG: activity-log entries moved into a new `[12.3.0]` section with a `### Migration` note (`activity_log.payload` TEXT → JSONB).

**Verification:** the code change is small (a SemVer constant, one `supportedVersions.add`, and the `ledgerServed` computation using already-imported `InputParser` / `SemVer` / `getVersionFromRequest`). I could not compile it through the local harness (cross-branch), so **CI on this PR is the compile gate** — flagging that explicitly.

Coordinated with postgresql-plugin 9.9.0 and plugin-interface 10.1.0.
